### PR TITLE
Add ability to ask for API key email confirmation to be resent

### DIFF
--- a/src/olympia/api/throttling.py
+++ b/src/olympia/api/throttling.py
@@ -228,11 +228,11 @@ contact_support_throttles = (
 
 class APIKeyUserThrottle(GranularUserRateThrottle):
     scope = 'user_api_key'
-    rate = '2/day'
+    rate = '3/day'
 
 
 class APIKeyIPThrottle(GranularIPRateThrottle):
-    rate = '4/day'
+    rate = '6/day'
 
 
 api_key_throttles = (APIKeyUserThrottle, APIKeyIPThrottle)

--- a/src/olympia/api/throttling.py
+++ b/src/olympia/api/throttling.py
@@ -228,11 +228,15 @@ contact_support_throttles = (
 
 class APIKeyUserThrottle(GranularUserRateThrottle):
     scope = 'user_api_key'
-    rate = '3/day'
+    # A new user would typically need 2 requests (one to ask for the
+    # confirmation email to be sent, one to submit the token they received).
+    # Add another one if they need to ask for the email to be sent again, and
+    # another to be on the safe side.
+    rate = '4/day'
 
 
 class APIKeyIPThrottle(GranularIPRateThrottle):
-    rate = '6/day'
+    rate = '8/day'
 
 
 api_key_throttles = (APIKeyUserThrottle, APIKeyIPThrottle)

--- a/src/olympia/api/throttling.py
+++ b/src/olympia/api/throttling.py
@@ -224,3 +224,15 @@ contact_support_throttles = (
     ContactSupportUserThrottle,
     ContactSupportIPThrottle,
 )
+
+
+class APIKeyUserThrottle(GranularUserRateThrottle):
+    scope = 'user_api_key'
+    rate = '2/day'
+
+
+class APIKeyIPThrottle(GranularIPRateThrottle):
+    rate = '4/day'
+
+
+api_key_throttles = (APIKeyUserThrottle, APIKeyIPThrottle)

--- a/src/olympia/api/throttling.py
+++ b/src/olympia/api/throttling.py
@@ -236,6 +236,7 @@ class APIKeyUserThrottle(GranularUserRateThrottle):
 
 
 class APIKeyIPThrottle(GranularIPRateThrottle):
+    scope = 'ip_api_key'
     rate = '8/day'
 
 

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -1523,6 +1523,9 @@ class APIKeyForm(CheckThrottlesFormMixin, forms.Form):
         self.request = kwargs.pop('request', None)
         super().__init__(*args, **kwargs)
         self.action = self.data.get('action', None)
+        self.set_available_actions()
+
+    def set_available_actions(self):
         self.available_actions = []
 
         # Available actions determine what you can do currently
@@ -1545,9 +1548,9 @@ class APIKeyForm(CheckThrottlesFormMixin, forms.Form):
                 or self.data.get('confirmation_token') is not None
             ):
                 help_text = _(
-                    'Please click the confirm button below to generate '
-                    'API credentials for user <strong>{name}</strong>.'
-                ).format(name=self.request.user.name)
+                    'Please click the button below to generate API credentials for '
+                    'user <strong>{name}</strong>.'
+                )
                 self.fields['confirmation_token'] = forms.CharField(
                     label='',
                     max_length=20,

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -50,6 +50,7 @@ from olympia.api.models import APIKey, APIKeyConfirmation
 from olympia.api.throttling import (
     CheckThrottlesFormMixin,
     addon_submission_throttles,
+    api_key_throttles,
     contact_support_throttles,
 )
 from olympia.applications.models import AppVersion
@@ -1484,15 +1485,18 @@ class AgreementForm(forms.Form):
         return self.cleaned_data
 
 
-class APIKeyForm(forms.Form):
+class APIKeyForm(CheckThrottlesFormMixin, forms.Form):
     class ACTION_CHOICES(StrEnumChoices):
         CONFIRM = 'confirm', _('Confirm email address')
         GENERATE = 'generate', _('Generate new credentials')
         REGENERATE = 'regenerate', _('Revoke and regenerate credentials')
         REVOKE = 'revoke', _('Revoke')
+        RESEND_CONFIRM = 'resend_confirm', _('Re-send email confirmation')
 
     ACTION_CHOICES.add_subset('REQUIRES_CREDENTIALS', ('REVOKE', 'REGENERATE'))
     ACTION_CHOICES.add_subset('REQUIRES_CONFIRMATION', ('GENERATE', 'REGENERATE'))
+
+    throttle_classes = api_key_throttles
 
     @cached_property
     def credentials(self):
@@ -1544,23 +1548,21 @@ class APIKeyForm(forms.Form):
                     'Please click the confirm button below to generate '
                     'API credentials for user <strong>{name}</strong>.'
                 ).format(name=self.request.user.name)
+                self.fields['confirmation_token'] = forms.CharField(
+                    label='',
+                    max_length=20,
+                    widget=forms.HiddenInput(),
+                    initial=get_token_param,
+                    required=False,
+                    help_text=help_text,
+                    validators=[self.validate_confirmation_token],
+                )
                 self.available_actions.append(self.ACTION_CHOICES.GENERATE)
             else:
-                help_text = _(
-                    'A confirmation link will be sent to your email address. '
-                    'After confirmation you will find your API keys on this page.'
-                )
-
-            self.fields['confirmation_token'] = forms.CharField(
-                label='',
-                max_length=20,
-                widget=forms.HiddenInput(),
-                initial=get_token_param,
-                required=False,
-                help_text=help_text,
-                validators=[self.validate_confirmation_token],
-            )
-
+                self.available_actions.append(self.ACTION_CHOICES.RESEND_CONFIRM)
+                if waffle.switch_is_active('developer-submit-addon-captcha'):
+                    self.fields['recaptcha'] = ReCaptchaField(label='', help_text='')
+                    self.fields['recaptcha'].widget.attrs['class'] += ' hidden'
         else:
             if waffle.switch_is_active('developer-submit-addon-captcha'):
                 self.fields['recaptcha'] = ReCaptchaField(
@@ -1584,6 +1586,7 @@ class APIKeyForm(forms.Form):
         credentials_revoked = False
         credentials_generated = False
         confirmation_created = False
+        confirmation_rerequested = False
 
         # User is revoking or regenerating credentials, revoke existing credentials
         if self.action in self.ACTION_CHOICES.REQUIRES_CREDENTIALS:
@@ -1603,10 +1606,15 @@ class APIKeyForm(forms.Form):
             )
             confirmation_created = True
 
+        if self.action == self.ACTION_CHOICES.RESEND_CONFIRM:
+            self.confirmation.update(token=APIKeyConfirmation.generate_token())
+            confirmation_rerequested = True
+
         return {
             'credentials_revoked': credentials_revoked,
             'credentials_generated': credentials_generated,
             'confirmation_created': confirmation_created,
+            'confirmation_rerequested': confirmation_rerequested,
         }
 
 

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -1562,7 +1562,11 @@ class APIKeyForm(CheckThrottlesFormMixin, forms.Form):
                 self.available_actions.append(self.ACTION_CHOICES.RESEND_CONFIRM)
                 if waffle.switch_is_active('developer-submit-addon-captcha'):
                     self.fields['recaptcha'] = ReCaptchaField(label='', help_text='')
-                    self.fields['recaptcha'].widget.attrs['class'] += ' hidden'
+                    if not self.data:
+                        # Initially hidden, unless you're already submitting.
+                        # (on success you won't see it because we'll redirect,
+                        # but we need to show it again on error).
+                        self.fields['recaptcha'].widget.attrs['class'] += ' hidden'
         else:
             if waffle.switch_is_active('developer-submit-addon-captcha'):
                 self.fields['recaptcha'] = ReCaptchaField(

--- a/src/olympia/devhub/templates/devhub/api/key.html
+++ b/src/olympia/devhub/templates/devhub/api/key.html
@@ -11,17 +11,15 @@
   <form method="post" class="api-credentials" name="api-credentials-form">
     {% csrf_token %}
     {% if '__all__' in form.errors %}
-      <div class="text-danger">
+      <p class="text-danger">
         {{ form.errors.__all__ }}
-      </div>
+      </p>
     {% endif %}
     <p>
       {% trans jwt_url='https://datatracker.ietf.org/doc/html/rfc7519', docs_url='https://mozilla.github.io/addons-server/topics/api/index.html',
       a_attrs='target="_blank" rel="noopener noreferrer"' %}
         To execute authenticated calls against the <a {{ a_attrs }} href="{{ docs_url }}">API</a> as an external consumer, you need to include a <a {{ a_attrs }} href="{{ jwt_url }}">JSON Web Token (JWT)</a> in the <code>Authorization</code> header for every request.
       {% endtrans %}
-    </p>
-    <p>
       {% trans %}
         Keep your API keys secret and never share them with anyone, including Mozilla staff or contributors.
       {% endtrans %}
@@ -41,19 +39,26 @@
           {% endif %}
         </dd>
       </dl>
+    {% elif form.confirmation %}
+      <p>
+        {% trans %}
+          After following the confirmation link that was sent to your email address, you will find your API keys on this page.
+        {% endtrans %}
+        <a class="show-resend-button" href="#">{{ _("Haven't received the email yet?") }}</a>
+      </p>
     {% endif %}
     {% for field in form %}
       <div class="row api-input key-input">
         {% if field.help_text %}
-        <div>{{ field.help_text|format_html }}</div>
+          <p>{{ field.help_text|format_html }}</p>
         {% endif %}
-        <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-        {{ field }}
         {% if field.errors %}
           <div class="text-danger">
               {{ field.errors }}
           </div>
         {% endif %}
+        <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+        {{ field }}
       </div>
     {% endfor %}
     <div>

--- a/src/olympia/devhub/templates/devhub/api/key.html
+++ b/src/olympia/devhub/templates/devhub/api/key.html
@@ -39,18 +39,20 @@
           {% endif %}
         </dd>
       </dl>
-    {% elif form.confirmation %}
+    {% elif 'resend_confirm' in form.available_actions or 'confirm' in form.available_actions %}
       <p>
         {% trans %}
           After following the confirmation link that was sent to your email address, you will find your API keys on this page.
         {% endtrans %}
-        <a class="show-resend-button" href="#">{{ _("Haven't received the email yet?") }}</a>
+        {% if 'resend_confirm' in form.available_actions %}
+          <a class="show-resend-button" href="#">{{ _("Haven't received the email yet?") }}</a>
+        {% endif %}
       </p>
     {% endif %}
     {% for field in form %}
       <div class="row api-input key-input">
         {% if field.help_text %}
-          <p>{{ field.help_text|format_html }}</p>
+          <p>{{ field.help_text|format_html(name=form.request.user.name) }}</p>
         {% endif %}
         {% if field.errors %}
           <div class="text-danger">

--- a/src/olympia/devhub/templates/devhub/api/key.html
+++ b/src/olympia/devhub/templates/devhub/api/key.html
@@ -64,7 +64,7 @@
     <div>
       {% for action in form.available_actions %}
         <button
-          class="button prominent"
+          class="button prominent {{ 'hidden' if action == 'resend_confirm' and request.method == 'GET' else ''}}"
           type="submit"
           name="action"
           value="{{ action }}"

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -1391,15 +1391,13 @@ class TestAPIKeyForm(TestCase):
         request = self._request(action=forms.APIKeyForm.ACTION_CHOICES.GENERATE)
         form = forms.APIKeyForm(request.POST, request=request)
         assert 'recaptcha' not in form.fields
-
-        confirmation_token = form.fields['confirmation_token']
-        self.assertEqual(confirmation_token.label, '')
-        self.assertEqual(confirmation_token.max_length, 20)
-        self.assertEqual(confirmation_token.required, False)
+        assert 'confirmation_token' not in form.fields
 
         form = forms.APIKeyForm(request.POST, request=request)
         assert not form.is_valid()
-        assert form.available_actions == []
+        assert form.available_actions == [
+            forms.APIKeyForm.ACTION_CHOICES.RESEND_CONFIRM,
+        ]
 
         request = self._request(
             action=forms.APIKeyForm.ACTION_CHOICES.GENERATE,

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1032,6 +1032,8 @@ class TestAPIKeyPage(TestCase):
             resend_confirmation_button.get('value')
             == APIKeyForm.ACTION_CHOICES.RESEND_CONFIRM
         )
+        # Link to show resend email button is present.
+        assert doc('.show-resend-button')
 
     def test_view_without_credentials_confirmation_requested_with_token(self):
         APIKeyConfirmation.objects.create(
@@ -1058,6 +1060,8 @@ class TestAPIKeyPage(TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
+        # Link to resend the email is no longer present.
+        assert not doc('.show-resend-button')
         (confirm_button,) = self._submit_actions(doc)
         assert 'Generate new credentials' in confirm_button.text
         assert confirm_button.get('value') == APIKeyForm.ACTION_CHOICES.GENERATE
@@ -1125,6 +1129,10 @@ class TestAPIKeyPage(TestCase):
         info = doc('.api-credentials dd')
         assert info[1].text_content() == apikey.key
         assert info[2].text_content().strip() == apikey.secret
+
+        # We removed the confirmation token from the form after confirming.
+        assert 'confirmation_token' not in response.context['form'].fields
+        assert not doc('#id_confirmation_token')
 
     def test_create_new_credentials_not_confirmed_yet(self):
         assert not APIKey.objects.filter(user=self.user).exists()

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1310,6 +1310,62 @@ class TestAPIKeyPage(TestCase):
         assert 'confirmation_token' in form.errors
         assert form.data.get('confirmation_token') == 'wrong'
 
+    def test_send_confirmation_again(self):
+        confirmation = APIKeyConfirmation.objects.create(
+            user=self.user, token='old token', confirmed_once=False
+        )
+        response = self.client.post(
+            self.url,
+            data={
+                'action': APIKeyForm.ACTION_CHOICES.RESEND_CONFIRM,
+                'g-recaptcha-response': 'test',
+            },
+        )
+        assert response.status_code == 302
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        assert message.to == [self.user.email]
+        assert not APIKey.objects.filter(user=self.user).exists()
+        confirmation.reload()
+        assert not confirmation.confirmed_once  # Still False.
+        assert confirmation.token
+        token = confirmation.token
+        assert token != 'old token'  # This was updated
+        expected_url = (
+            f'http://testserver/en-US/developers/addon/api/key/?token={token}'
+        )
+        assert message.subject == 'Confirmation for developer API keys'
+        assert expected_url in message.body
+
+    def test_throttling(self):
+        confirmation = APIKeyConfirmation.objects.create(
+            user=self.user, token='old token', confirmed_once=False
+        )
+        with time_machine.travel(datetime.now(), tick=False):
+            for _x in range(0, 4):
+                self._add_fake_throttling_action(
+                    view_class=APIKeyForm,
+                    url=self.url,
+                    user=self.user,
+                    remote_addr='1.2.3.4',
+                )
+        response = self.client.post(
+            self.url,
+            data={
+                'action': APIKeyForm.ACTION_CHOICES.RESEND_CONFIRM,
+                'g-recaptcha-response': 'test',
+            },
+        )
+        assert response.status_code == 200
+        form = response.context['form']
+        assert not form.is_valid()
+        assert form.non_field_errors() == [
+            'You have submitted this form too many times recently. '
+            'Please try again after some time.'
+        ]
+        confirmation.reload()
+        assert confirmation.token == 'old token'  # Hasn't changed.
+
 
 class TestUpload(UploadMixin, TestCase):
     fixtures = ['base/users']

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1024,12 +1024,14 @@ class TestAPIKeyPage(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         form = response.context['form']
-        assert 'confirmation_token' in form.fields
+        assert 'confirmation_token' not in form.fields
 
-        _, confirmation_token = self._inputs(doc)
-        assert confirmation_token.get('value') is None
-
-        assert len(self._submit_actions(doc)) == 0
+        (resend_confirmation_button,) = self._submit_actions(doc)
+        assert 'Re-send email confirmation' in resend_confirmation_button.text
+        assert (
+            resend_confirmation_button.get('value')
+            == APIKeyForm.ACTION_CHOICES.RESEND_CONFIRM
+        )
 
     def test_view_without_credentials_confirmation_requested_with_token(self):
         APIKeyConfirmation.objects.create(

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -2142,7 +2142,11 @@ def api_key(request):
             send_key_change_email(request.user.email, new_credentials.key)
 
             # Don't redirect in this case: the credentials are only displayed
-            # this one time.
+            # this one time. Reset available actions though, it depends on
+            # credentials so it's out of date. Also remove confirmation token
+            # field if present, it's no longer relevant.
+            form.set_available_actions()
+            form.fields.pop('confirmation_token', None)
 
     context_data = {
         'title': gettext('Manage API Keys'),

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -2104,8 +2104,12 @@ def api_key(request):
     if request.method == 'POST' and form.is_valid():
         result = form.save()
 
-        if result.get('confirmation_created'):
+        if result.get('confirmation_created') or result.get('confirmation_rerequested'):
             form.confirmation.send_confirmation_email()
+            msg = gettext(
+                'A confirmation link will be sent to your email address shortly.'
+            )
+            messages.success(request, msg)
             return redirect(reverse('devhub.api_key'))
 
         if result.get('credentials_revoked'):

--- a/static/css/impala/devhub-api.less
+++ b/static/css/impala/devhub-api.less
@@ -13,3 +13,7 @@
     outline: 1px solid gray;
     padding: 0.2em
 }
+
+button[value="resend_confirm"] {
+    display: none; /* hidden by default until you ask for it */
+}

--- a/static/css/impala/devhub-api.less
+++ b/static/css/impala/devhub-api.less
@@ -13,7 +13,3 @@
     outline: 1px solid gray;
     padding: 0.2em
 }
-
-button[value="resend_confirm"] {
-    display: none; /* hidden by default until you ask for it */
-}

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -202,6 +202,12 @@ $(document).ready(function () {
 
     return false;
   });
+
+  $('.api-credentials .show-resend-button').on('click', function() {
+    $('button[value="resend_confirm"]').show();
+    $('#id_recaptcha').removeClass('hidden');
+    $(this).remove();
+  });
 });
 
 $(document).ready(function () {

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -204,7 +204,7 @@ $(document).ready(function () {
   });
 
   $('.api-credentials .show-resend-button').on('click', function() {
-    $('button[value="resend_confirm"]').show();
+    $('button[value="resend_confirm"]').removeClass('hidden');
     $('#id_recaptcha').removeClass('hidden');
     $(this).remove();
   });


### PR DESCRIPTION
Fixes mozilla/addons#15302

This refactors the form a bit to accommodate for the new functionality.

### Screenshots

If you have asked for the email confirmation but haven't confirmed yet, you get this extra link on top of the existing copy
<img width="1452" height="190" alt="Screenshot 2026-05-20 at 18-02-13 Manage API Keys Developer Hub Add-ons for Firefox" src="https://github.com/user-attachments/assets/22502422-35ff-4a04-9937-af5d4a862679" />

Clicking it reveals the button to resend the confirmation
<img width="1494" height="213" alt="Screenshot 2026-05-20 at 18-02-33 Manage API Keys Developer Hub Add-ons for Firefox" src="https://github.com/user-attachments/assets/124e36f1-fbb0-41f9-9c3b-3f9ad543b52d" />

Doing that gives you the same message we send when you hit the confirmation button for the first time
<img width="1477" height="120" alt="Screenshot 2026-05-20 at 18-03-39 Manage API Keys Developer Hub Add-ons for Firefox" src="https://github.com/user-attachments/assets/987b0ff2-4386-475e-8307-79d09aaa34a0" />

