### PR TITLE
Start services earlier in CI to improve speed

### DIFF
--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -129,23 +129,6 @@ jobs:
             group="--group ${{ matrix.group }}"
             make test_main ARGS="${split} ${group}"
 
-#  test_internal_routes:
-#    runs-on: ubuntu-latest
-#    needs: [test_config]
-#
-#    steps:
-#      - uses: actions/checkout@v6
-#        with:
-#          persist-credentials: false
-#
-#      - name: Test
-#        uses: ./.github/actions/run-docker-minimal
-#        with:
-#          digest: ${{ inputs.digest }}
-#          version: ${{ inputs.version }}
-#          run: |
-#            make test_internal_routes_allowed
-
   test_needs_locales:
     runs-on: ubuntu-latest
     needs: [test_config]

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -171,3 +171,28 @@ jobs:
           version: ${{ inputs.version }}
           run: |
             make test_requires_elasticsearch_tests
+
+  test_autograph:
+    runs-on: ubuntu-latest
+    needs: [test_config]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Create empty environment
+        run: |
+          touch .env
+
+      - name: Spin up Autograph
+        run: |
+          docker compose up -d autograph
+
+      - name: Test
+        uses: ./.github/actions/run-docker-minimal
+        with:
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          run: |
+            make test_requires_autograph_tests

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -111,13 +111,21 @@ jobs:
         run: |
           touch .env
 
-      - name: Spin up autograph
+      - name: Spin up MySQLd
         run: |
-          docker compose up --wait autograph
+          docker compose up mysql
+      # FIXME: Move tests depending on autograph and redis elsewhere.
+      # Like MySQLd, spin them up early without --wait, but add the --wait
+      # in the run-docker-minimal action if the relevant parameter is passed
+      # (by the time we reach that, the service should have become healthy
+      # in the background)
+      # - name: Spin up autograph
+      #   run: |
+      #     docker compose up --wait autograph
 
-      - name: Spin up redis
-        run: |
-          docker compose up --wait redis
+      # - name: Spin up redis
+      #   run: |
+      #     docker compose up --wait redis
 
       - name: Test (test_matrix)
         uses: ./.github/actions/run-docker-minimal

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Spin up MySQLd
         run: |
-          docker compose up mysql
+          docker compose up mysqld
       # FIXME: Move tests depending on autograph and redis elsewhere.
       # Like MySQLd, spin them up early without --wait, but add the --wait
       # in the run-docker-minimal action if the relevant parameter is passed

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -115,18 +115,10 @@ jobs:
         run: |
           make docker_mysqld_volume_create
           docker compose up -d mysqld
-      # FIXME: Move tests depending on autograph and redis elsewhere.
-      # Like MySQLd, spin them up early without --wait, but add the --wait
-      # in the run-docker-minimal action if the relevant parameter is passed
-      # (by the time we reach that, the service should have become healthy
-      # in the background)
-      # - name: Spin up autograph
-      #   run: |
-      #     docker compose up --wait autograph
 
-      # - name: Spin up redis
-      #   run: |
-      #     docker compose up --wait redis
+      - name: Spin up redis
+        run: |
+          docker compose up -d redis
 
       - name: Test (test_matrix)
         uses: ./.github/actions/run-docker-minimal

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -113,6 +113,7 @@ jobs:
 
       - name: Spin up MySQLd
         run: |
+          make docker_mysqld_volume_create
           docker compose up mysqld
       # FIXME: Move tests depending on autograph and redis elsewhere.
       # Like MySQLd, spin them up early without --wait, but add the --wait

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -120,6 +120,10 @@ jobs:
         run: |
           docker compose up -d redis
 
+      - name: Spin up memcached
+        run: |
+          docker compose up -d memcached
+
       - name: Test (test_matrix)
         uses: ./.github/actions/run-docker-minimal
         with:

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -129,7 +129,7 @@ jobs:
             group="--group ${{ matrix.group }}"
             make test_main ARGS="${split} ${group}"
 
-  test_needs_locales:
+  test_js:
     runs-on: ubuntu-latest
     needs: [test_config]
 
@@ -144,8 +144,7 @@ jobs:
           digest: ${{ inputs.digest }}
           version: ${{ inputs.version }}
           run: |
-            make compile_locales
-            make test_needs_locales_compilation
+            make test_js
 
   test_search:
     runs-on: ubuntu-latest

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Spin up MySQLd
         run: |
           make docker_mysqld_volume_create
-          docker compose up mysqld
+          docker compose up -d mysqld
       # FIXME: Move tests depending on autograph and redis elsewhere.
       # Like MySQLd, spin them up early without --wait, but add the --wait
       # in the run-docker-minimal action if the relevant parameter is passed

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Spin up Elasticsearch
         run: |
-          docker compose up --wait elasticsearch
+          docker compose up -d elasticsearch
 
       - name: Test
         uses: ./.github/actions/run-docker-minimal
@@ -170,4 +170,4 @@ jobs:
           digest: ${{ inputs.digest }}
           version: ${{ inputs.version }}
           run: |
-            make test_es_tests
+            make test_requires_elasticsearch_tests

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -95,7 +95,8 @@ initialize: ## ensure database exists
 PYTEST_SRC := src/olympia/
 
 .PHONY: test_js
-test_js: run_js_tests
+test_js:
+	npm run test tests/js
 
 .PHONY: test_main
 test_main:
@@ -144,10 +145,6 @@ test_failed: ## rerun the failed tests from the previous run
 	$(PYTEST_SRC) \
 	--lf \
 	$(ARGS)
-
-.PHONY: run_js_tests
-run_js_tests: ## Run the JavaScript test suite (requires compiled/compressed assets).
-	npm run test tests/js
 
 .PHONY: watch_js_tests
 watch_js_tests: ## Run+watch the JavaScript test suite (requires compiled/compressed assets).

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -105,18 +105,7 @@ test_needs_locales_compilation:
 test_main:
 	pytest $(PYTEST_SRC) \
 		-n auto \
-		-m 'not es_tests and not needs_locales_compilation and not internal_routes_allowed' \
-		$(ARGS)
-
-.PHONY: test_internal_routes_allowed
-test_internal_routes_allowed:
-# We need to change the setting in the file because we can't
-# override an env variable here, and the next command requires
-# `INTERNAL_ROUTES_ALLOWED` to be set to `True`.
-	sed -i 's/^INTERNAL_ROUTES_ALLOWED.*/INTERNAL_ROUTES_ALLOWED=True/' settings_test.py
-	pytest \
-		$(PYTEST_SRC) \
-		-m 'internal_routes_allowed' \
+		-m 'not es_tests and not needs_locales_compilation' \
 		$(ARGS)
 
 .PHONY: test_es_tests

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -111,21 +111,15 @@ test_requires_elasticsearch_tests:
 		-m 'requires_elasticsearch' \
 		$(ARGS)
 
+.PHONY: test_requires_autograph_tests
+test_requires_autograph_tests:
+	pytest \
+		$(PYTEST_SRC) \
+		-m 'requires_autograph' \
+		$(ARGS)
+
 .PHONY: test
 test: ## run the entire test suite
-	pytest \
-		$(PYTEST_SRC) \
-		$(ARGS)
-
-.PHONY: test_es
-test_es: ## run the ES tests
-	pytest \
-		$(PYTEST_SRC) \
-		-m es_tests \
-		$(ARGS)
-
-.PHONY: test_no_es
-test_no_es: ## run all but the ES tests
 	pytest \
 		$(PYTEST_SRC) \
 		$(ARGS)

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -94,25 +94,21 @@ initialize: ## ensure database exists
 
 PYTEST_SRC := src/olympia/
 
-.PHONY: test_needs_locales_compilation
-test_needs_locales_compilation:
-	pytest $(PYTEST_SRC) \
-		-m 'needs_locales_compilation' \
-		$(ARGS)
-	npm run test tests/js/
+.PHONY: test_js
+test_js: run_js_tests
 
 .PHONY: test_main
 test_main:
 	pytest $(PYTEST_SRC) \
 		-n auto \
-		-m 'not es_tests and not needs_locales_compilation' \
+		-m 'not es_tests' \
 		$(ARGS)
 
 .PHONY: test_es_tests
 test_es_tests:
 	pytest \
 		$(PYTEST_SRC) \
-		-m 'es_tests and not needs_locales_compilation' \
+		-m 'es_tests' \
 		$(ARGS)
 
 .PHONY: test

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -154,7 +154,7 @@ test_failed: ## rerun the failed tests from the previous run
 
 .PHONY: run_js_tests
 run_js_tests: ## Run the JavaScript test suite (requires compiled/compressed assets).
-	npm run test
+	npm run test tests/js
 
 .PHONY: watch_js_tests
 watch_js_tests: ## Run+watch the JavaScript test suite (requires compiled/compressed assets).

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -101,14 +101,14 @@ test_js: run_js_tests
 test_main:
 	pytest $(PYTEST_SRC) \
 		-n auto \
-		-m 'not es_tests' \
+		-m 'not requires_elasticsearch' \
 		$(ARGS)
 
-.PHONY: test_es_tests
-test_es_tests:
+.PHONY: test_requires_elasticsearch_tests
+test_requires_elasticsearch_tests:
 	pytest \
 		$(PYTEST_SRC) \
-		-m 'es_tests' \
+		-m 'requires_elasticsearch' \
 		$(ARGS)
 
 .PHONY: test
@@ -128,7 +128,6 @@ test_es: ## run the ES tests
 test_no_es: ## run all but the ES tests
 	pytest \
 		$(PYTEST_SRC) \
-		-m "not es_tests" \
 		$(ARGS)
 
 .PHONY: test_force_db

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -101,7 +101,7 @@ test_js: run_js_tests
 test_main:
 	pytest $(PYTEST_SRC) \
 		-n auto \
-		-m 'not requires_elasticsearch' \
+		-m 'not requires_elasticsearch and not requires_autograph' \
 		$(ARGS)
 
 .PHONY: test_requires_elasticsearch_tests

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -28,6 +28,8 @@ services:
         condition: service_healthy
       memcached:
         condition: service_started
+      redis:
+        condition: service_healthy
     # We don't need to bind the local filesystem like we do for development,
     # but we do need a persistent deps volume to install dependencies used for
     # testing not present in the production image.

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -29,7 +29,7 @@ services:
       memcached:
         condition: service_started
       redis:
-        condition: service_healthy
+        condition: service_started
     # We don't need to bind the local filesystem like we do for development,
     # but we do need a persistent deps volume to install dependencies used for
     # testing not present in the production image.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ markers = [
   "es_tests: mark a test as an elasticsearch test.",
   "needs_locales_compilation: mark a test as needing compiled locales to work.",
   "allow_external_http_requests: mark a test to allow external http requests and disable responses.",
-  "internal_routes_allowed: mark a test as needing INTERNAL_ROUTES_ALLOWED=True.",
 ]
 env = [
     "ENV=test",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ filterwarnings = [
   "ignore::ResourceWarning",
 ]
 markers = [
-  "es_tests: mark a test as an elasticsearch test.",
+  "requires_elasticsearch: mark a test as a depending on elasticsearch.",
   "allow_external_http_requests: mark a test to allow external http requests and disable responses.",
 ]
 env = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ filterwarnings = [
 ]
 markers = [
   "es_tests: mark a test as an elasticsearch test.",
-  "needs_locales_compilation: mark a test as needing compiled locales to work.",
   "allow_external_http_requests: mark a test to allow external http requests and disable responses.",
 ]
 env = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ filterwarnings = [
 markers = [
   "requires_elasticsearch: mark a test as a depending on elasticsearch.",
   "allow_external_http_requests: mark a test to allow external http requests and disable responses.",
+  "requires_autograph: mark a test as depending on autograph.",
 ]
 env = [
     "ENV=test",

--- a/settings.py
+++ b/settings.py
@@ -21,8 +21,6 @@ HOST_UID = os.environ.get('HOST_UID')
 
 WSGI_APPLICATION = 'olympia.wsgi.application'
 
-INTERNAL_ROUTES_ALLOWED = True
-
 # Always
 SERVE_STATIC_FILES = True
 

--- a/settings_test.py
+++ b/settings_test.py
@@ -17,8 +17,6 @@ MIDDLEWARE = tuple(
     if middleware != 'debug_toolbar.middleware.DebugToolbarMiddleware'
 )
 
-INTERNAL_ROUTES_ALLOWED = env('INTERNAL_ROUTES_ALLOWED', default=False)
-
 # See settings.py for documentation:
 IN_TEST_SUITE = True
 

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -1040,7 +1040,7 @@ def block_factory(*, version_ids=None, block_type=BlockType.BLOCKED, **kwargs):
     return block
 
 
-@pytest.mark.es_tests
+@pytest.mark.requires_elasticsearch
 class ESTestCaseMixin:
     @classmethod
     def get_index_name(cls, key):

--- a/src/olympia/amo/tests/test_monitor.py
+++ b/src/olympia/amo/tests/test_monitor.py
@@ -84,6 +84,7 @@ class TestMonitor(TestCase):
         assert status == ''
         assert rabbitmq_results[0][1]
 
+    @pytest.mark.requires_autograph
     def test_signer(self):
         responses.add_passthru(settings.AUTOGRAPH_CONFIG['server_url'])
 

--- a/src/olympia/amo/tests/test_monitor.py
+++ b/src/olympia/amo/tests/test_monitor.py
@@ -46,7 +46,7 @@ class TestMonitor(TestCase):
         assert status == ''
         assert libraries_result == [('PIL+JPEG', True, 'Got it!')]
 
-    @pytest.mark.es_tests
+    @pytest.mark.requires_elasticsearch
     def test_elastic(self):
         status, elastic_result = monitors.elastic()
         assert status == ''

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -45,6 +45,7 @@ def _get_recommendation_data(path):
         return json.loads(force_str(zobj.read('mozilla-recommendation.json')))
 
 
+@pytest.mark.requires_autograph
 @override_settings(ENABLE_ADDON_SIGNING=True)
 class TestSigning(TestCase):
     def setUp(self):

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -11,6 +11,7 @@ from django.db import transaction
 from django.test.utils import override_settings
 from django.urls import reverse
 
+import pytest
 import responses
 from waffle.testutils import override_switch
 
@@ -4781,6 +4782,7 @@ class TestReviewHelper(TestReviewHelperBase):
         }
 
 
+@pytest.mark.requires_autograph
 @override_settings(ENABLE_ADDON_SIGNING=True)
 class TestReviewHelperSigning(TestReviewHelperBase):
     """Tests that call signing but don't mock the actual call.

--- a/tests/make/test_compile_locales.py
+++ b/tests/make/test_compile_locales.py
@@ -5,8 +5,6 @@ from pathlib import Path
 from unittest import TestCase, mock
 from unittest.mock import Mock, patch
 
-import pytest
-
 from scripts.compile_locales import compile_locales, process_po_file
 from tests import override_env
 

--- a/tests/make/test_compile_locales.py
+++ b/tests/make/test_compile_locales.py
@@ -11,7 +11,6 @@ from scripts.compile_locales import compile_locales, process_po_file
 from tests import override_env
 
 
-@pytest.mark.needs_locales_compilation
 class TestCompileLocales(TestCase):
     def setUp(self):
         self.home_dir = Path(tempfile.mkdtemp())


### PR DESCRIPTION
Fixes mozilla/addons#16074

- Remove obsolete and unused internal routes allowed setting & test marker
- Remove obsolete `needs_locale_compilation`: we are building locales when building the `web` image anyway...
- Split out js tests that were hidden inside the `locales` job for some reason
- Start MySQL, memcached and redis in detached mode early, without waiting for them to be healthy.
  - Wait for them as you'd expect later through the compose file (so that check is done after building the image for the `web` container, by the time this happens the services are healthy)
- Rename `es_tests` marker to `requires_elasticsearch`, and introduce `requires_autograph` that does what it says on the tin. Split out tests requiring autograph to their own job, and stop spinning up an `autograph` container for all the other jobs.

For jobs inside `test_main` on a PR from an outside repos, this saves around 30 seconds on both average and median times, going from around 7 minutes to 6 and a half. Some jobs remain slow, especially outside `test_main`, and we could improve things further with a better split, but that should be good enough for now.