### PR TITLE
Expose policies in devhub review history

### DIFF
--- a/src/olympia/activity/serializers.py
+++ b/src/olympia/activity/serializers.py
@@ -40,11 +40,11 @@ class ActivityLogSerializer(AMOModelSerializer):
         self.to_highlight = kwargs.get('context', {}).get('to_highlight', [])
 
     def get_policies(self, obj):
-        # Some activity logs might not have `policy_texts`
-        policies = obj.details.get('policy_texts', []) if obj.details else []
         sanitize = getattr(obj.log(), 'sanitize', None)
         if sanitize is not None:
             return [sanitize]
+        # Some activity logs might not have `policy_texts`
+        policies = obj.details.get('policy_texts', []) if obj.details else []
         return policies
 
     def get_comments(self, obj):

--- a/src/olympia/activity/serializers.py
+++ b/src/olympia/activity/serializers.py
@@ -12,6 +12,7 @@ from olympia.api.utils import is_gate_active
 class ActivityLogSerializer(AMOModelSerializer):
     action = serializers.SerializerMethodField()
     action_label = serializers.SerializerMethodField()
+    policies = serializers.SerializerMethodField()
     comments = serializers.SerializerMethodField()
     date = serializers.DateTimeField(source='created')
     user = serializers.SerializerMethodField()
@@ -25,6 +26,7 @@ class ActivityLogSerializer(AMOModelSerializer):
             'id',
             'action',
             'action_label',
+            'policies',
             'comments',
             'user',
             'date',
@@ -36,6 +38,14 @@ class ActivityLogSerializer(AMOModelSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.to_highlight = kwargs.get('context', {}).get('to_highlight', [])
+
+    def get_policies(self, obj):
+        # Some activity logs might not have `policy_texts`
+        policies = obj.details.get('policy_texts', []) if obj.details else []
+        sanitize = getattr(obj.log(), 'sanitize', None)
+        if sanitize is not None:
+            return [sanitize]
+        return policies
 
     def get_comments(self, obj):
         comments = obj.details['comments'] if obj.details else ''

--- a/src/olympia/activity/tests/test_serializers.py
+++ b/src/olympia/activity/tests/test_serializers.py
@@ -10,9 +10,11 @@ from olympia.amo.tests import TestCase, addon_factory, user_factory
 
 
 class LogMixin:
-    def log(self, comments, action, created=None):
+    def log(self, comments, action, created=None, policy_texts=None):
         version = self.addon.find_latest_version(channel=amo.CHANNEL_LISTED)
         details = {'comments': comments, 'version': version.version}
+        if policy_texts is not None:
+            details['policy_texts'] = policy_texts
         kwargs = {'user': self.user, 'details': details}
         al = ActivityLog.objects.create(action, self.addon, version, **kwargs)
         if created:
@@ -80,15 +82,39 @@ class TestReviewNotesSerializerOutput(TestCase, LogMixin):
         assert not result['highlight']
 
     def test_sanitized_activity_detail_not_exposed_to_developer(self):
-        self.entry = self.log('ßäď ŞŤųƒƒ', amo.LOG.REQUEST_ADMIN_REVIEW_THEME)
+        self.entry = self.log(
+            'ßäď ŞŤųƒƒ',
+            amo.LOG.REQUEST_ADMIN_REVIEW_THEME,
+            policy_texts=['Secret policy text.'],
+        )
         result = self.serialize()
 
         assert result['action_label'] == (amo.LOG.REQUEST_ADMIN_REVIEW_THEME.short)
-        # Comments should be the santized text rather than the actual content.
+        # Comments and policies should be the sanitized text rather than the
+        # actual content.
         assert result['comments'] == amo.LOG.REQUEST_ADMIN_REVIEW_THEME.sanitize
         assert result['comments'].startswith(
             'The add-on has been flagged for Admin Review.'
         )
+        assert result['policies'] == [amo.LOG.REQUEST_ADMIN_REVIEW_THEME.sanitize]
+
+    def test_policies(self):
+        self.entry = self.log(
+            'Oh nøes!',
+            amo.LOG.REJECT_VERSION,
+            policy_texts=['Policy one violation.', 'Policy two violation.'],
+        )
+        result = self.serialize()
+        assert result['policies'] == [
+            'Policy one violation.',
+            'Policy two violation.',
+        ]
+
+    def test_policies_missing_from_details(self):
+        # Create a log with a details property but no policies key inside.
+        self.entry = self.log('Oh nøes!', amo.LOG.REJECT_VERSION, self.now)
+        result = self.serialize()
+        assert result['policies'] == []
 
     def test_log_entry_without_details(self):
         # Create a log but without a details property.
@@ -99,8 +125,9 @@ class TestReviewNotesSerializerOutput(TestCase, LogMixin):
             user=self.user,
         )
         result = self.serialize()
-        # Should output an empty string.
+        # Should output an empty string/list.
         assert result['comments'] == ''
+        assert result['policies'] == []
 
     def test_attachment_link(self):
         self.entry = ActivityLog.objects.create(

--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -278,6 +278,31 @@ class TestReviewNotesViewSetDetail(ReviewNotesViewSetDetailMixin, TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 404
 
+    def test_get_rejected_version_returns_policies_and_comments(self):
+        self.note = self.log(
+            'Manual reasoning',
+            amo.LOG.REJECT_VERSION,
+            self.days_ago(0),
+            policy_texts=[
+                'Acceptable Use: do not do bad things.',
+                'Another policy violation.',
+            ],
+        )
+        self._set_tested_url()
+        self._login_developer()
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        result = json.loads(response.content)
+
+        assert result['id'] == self.note.pk
+        assert result['action_label'] == amo.LOG.REJECT_VERSION.short
+        assert result['comments'] == 'Manual reasoning'
+        assert result['policies'] == [
+            'Acceptable Use: do not do bad things.',
+            'Another policy violation.',
+        ]
+
 
 class TestReviewNotesViewSetList(ReviewNotesViewSetDetailMixin, TestCase):
     client_class = APITestClientSessionID

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -125,6 +125,7 @@
                     <p><strong class="action">$action_label</strong> {{ _('by') }}
                     <em class="user_name">$user_name</em> <time class="timeago" datetime="$date">$date</time></p>
                     <ul class="review-entry-policies"></ul>
+                    <p class="review-entry-comments-label hidden">{{ _('Additional comments:') }}</p>
                     <pre>$comments</pre>
                   </div>
                   <div class="review-entry-attachment hidden">

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -124,6 +124,7 @@
                   <div>
                     <p><strong class="action">$action_label</strong> {{ _('by') }}
                     <em class="user_name">$user_name</em> <time class="timeago" datetime="$date">$date</time></p>
+                    <ul class="review-entry-policies"></ul>
                     <pre>$comments</pre>
                   </div>
                   <div class="review-entry-attachment hidden">

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -779,6 +779,7 @@ class TestVersion(TestCase):
 
         review_entry = doc('.review-entry-empty')
         assert review_entry.find('.review-entry-policies').length == 2
+        assert review_entry.find('.review-entry-comments-label').length == 2
         assert review_entry.find('pre:contains("$comments")').length == 2
 
     def test_version_history_mixed_channels(self):

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -777,6 +777,10 @@ class TestVersion(TestCase):
             textarea = doc('.dev-review-reply-form textarea')[idx]
             assert textarea.attrib['maxlength'] == '100000'
 
+        review_entry = doc('.review-entry-empty')
+        assert review_entry.find('.review-entry-policies').length == 2
+        assert review_entry.find('pre:contains("$comments")').length == 2
+
     def test_version_history_mixed_channels(self):
         v1 = self.version
         v2, _ = self._extra_version_and_file(amo.STATUS_AWAITING_REVIEW)

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -717,6 +717,21 @@ div.review-entry pre {
     margin-bottom: 0px;
 }
 
+div.review-entry ul.review-entry-policies {
+    list-style-type: "- ";
+    padding-left: 1em;
+    margin: 0;
+}
+
+div.review-entry .review-entry-comments-label {
+    margin-top: 0.5em;
+    padding-left: 1em;
+}
+
+div.review-entry .review-entry-comments-label + pre {
+    padding-left: 1em;
+}
+
 div.dev-review-reply {
     margin: 0em 1em;
 }

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -725,7 +725,7 @@ div.review-entry ul.review-entry-policies {
 
 div.review-entry .review-entry-comments-label {
     margin-top: 0.5em;
-    padding-left: 1em;
+    padding-left: 0.3em;
 }
 
 div.review-entry .review-entry-comments-label + pre {

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -717,6 +717,9 @@ function initVersions() {
         li.textContent = text;
         policiesContainer.append(li);
       });
+      if (note['comments']) {
+        clone.find('.review-entry-comments-label').removeClass('hidden');
+      }
       clone.find('pre:contains("$comments")')[0].textContent = note['comments'];
       if (note['attachment_url']) {
         clone.find('.review-entry-attachment').removeClass('hidden');

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -711,6 +711,12 @@ function initVersions() {
       date[0].textContent = note['date'];
       date.attr('datetime', note['date']);
       date.attr('title', note['date']);
+      let policiesContainer = clone.find('.review-entry-policies');
+      (note['policies'] || []).forEach(function (text) {
+        let li = document.createElement('li');
+        li.textContent = text;
+        policiesContainer.append(li);
+      });
       clone.find('pre:contains("$comments")')[0].textContent = note['comments'];
       if (note['attachment_url']) {
         clone.find('.review-entry-attachment').removeClass('hidden');


### PR DESCRIPTION
Fixes mozilla/addons#16232

### Description

Adds the policies (`policy_texts` in `ActivityLog.details`) to the review history.

Before:
<img width="751" height="62" alt="before" src="https://github.com/user-attachments/assets/1467d053-06df-446a-b77c-85a73469f368" />

After:
<img width="760" height="225" alt="Screenshot 2026-05-22 at 12 19 26" src="https://github.com/user-attachments/assets/b5620a06-532f-4b6f-a793-943dd38bf873" />

### Context

When the waffle switch `cinder_policy_review_reasons_enabled` is enabled, the policies the reviewer selected are stored in `policy_texts`, rather than `comments`. That field needs to be exposed in the developer hub as well so developers can see the policies for which their submission was rejected.

### Testing

1. Submit an add-on.
2. Reject it, ideally with at least two policies and an additional note added to "Comments" in the reviewer tools.
3. Check the _Review History_ for that version in devhub. Make sure it contains both the selected policies and the note from "Comments".

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.

### History of this PR

#### Initial "After" screenshot

<img width="757" height="198" alt="after" src="https://github.com/user-attachments/assets/57ce85ed-e92c-4d9f-9ab6-412413fadb64" />
