### PR TITLE
Don't compile python dependencies on install if dev is one of the targets

### DIFF
--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -61,6 +61,8 @@ def main(targets):
         '--no-deps',
         '--exists-action=w',
     ]
+    if 'dev' in targets:
+        pip_args.append('--no-compile')
 
     # NPM_ARGS is set by the Dockerfile
     npm_args_env = os.environ['NPM_ARGS']

--- a/tests/make/test_install_deps.py
+++ b/tests/make/test_install_deps.py
@@ -115,6 +115,7 @@ class TestInstallDeps(unittest.TestCase):
                     '--progress-bar=off',
                     '--no-deps',
                     '--exists-action=w',
+                    '--no-compile',
                     '-r',
                     'requirements/pip.txt',
                     '-r',
@@ -140,6 +141,48 @@ class TestInstallDeps(unittest.TestCase):
                     'prod',
                     '--include',
                     'dev',
+                ],
+                check=True,
+            ),
+        ]
+
+    def test_correct_args_passed_to_subprocesses_prod(self):
+        """
+        Test that the correct arguments are passed to the subprocesses
+        """
+        main(['pip', 'prod'])
+
+        assert self.mocks['subprocess.run'].call_args_list == [
+            mock.call(
+                [
+                    'python3',
+                    '-m',
+                    'pip',
+                    'install',
+                    '--progress-bar=off',
+                    '--no-deps',
+                    '--exists-action=w',
+                    '-r',
+                    'requirements/pip.txt',
+                    '-r',
+                    'requirements/prod.txt',
+                ],
+                check=True,
+            ),
+            # NPM excludes the pip target
+            mock.call(
+                [
+                    'npm',
+                    'install',
+                    '--no-save',
+                    '--no-audit',
+                    '--no-fund',
+                    '--cache',
+                    '/data/olympia/deps/cache/npm',
+                    '--loglevel',
+                    'verbose',
+                    '--include',
+                    'prod',
                 ],
                 check=True,
             ),


### PR DESCRIPTION
CI/local dev envs run with `PYTHONDONTWRITEBYTECODE=1` anyway.

Fixes https://github.com/mozilla/addons/issues/16075