### PR TITLE
Mark ScannerRule.name field as read-only after creation

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -542,7 +542,7 @@ class AbstractScannerRuleAdminMixin:
     def get_readonly_fields(self, request, obj=None):
         fields = super().get_readonly_fields(request, obj)
         if obj:
-            fields += ('scanner',)
+            fields += ('scanner', 'name')
         return fields
 
     def matched_results_link(self, obj):

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -906,6 +906,7 @@ class TestScannerRuleAdmin(TestCase):
         request.user = self.user
         fields = self.admin.get_readonly_fields(request=request)
         assert 'scanner' not in fields
+        assert 'name' not in fields
 
     def test_get_readonly_fields_with_obj(self):
         rule = ScannerRule.objects.create(name='bar', scanner=YARA)
@@ -913,6 +914,7 @@ class TestScannerRuleAdmin(TestCase):
         request.user = self.user
         fields = self.admin.get_readonly_fields(request=request, obj=rule)
         assert 'scanner' in fields
+        assert 'name' in fields
 
     def test_create_form_filters_list_of_scanners(self):
         url = reverse('admin:scanners_scannerrule_add')


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/16216