### PR TITLE
Don't fail if we can't resolve translations for a given locale in a XPI

### DIFF
--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -1459,6 +1459,21 @@ class TestResolvei18nMessage:
         result = utils.resolve_i18n_message('__MSG_foo__', messages, 'en')
         assert result == 'bar'
 
+    def test_ignores_broken_messages_in_locale(self):
+        messages = {'en-US': {'foo': {'message': 'bar'}}, 'de': []}
+
+        result = utils.resolve_i18n_message('__MSG_foo__', messages, 'de')
+        assert result is None
+
+        result = utils.resolve_i18n_message('__MSG_foo__', messages, 'de', 'en-US')
+        assert result == 'bar'
+
+    def test_ignores_broken_messages_in_default_locale(self):
+        messages = {'en-US': {'foo': {'message': 'bar'}}, 'de': []}
+
+        result = utils.resolve_i18n_message('__MSG_foo__', messages, 'it', 'de')
+        assert result == '__MSG_foo__'
+
     def test_ignore_wrong_format_default(self):
         messages = {'en-US': {'foo': 'bar'}}
 

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1210,9 +1210,9 @@ def resolve_i18n_message(message, messages, locale, default_locale=None):
     msgid = match.group('msgid')
     default = {'message': message} if default_locale else {'message': None}
 
-    if locale in messages:
+    if locale in messages and messages[locale]:
         message = messages[locale].get(msgid, default)
-    elif default_locale in messages:
+    elif default_locale in messages and messages[default_locale]:
         message = messages[default_locale].get(msgid, default)
 
     if not isinstance(message, dict):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1210,10 +1210,10 @@ def resolve_i18n_message(message, messages, locale, default_locale=None):
     msgid = match.group('msgid')
     default = {'message': message} if default_locale else {'message': None}
 
-    if locale in messages and messages[locale]:
-        message = messages[locale].get(msgid, default)
-    elif default_locale in messages and messages[default_locale]:
-        message = messages[default_locale].get(msgid, default)
+    if messages_locale := messages.get(locale):
+        message = messages_locale.get(msgid, default)
+    elif messages_default_locale := messages.get(default_locale):
+        message = messages_default_locale.get(msgid, default)
 
     if not isinstance(message, dict):
         # Fallback for invalid message format, should be caught by


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/16245

### Context

We used to allow XPIs to be submitted with a `messages.json` file containing just `[]`, which is invalid. Sometime later we started raising an error at submission, but also when loading translations, which NARC query rules do.

### Testing

See https://github.com/mozilla/addons/issues/16245#issuecomment-4554612449 for STR, or look at unit tests added.