### PR TITLE
Exclude yara-x requirement file from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,6 +75,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  exclude-paths:
+    - "requirements/yara-x.txt"
   groups:
       google:
         patterns:


### PR DESCRIPTION
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#exclude-paths-