### PR TITLE
Duplicate scanner results for rollbacked versions

### DIFF
--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -156,13 +156,14 @@ class AbstractScannerResult(ModelBase):
         return res
 
     def duplicate(self, *, version=None, version_id=None):
+        """Creates a (saved) copy of this instance, for a different version."""
         overrides = {}
         if version_id:
             overrides['version_id'] = version_id
         elif version:
             overrides['version'] = version
             overrides['version_id'] = version.id
-        return self.__class__(
+        obj = self.__class__(
             **{
                 field.attname: getattr(self, field.attname)
                 for field in self._meta.concrete_fields
@@ -170,6 +171,8 @@ class AbstractScannerResult(ModelBase):
             },
             **overrides,
         )
+        obj.save()  # to recreate the matched_rules m2m
+        return obj
 
 
 def rule_schema(instance=None):

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -155,6 +155,22 @@ class AbstractScannerResult(ModelBase):
                             res[ruleId].append({'filename': filename, 'data': data})
         return res
 
+    def duplicate(self, *, version=None, version_id=None):
+        overrides = {}
+        if version_id:
+            overrides['version_id'] = version_id
+        elif version:
+            overrides['version'] = version
+            overrides['version_id'] = version.id
+        return self.__class__(
+            **{
+                field.attname: getattr(self, field.attname)
+                for field in self._meta.concrete_fields
+                if not field.primary_key and field.attname not in overrides
+            },
+            **overrides,
+        )
+
 
 def rule_schema(instance=None):
     if instance:

--- a/src/olympia/scanners/tests/test_models.py
+++ b/src/olympia/scanners/tests/test_models.py
@@ -354,23 +354,25 @@ class TestScannerResultMixin:
             version=result_version,
             results={'matchedRules': ['ringo']},
         )
+        assert result.matched_rules.exists()
+
         dupe_version = version_factory(addon=addon)
         dupe = result.duplicate(version=dupe_version)
-        assert dupe.pk is None
+        assert dupe.pk is not None
         assert dupe.results == result.results
         assert dupe.scanner == result.scanner
         assert dupe.version == dupe_version
-        dupe.save()
-        assert dupe.pk is not None
+        assert list(dupe.matched_rules.all()) == list(result.matched_rules.all())
 
         dupe_again_version = version_factory(addon=addon)
         dupe_again = dupe.duplicate(version_id=dupe_again_version.id)
-        assert dupe_again.pk is None
+        assert dupe_again.pk is not None
         assert dupe_again.results == result.results
         assert dupe_again.scanner == result.scanner
         assert dupe_again.version == dupe_again_version
-        dupe_again.save()
-        assert dupe_again.pk is not None
+        assert list(dupe_again.matched_rules.all()) == list(
+            dupe_again.matched_rules.all()
+        )
 
 
 class TestScannerResult(TestScannerResultMixin, TestCase):

--- a/src/olympia/scanners/tests/test_models.py
+++ b/src/olympia/scanners/tests/test_models.py
@@ -10,7 +10,7 @@ from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.access.models import Group, GroupUser
-from olympia.amo.tests import TestCase, addon_factory, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory, version_factory
 from olympia.constants.scanners import (
     ABORTED,
     ABORTING,
@@ -345,6 +345,32 @@ class TestScannerResultMixin:
                 },
             ],
         }
+
+    def test_duplicate(self):
+        addon = addon_factory()
+        result_version = version_factory(addon=addon)
+        result = ScannerResult.objects.create(
+            scanner=ScannerRule.objects.create(name='ringo', scanner=WEBHOOK).scanner,
+            version=result_version,
+            results={'matchedRules': ['ringo']},
+        )
+        dupe_version = version_factory(addon=addon)
+        dupe = result.duplicate(version=dupe_version)
+        assert dupe.pk is None
+        assert dupe.results == result.results
+        assert dupe.scanner == result.scanner
+        assert dupe.version == dupe_version
+        dupe.save()
+        assert dupe.pk is not None
+
+        dupe_again_version = version_factory(addon=addon)
+        dupe_again = dupe.duplicate(version_id=dupe_again_version.id)
+        assert dupe_again.pk is None
+        assert dupe_again.results == result.results
+        assert dupe_again.scanner == result.scanner
+        assert dupe_again.version == dupe_again_version
+        dupe_again.save()
+        assert dupe_again.pk is not None
 
 
 class TestScannerResult(TestScannerResultMixin, TestCase):

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -27,6 +27,7 @@ from olympia.files.models import File
 from olympia.files.utils import get_background_images
 from olympia.lib.crypto.tasks import duplicate_addon_version
 from olympia.reviewers.models import NeedsHumanReview
+from olympia.scanners.models import ScannerResult
 from olympia.scanners.tasks import call_webhooks
 from olympia.users.models import UserProfile
 from olympia.users.utils import get_task_user
@@ -341,6 +342,12 @@ def duplicate_addon_version_for_rollback(
         VersionLog.objects.bulk_create(
             VersionLog(version=version, activity_log=vl.activity_log)
             for vl in VersionLog.objects.filter(version=old_version)
+        )
+
+        # Duplicate any scanner [query] results
+        ScannerResult.objects.bulk_create(
+            sr.duplicate(version=version)
+            for sr in ScannerResult.objects.filter(version=old_version)
         )
 
         # Now log and notify the developers of that add-on.

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -345,10 +345,8 @@ def duplicate_addon_version_for_rollback(
         )
 
         # Duplicate any scanner [query] results
-        ScannerResult.objects.bulk_create(
+        for sr in ScannerResult.objects.filter(version=old_version):
             sr.duplicate(version=version)
-            for sr in ScannerResult.objects.filter(version=old_version)
-        )
 
         # Now log and notify the developers of that add-on.
         # Any exception should have caused an early return before reaching this point.

--- a/src/olympia/versions/tests/test_tasks.py
+++ b/src/olympia/versions/tests/test_tasks.py
@@ -30,6 +30,7 @@ from olympia.constants.scanners import (
     WEBHOOK_ON_VERSION_CREATED,
 )
 from olympia.reviewers.models import NeedsHumanReview
+from olympia.scanners.models import WEBHOOK, ScannerResult, ScannerRule
 from olympia.scanners.serializers import (
     WebhookAddonSerializer,
     WebhookVersionSerializer,
@@ -721,10 +722,19 @@ class TestDuplicateAddonVersionForRollback(TestCase):
             f'by re-publishing as "{new.version}" successful' in mail.outbox[0].body
         )
 
+    def check_scanner_results(self, old, new):
+        assert new.scannerresults.count() == 1
+        assert new.scannerresults.get().results == old.scannerresults.get().results
+
     @mock.patch('olympia.versions.tasks.statsd.incr')
     @mock.patch('olympia.lib.crypto.tasks.sign_file')
     def _test_rollback_success(self, sign_file_mock, statsd_mock):
         new_version_number = '123'
+        ScannerResult.objects.create(
+            scanner=ScannerRule.objects.create(name='ringo', scanner=WEBHOOK).scanner,
+            version=self.rollback_version,
+            results={'matchedRules': ['ringo']},
+        )
 
         duplicate_addon_version_for_rollback.delay(
             version_pk=self.rollback_version.pk,
@@ -749,6 +759,7 @@ class TestDuplicateAddonVersionForRollback(TestCase):
         self.check_version_fields(new_version)
         self.check_new_xpi(new_version)
         self.check_email(new_version)
+        self.check_scanner_results(self.rollback_version, new_version)
         return new_version
 
     def test_listed(self):

--- a/src/olympia/versions/tests/test_tasks.py
+++ b/src/olympia/versions/tests/test_tasks.py
@@ -724,7 +724,13 @@ class TestDuplicateAddonVersionForRollback(TestCase):
 
     def check_scanner_results(self, old, new):
         assert new.scannerresults.count() == 1
-        assert new.scannerresults.get().results == old.scannerresults.get().results
+        new_result = new.scannerresults.get()
+        old_result = old.scannerresults.get()
+        assert new_result.scanner == old_result.scanner
+        assert new_result.results == old_result.results
+        assert list(new_result.matched_rules.all()) == list(
+            old_result.matched_rules.all()
+        )
 
     @mock.patch('olympia.versions.tasks.statsd.incr')
     @mock.patch('olympia.lib.crypto.tasks.sign_file')


### PR DESCRIPTION
Fixes mozilla/addons#16152

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Duplicates scanner results linked to a version when we're rolling it back

### Context

I tried to make AbstractScannerResult.duplicate as generic as possible, not knowing what future fields could be added to the models.  (I started writing a more generic function that would accept any arbitrary fields as overrides - not just version  - but it ended up getting complicated due to foreign keys and it really wasn't worth it given our current use case)

### Testing

- Have a version with one or more scanner results
- have 1 newer approved version you can rollback over
- rollback to the version with the scanner results
- see the scanner results are shown in reviewer tools for the newly rolled back version

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
