### PR TITLE
Support manual Cinder decisions in webhook

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1147,6 +1147,8 @@ class ContentDecision(ModelBase):
             return DECISION_SOURCES.REVIEWER
         elif self.from_job_queue == CinderAddonHandledByLegal.queue:
             return DECISION_SOURCES.LEGAL
+        elif self.from_job_queue is None:
+            return DECISION_SOURCES.MANUAL
         else:
             return DECISION_SOURCES.TASKUS
 

--- a/src/olympia/abuse/tests/assets/cinder_webhook_payloads/proactive_decision_from_cinder.json
+++ b/src/olympia/abuse/tests/assets/cinder_webhook_payloads/proactive_decision_from_cinder.json
@@ -1,0 +1,71 @@
+{
+  "event": "decision.created",
+  "payload": {
+    "appeals_resolved": [],
+    "enforcement_actions": [
+      "amo-approve"
+    ],
+    "enforcement_actions_removed": [],
+    "entity": {
+      "attributes": {
+        "average_daily_users": 0,
+        "created": "2025-09-09T08:12:58.308105",
+        "guid": "{58d58fa6-2667-4695-a2d9-b05365899ba6}",
+        "id": "10001",
+        "last_updated": "2025-09-09T08:20:24.728686",
+        "name": "Livemarks_rollback2",
+        "promoted": "",
+        "slug": "livemarks_rollback2",
+        "summary": "Restores RSS live bookmark support to Firefox 64 and above."
+      },
+      "entity_schema": "amo_addon"
+    },
+    "notes": "some notes",
+    "point_updates": [],
+    "policies": [
+      {
+        "enforcement_actions": [
+          "amo-approve"
+        ],
+        "id": "bfc16995-6a3f-4fb7-abd5-58c4ecab44e6",
+        "is_illegal": false,
+        "is_non_violating": true,
+        "name": "Approve"
+      }
+    ],
+    "policies_removed": [],
+    "source": {
+      "decision": {
+        "id": "a51b39a6-e628-4cf6-b275-2a78bae497ee",
+        "metadata": {},
+        "notes": "some notes",
+        "type": "manual",
+        "user": {
+          "email": "awilliamson@test.com",
+          "groups": [
+            {
+              "name": "Admin"
+            },
+            {
+              "name": "Everyone"
+            }
+          ],
+          "name": "Andrew Williamson"
+        }
+      },
+      "user": {
+        "email": "awilliamson@test.com",
+        "groups": [
+          {
+            "name": "Admin"
+          },
+          {
+            "name": "Everyone"
+          }
+        ],
+        "name": "Andrew Williamson"
+      }
+    },
+    "timestamp": "2026-05-28T12:01:13.403410+00:00"
+  }
+}

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2503,7 +2503,7 @@ class TestContentDecision(TestCase):
         decision = ContentDecision.objects.create(
             action=DECISION_ACTIONS.AMO_DISABLE_ADDON, addon=addon
         )
-        assert decision.source == DECISION_SOURCES.TASKUS
+        assert decision.source == DECISION_SOURCES.MANUAL
 
         decision.update(reviewer_user=self.task_user)
         assert decision.source == DECISION_SOURCES.AUTOMATION

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -1742,8 +1742,33 @@ class TestCinderWebhook(TestCase):
         }
 
     def test_proactive_decision_from_cinder(self):
+        data = self.get_data(filename='proactive_decision_from_cinder.json')
+        addon = addon_factory(
+            id=10001,
+            created=datetime.fromisoformat(
+                data['payload']['entity']['attributes']['created']
+            ),
+        )
+        self._setup_reports()
+        req = self.get_request(data=data)
+        with mock.patch.object(CinderJob, 'create_and_execute_decision') as create_mock:
+            response = cinder_webhook(req)
+            create_mock.assert_called()
+            create_mock.assert_called_with(
+                None,
+                target=addon,
+                decision_cinder_id=data['payload']['source']['decision']['id'],
+                decision_actions=[DECISION_ACTIONS.AMO_APPROVE.value],
+                decision_notes='some notes',
+                policy_ids=[data['payload']['policies'][0]['id']],
+                job_queue=None,
+            )
+        assert response.status_code == 201
+        assert response.data == {'amo': {'received': True, 'handled': True}}
+
+    def test_unsupported_decision_from_cinder(self):
         data = self.get_data(filename='proactive_decision_from_amo.json')
-        data['payload']['source']['decision']['type'] = 'queue_review'
+        data['payload']['source']['decision']['type'] = 'something'
         self._setup_reports()
         req = self.get_request(data=data)
         with mock.patch.object(CinderJob, 'create_and_execute_decision') as create_mock:
@@ -1754,7 +1779,7 @@ class TestCinderWebhook(TestCase):
             'amo': {
                 'received': True,
                 'handled': False,
-                'not_handled_reason': 'Unsupported Manual decision',
+                'not_handled_reason': 'Unsupported decision',
             }
         }
 

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -193,7 +193,8 @@ class CinderWebhookMissingIdError(CinderWebhookError):
 
 
 def get_job_from_payload(payload):
-    if job_id := payload.get('source', {}).get('job', {}).get('id'):
+    source = payload.get('source', {})
+    if job_id := source.get('job', {}).get('id'):
         try:
             return CinderJob.objects.get(job_id=job_id)
         except CinderJob.DoesNotExist:
@@ -208,11 +209,12 @@ def get_job_from_payload(payload):
             raise CinderWebhookMissingIdError('No matching decision id found') from exc
         return prev_decision.cinder_job
 
+    if source.get('decision', {}).get('type') == 'manual':
+        log.debug('Cinder webhook decision is a manual decision, no job to link to.')
+        return None
     else:
-        # We may support this one day, but we currently don't support manual decisions
-        # that originated in Cinder
-        log.debug('Cinder webhook decision for cinder proactive decision skipped.')
-        raise CinderWebhookError('Unsupported Manual decision')
+        log.debug('Cinder webhook decision for unsupported scenario skipped.')
+        raise CinderWebhookError('Unsupported decision')
 
 
 def get_target_from_payload_entity(entity):

--- a/src/olympia/constants/abuse.py
+++ b/src/olympia/constants/abuse.py
@@ -357,3 +357,4 @@ class DECISION_SOURCES(StrEnum):
     REVIEWER = 'AMO Reviewer'
     LEGAL = 'Legal'
     TASKUS = 'TaskUs'
+    MANUAL = 'Manual'

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -8121,10 +8121,13 @@ class TestHeldDecisionQueue(ReviewerTest):
         self.url = reverse('reviewers.queue_decisions')
 
         self.addon_decision = ContentDecision.objects.create(
-            action=DECISION_ACTIONS.AMO_DISABLE_ADDON, addon=addon_factory()
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            addon=addon_factory(),
+            from_job_queue='some-extension-queue',
         )
         self.user_decision = ContentDecision.objects.create(
-            action=DECISION_ACTIONS.AMO_BAN_USER, user=user_factory()
+            action=DECISION_ACTIONS.AMO_BAN_USER,
+            user=user_factory(),
         )
         self.collection_decision = ContentDecision.objects.create(
             action=DECISION_ACTIONS.AMO_DELETE_COLLECTION,
@@ -8211,6 +8214,7 @@ class TestHeldDecisionReview(ReviewerTest):
             metadata={
                 ContentDecision.POLICY_DYNAMIC_VALUES: {policy.uuid: {'FOO': 'baa'}}
             },
+            from_job_queue='some-cinder-queue',
         )
         self.version = self.decision.addon.current_version
         self.decision.target_versions.set([self.version])
@@ -8427,3 +8431,13 @@ class TestHeldDecisionReview(ReviewerTest):
             field=None,
             errors=['Not currently held for 2nd level approval'],
         )
+
+    def test_manual_source(self):
+        self.decision.update(from_job_queue=None)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)('.entity-type-Extension')
+
+        assert f'Extension Decision for {self.decision.addon.name}' in doc.html()
+        assert doc('h2').attr('class') == 'held-item MANUAL'
+        assert 'Manual' == doc('.decision-source td').text()


### PR DESCRIPTION
Connected to mozilla/addons#16052 and fixes mozilla/addons#16253

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Expands the webhook so it can accept decisions from Cinder that don't originate with a job - i.e. manual decisions taken via the Cinder investigate entity tool

### Context

Most of the heavy lifting was done for content review, it was mainly just double checking the payload was processed as expected.  Both  "Take a manual action" and "Apply a policy" from the rhs kebab menu work - the former results in a decision without a policy, for a specific enforcement action - though I'd imagine the latter will be more commonly used.

### Testing

- select an add-on that exists locally and in cinder staging 
  - if you don't want to have to tinker with json, the easiest way is to trigger something that would create/update the entity in Cinder with the exact same created and id, like reporting it for abuse
- go to the investigate page for the addon at https://mozilla-staging.cinderapp.com/investigate/amo_addon/{id}
- use the rhs kebab menu to select "Apply a policy", and choose a policy that would disable the add-on
- replay the webhook payload locally with `./manage.py fake_cinder_webhook`
- See the decision has been created, and the add-on disabled, with the policy selected
  - if the add-on you chose was promoted, you'll need to confirm from 2nd level approval before the action takes place
 
### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
