### PR TITLE
Allow multiple versions to be selected with a policy.

### DIFF
--- a/src/olympia/constants/abuse.py
+++ b/src/olympia/constants/abuse.py
@@ -119,6 +119,14 @@ DECISION_ACTIONS.add_subset(
         'AMO_BLOCK_ADDON',
     ),
 )
+DECISION_ACTIONS.add_subset(
+    'VERSION_SPECIFIC',
+    (
+        'AMO_REJECT_VERSION_ADDON',
+        'AMO_REJECT_VERSION_WARNING_ADDON',
+        'AMO_APPROVE_VERSION',
+    ),
+)
 
 
 # Illegal categories, only used when the reason is `illegal`. The constants

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -116,12 +116,14 @@ class VersionsChoiceWidget(forms.SelectMultiple):
     actions_filters = {
         amo.CHANNEL_UNLISTED: {
             amo.STATUS_APPROVED: [
+                'review_with_policy',
                 'block_multiple_versions',
                 'confirm_multiple_versions',
                 'reject_multiple_versions',
                 'reply',
             ],
             amo.STATUS_AWAITING_REVIEW: [
+                'review_with_policy',
                 'approve_multiple_versions',
                 'reject_multiple_versions',
                 'reply',
@@ -133,11 +135,13 @@ class VersionsChoiceWidget(forms.SelectMultiple):
         },
         amo.CHANNEL_LISTED: {
             amo.STATUS_APPROVED: [
+                'review_with_policy',
                 'block_multiple_versions',
                 'reject_multiple_versions',
                 'reply',
             ],
             amo.STATUS_AWAITING_REVIEW: [
+                'review_with_policy',
                 'approve_multiple_versions',
                 'reject_multiple_versions',
                 'reply',
@@ -300,7 +304,9 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
             'resolve_appeal_job' if not is_appeal else 'resolve_reports_job'
         ]
         if is_developer_appeal:
-            hide_for_these_actions.extend(('reject', 'reject_multiple_versions'))
+            hide_for_these_actions.extend(
+                ('review_with_policy', 'reject', 'reject_multiple_versions')
+            )
         attrs['data-value'] = ' '.join(hide_for_these_actions)
         return super().create_option(
             name, value, label, selected, index, subindex, attrs
@@ -331,11 +337,11 @@ class CinderPolicyWidget(forms.CheckboxSelectMultiple):
         )
         attrs['class'] = 'data-toggle'
         attrs['data-value'] = ' '.join(visible_for_reviewer_actions)
-        attrs['data-enforcement-primary-actions'] = ', '.join(
-            DECISION_ACTIONS(action).label for action in enforcement_actions.primary
+        attrs['data-enforcement-primary-actions'] = str(
+            [action.value for action in enforcement_actions.primary]
         )
-        attrs['data-enforcement-followup-actions'] = ', '.join(
-            DECISION_ACTIONS(action).label for action in enforcement_actions.followup
+        attrs['data-enforcement-followup-actions'] = str(
+            [action.value for action in enforcement_actions.followup]
         )
         attrs['data-enforcement-actions-order'] = hash_addon_negative_actions(
             enforcement_actions
@@ -490,7 +496,9 @@ class ReviewForm(forms.Form):
         # the individual <option> which is also needed for unlisted review
         # where for some actions we display the dropdown hiding some of the
         # versions it contains.
-        widget=VersionsChoiceWidget(attrs={'class': 'data-toggle'}),
+        widget=VersionsChoiceWidget(
+            attrs={'class': 'data-toggle data-toggle-enforcement'}
+        ),
         required=False,
         queryset=Version.objects.none(),
     )  # queryset is set later in __init__.
@@ -566,7 +574,9 @@ class ReviewForm(forms.Form):
         if action:
             if not action.get('comments', True):
                 self.fields['comments'].required = False
-            if action.get('multiple_versions', False):
+            if action.get('multiple_versions', False) and not action.get(
+                'policy_enforcement', False
+            ):
                 self.fields['versions'].required = True
             if not action.get('enforcement_actions'):
                 self.fields['cinder_policies'].required = False
@@ -623,7 +633,7 @@ class ReviewForm(forms.Form):
                         selected_actions
                     )
                 ]
-            all_actions = set(
+            all_primary_actions = set(
                 filtered.primary
                 for policy in policies
                 if (
@@ -632,28 +642,57 @@ class ReviewForm(forms.Form):
                     )
                 )
             )
-            if len(all_actions) == 0:
+            if len(all_primary_actions) == 0:
                 self.add_error(
                     'cinder_policies',
                     'No policies selected with an associated cinder action.',
                 )
-            elif (
-                not selected_definition.get('policy_enforcement')
-                and len(all_actions) > 1
-            ):
+            elif not is_policy_enforcement and len(all_primary_actions) > 1:
                 self.add_error(
                     'cinder_policies',
                     'Multiple policies selected with different cinder actions.',
                 )
-            elif any(len(actions) != 1 for actions in all_actions):
+            elif any(len(actions) != 1 for actions in all_primary_actions):
                 self.add_error(
                     'cinder_policies',
                     'Invalid policies selected with more than one primary enforcement '
                     'action.',
                 )
-            # TODO: once we support non-negative policies, we'll need to check that the
-            # policy selection is consistent - e.g. you shouldn't be able to select a
-            # positive and negative policy together
+
+            if is_policy_enforcement:
+                # get the most aggressive negative policy
+                # TODO: if we expand to support non-negative policies, we'll need to
+                # change this logic (e.g. most_postive_actions, or something).
+                sorted_actions = sorted(
+                    (
+                        filter_enforcement_actions(
+                            policy.split_enforcement_actions, Addon
+                        )
+                        for policy in policies
+                    ),
+                    key=lambda actions: hash_addon_negative_actions(actions),
+                    reverse=True,
+                )
+
+                if sorted_actions:
+                    self.cleaned_data['most_aggressive_policy_actions'] = (
+                        sorted_actions[0]
+                    )
+                    if self.cleaned_data['most_aggressive_policy_actions'].primary[
+                        0
+                    ] in DECISION_ACTIONS.VERSION_SPECIFIC and selected_definition.get(
+                        'multiple_versions'
+                    ):
+                        # we need versions if the primary enf action is version specific
+                        if not self.cleaned_data['versions']:
+                            self.add_error('versions', 'This field is required.')
+                    else:
+                        # otherwise, don't confuse logging with versions
+                        self.cleaned_data['versions'] = []
+
+                # TODO: once we support non-negative policies, we'll need to check that
+                # the policy selection is consistent - e.g. you shouldn't be able to
+                # select a positive and negative policy together
 
         if selected_definition.get('delayable'):
             delayed_rejection = self.cleaned_data.get('delayed_rejection')
@@ -782,6 +821,9 @@ class ReviewForm(forms.Form):
             # Reset data-value depending on widget depending on actions available.
             self.fields['versions'].widget.attrs['data-value'] = ' '.join(
                 versions_actions
+            )
+            self.fields['versions'].widget.attrs['data-value-enforcement'] = ' '.join(
+                f"'{action.value}'" for action in DECISION_ACTIONS.VERSION_SPECIFIC
             )
 
         # Set choices on the action field dynamically to raise an error when

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -501,6 +501,7 @@ class ReviewForm(forms.Form):
         ),
         required=False,
         queryset=Version.objects.none(),
+        label='Versions:',
     )  # queryset is set later in __init__.
 
     operating_systems = forms.CharField(required=False, label='Operating systems:')

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -239,8 +239,10 @@
 
       </div>
       <div class="review-actions-section">
-        {{ form.versions }}
-        {{ form.versions.errors }}
+        <label for="id_versions">{{ form.versions.label }}
+          {{ form.versions }}
+          {{ form.versions.errors }}
+        </label>
       </div>
 
       <div class="review-actions-section data-toggle review-resolve-abuse-reports"

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -171,9 +171,6 @@
         You can still submit this form, however only do so if you know it won't conflict.
       </div>
 
-      {{ form.versions }}
-      {{ form.versions.errors }}
-
       <div class="review-actions-section">
         <div class="review-actions-versions-reenabled data-toggle" data-value="enable_addon">
           {{ versions_that_would_be_enabled|count }} version(s) will be re-enabled:
@@ -218,9 +215,15 @@
             </div>
             <div class="data-toggle" data-value="{{ toggle_when_action('policy_enforcement') }}">
               <h4>Enforcement actions:</h4>
-              <span id="policy-enforcement-primary-actions"></span>;
-              <span id="policy-enforcement-followup-actions"></span>
-          </div>
+              <ol id="policy-enforcement-actions">
+                <li class="action-0 primary-enf">No Action</li>
+                {% for action in DECISION_ACTIONS %}
+                {% with enf='primary-enf' if not action in DECISION_ACTIONS.FOLLOWUP_CINDER_ACTIONS else 'followup-enf' %}
+                <li class="action-{{ action.value }} hidden {{ enf }}">{{ action.label }}</li>
+                {% endwith %}
+                {% endfor %}
+              </ol>
+            </div>
           </div>
           <div class="data-toggle"
                data-value="resolve_appeal_job">
@@ -233,6 +236,11 @@
             </div>
           </div>
         </div>
+
+      </div>
+      <div class="review-actions-section">
+        {{ form.versions }}
+        {{ form.versions.errors }}
       </div>
 
       <div class="review-actions-section data-toggle review-resolve-abuse-reports"

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -489,6 +489,10 @@ class TestReviewForm(TestCase):
         form = self.get_form(data=data)
         assert form.is_valid(), form.errors
         assert not form.errors
+        assert form.cleaned_data['most_aggressive_policy_actions'] == (
+            (DECISION_ACTIONS.AMO_DISABLE_ADDON,),
+            (),
+        )
 
         # multiple primary enforcement action per policy are prevented if that happens
         action_policy_c.update(
@@ -505,6 +509,55 @@ class TestReviewForm(TestCase):
                 'action.'
             ]
         }
+
+    @override_switch('enable-policy-review-selection', active=True)
+    def test_versions_required_when_enforcement_is_on_versions(self):
+        self.grant_permission(self.request.user, 'Addons:Review')
+        self.addon.update(status=amo.STATUS_NOMINATED)
+        self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
+        disable_policy = CinderPolicy.objects.create(
+            uuid='a',
+            name='disable',
+            expose_in_reviewer_tools=True,
+            enforcement_actions=[DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value],
+        )
+        reject_policy = CinderPolicy.objects.create(
+            uuid='c',
+            name='reject',
+            expose_in_reviewer_tools=True,
+            enforcement_actions=[DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON.api_value],
+        )
+
+        data = {
+            'action': 'review_with_policy',
+            'cinder_policies': [disable_policy.id],
+        }
+        form = self.get_form(data=data)
+        # versions isn't required
+        assert form.is_valid(), form.errors
+
+        data['cinder_policies'] = [disable_policy.id, reject_policy.id]
+        form = self.get_form(data=data)
+        # disable action takes priority over reject, so versions isn't required
+        assert form.is_valid(), form.errors
+
+        # and versions is cleaned if present
+        data['versions'] = [self.version.id]
+        form = self.get_form(data=data)
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data['versions'] == []
+
+        del data['versions']
+        data['cinder_policies'] = [reject_policy.id]
+        form = self.get_form(data=data)
+        assert not form.is_valid()
+        assert form.errors == {'versions': ['This field is required.']}
+
+        data['versions'] = [self.version.id]
+        form = self.get_form(data=data)
+        assert form.is_valid(), form.errors
+        assert not form.errors
+        assert list(form.cleaned_data['versions']) == [self.version]
 
     def test_cinder_jobs_filtered_for_resolve_reports_job_and_resolve_appeal_job(self):
         self.grant_permission(self.request.user, 'Addons:Review')
@@ -761,8 +814,13 @@ class TestReviewForm(TestCase):
         # <select> should have 'data-toggle' class and data-value attribute to
         # show/hide it depending on action in JavaScript.
         select = doc('select')[0]
-        assert select.attrib.get('class') == 'data-toggle'
+        assert select.attrib.get('class') == 'data-toggle data-toggle-enforcement'
         assert select.attrib.get('data-value').split(' ') == expected_select_data_value
+        assert select.attrib.get('data-value-enforcement') == (
+            f"'{DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON.value}' "
+            f"'{DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON.value}' "
+            f"'{DECISION_ACTIONS.AMO_APPROVE_VERSION.value}'"
+        )
 
         # <option>s should as well, and the value depends on which version:
         # the approved one and the pending one should have different values.
@@ -771,6 +829,7 @@ class TestReviewForm(TestCase):
         assert option1.attrib.get('class') == 'data-toggle'
         assert option1.attrib.get('data-value').split(' ') == [
             # That version is approved.
+            'review_with_policy',
             'block_multiple_versions',
             'reject_multiple_versions',
             'reply',
@@ -782,6 +841,7 @@ class TestReviewForm(TestCase):
         assert option2.attrib.get('class') == 'data-toggle'
         assert option2.attrib.get('data-value').split(' ') == [
             # That version is pending.
+            'review_with_policy',
             'approve_multiple_versions',
             'reject_multiple_versions',
             'reply',
@@ -794,7 +854,7 @@ class TestReviewForm(TestCase):
         assert option3.attrib.get('data-value').split(' ') == [
             # That version is rejected, so it has unreject_multiple_versions,
             # but it was never signed so it doesn't get
-            # set_needs_human_review_multiple_versions
+            # set_needs_human_review_multiple_version
             'unreject_multiple_versions',
             'reply',
         ]
@@ -892,8 +952,13 @@ class TestReviewForm(TestCase):
         # <select> should have 'data-toggle' class and data-value attribute to
         # show/hide it depending on action in JavaScript.
         select = doc('select')[0]
-        assert select.attrib.get('class') == 'data-toggle'
+        assert select.attrib.get('class') == 'data-toggle data-toggle-enforcement'
         assert select.attrib.get('data-value').split(' ') == expected_select_data_value
+        assert select.attrib.get('data-value-enforcement') == (
+            f"'{DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON.value}' "
+            f"'{DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON.value}' "
+            f"'{DECISION_ACTIONS.AMO_APPROVE_VERSION.value}'"
+        )
 
         # <option>s should as well, and the value depends on which version:
         # the approved one and the pending one should have different values.
@@ -902,6 +967,7 @@ class TestReviewForm(TestCase):
         assert option1.attrib.get('class') == 'data-toggle'
         assert option1.attrib.get('data-value').split(' ') == [
             # That version is approved.
+            'review_with_policy',
             'block_multiple_versions',
             'confirm_multiple_versions',
             'reject_multiple_versions',
@@ -914,6 +980,7 @@ class TestReviewForm(TestCase):
         assert option2.attrib.get('class') == 'data-toggle'
         assert option2.attrib.get('data-value').split(' ') == [
             # That version is pending.
+            'review_with_policy',
             'approve_multiple_versions',
             'reject_multiple_versions',
             'reply',
@@ -1403,7 +1470,12 @@ class TestReviewForm(TestCase):
         assert label_0.attr['data-value'] == 'resolve_appeal_job'
         assert label_1.attr['class'] == 'data-toggle-hide'
         assert label_1.attr['data-value'] == ' '.join(
-            ('resolve_reports_job', 'reject', 'reject_multiple_versions')
+            (
+                'resolve_reports_job',
+                'review_with_policy',
+                'reject',
+                'reject_multiple_versions',
+            )
         )
         assert label_2.attr['class'] == 'data-toggle-hide'
         assert label_2.attr['data-value'] == 'resolve_appeal_job'
@@ -1496,24 +1568,29 @@ class TestReviewForm(TestCase):
 
         assert label_0.attr['class'] == 'data-toggle'
         assert label_0.attr['data-value'] == ''
-        assert label_0.attr['data-enforcement-primary-actions'] == ''
-        assert label_0.attr['data-enforcement-followup-actions'] == ''
+        assert label_0.attr['data-enforcement-primary-actions'] == '[]'
+        assert label_0.attr['data-enforcement-followup-actions'] == '[]'
         assert label_0.attr['data-enforcement-actions-order'] == ''
 
         assert label_1.attr['class'] == 'data-toggle'
         assert label_1.attr['data-value'] == 'reject reject_multiple_versions'
-        assert label_1.attr['data-enforcement-primary-actions'] == 'Add-on disable'
+        assert (
+            label_1.attr['data-enforcement-primary-actions']
+            == f'[{DECISION_ACTIONS.AMO_DISABLE_ADDON.value}]'
+        )
         assert label_1.attr['data-enforcement-followup-actions'] == (
-            '[Follow-up] Long-delayed soft block, [Follow-up] Short-delayed hard block'
+            f'[{DECISION_ACTIONS.AMO_FU_DELAY_LONG_SOFT_BLOCK_ADDON.value}, '
+            f'{DECISION_ACTIONS.AMO_FU_DELAY_SHORT_HARD_BLOCK_ADDON.value}]'
         )
         assert label_1.attr['data-enforcement-actions-order'] == '090500'
 
         assert label_2.attr['class'] == 'data-toggle'
         assert label_2.attr['data-value'] == 'public'
         assert (
-            label_2.attr['data-enforcement-primary-actions'] == 'Approved (no action)'
+            label_2.attr['data-enforcement-primary-actions']
+            == f'[{DECISION_ACTIONS.AMO_APPROVE.value}]'
         )
-        assert label_2.attr['data-enforcement-followup-actions'] == ''
+        assert label_2.attr['data-enforcement-followup-actions'] == '[]'
         assert label_2.attr['data-enforcement-actions-order'] == ''
 
     def test_policy_values_fields(self):

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -17,6 +17,7 @@ from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.abuse.models import AbuseReport, CinderJob, CinderPolicy, ContentDecision
+from olympia.abuse.utils import filter_enforcement_actions
 from olympia.activity import log_create
 from olympia.activity.models import (
     ActivityLog,
@@ -1218,7 +1219,6 @@ class TestReviewHelper(TestReviewHelperBase):
         expected = [
             'review_with_policy',
             'public',
-            'reject_multiple_versions',
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
@@ -1377,12 +1377,14 @@ class TestReviewHelper(TestReviewHelperBase):
                         DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON.api_value
                     ],
                 ),
-                CinderPolicy.objects.create(
-                    uuid='y',
-                    enforcement_actions=[
-                        DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
-                        DECISION_ACTIONS.AMO_FU_DELAY_SHORT_HARD_BLOCK_ADDON.api_value,
-                    ],
+                (
+                    most := CinderPolicy.objects.create(
+                        uuid='y',
+                        enforcement_actions=[
+                            DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+                            DECISION_ACTIONS.AMO_FU_DELAY_SHORT_HARD_BLOCK_ADDON.api_value,
+                        ],
+                    )
                 ),
                 CinderPolicy.objects.create(
                     uuid='z',
@@ -1393,6 +1395,9 @@ class TestReviewHelper(TestReviewHelperBase):
                 ),
             ],
             'cinder_jobs_to_resolve': [cinder_job],
+            'most_aggressive_policy_actions': filter_enforcement_actions(
+                most.split_enforcement_actions, Addon
+            ),
         }
         self.helper.set_data(data)
         self.helper.handler.review_action = self.helper.actions.get(
@@ -4105,11 +4110,14 @@ class TestReviewHelper(TestReviewHelperBase):
         data = {
             'action': 'review_with_policy',
             'cinder_policies': [
-                CinderPolicy.objects.create(
+                policy := CinderPolicy.objects.create(
                     uuid='z',
                     enforcement_actions=[DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value],
                 ),
             ],
+            'most_aggressive_policy_actions': filter_enforcement_actions(
+                policy.split_enforcement_actions, Addon
+            ),
         }
         self.helper.set_data(data)
         self.helper.handler.review_action = self.helper.actions['review_with_policy']

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -6814,7 +6814,7 @@ class TestReview(ReviewBase):
         )
 
     @override_switch('enable-policy-review-selection', active=True)
-    def test_review_with_review_with_policy_action(self):
+    def test_review_with_review_with_policy_action_disable(self):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}v1/create_decision',
@@ -6844,7 +6844,7 @@ class TestReview(ReviewBase):
         )
 
     @override_switch('enable-policy-review-selection', active=True)
-    def test_review_with_review_with_policy_action_reject_action(self):
+    def test_review_with_review_with_policy_action_reject(self):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}v1/create_decision',
@@ -6866,6 +6866,7 @@ class TestReview(ReviewBase):
             self.get_dict(
                 action='review_with_policy',
                 cinder_policies=[policy.id],
+                versions=[self.version.pk],
             ),
         )
         assert response.status_code == 302, response.context['form'].errors
@@ -6883,6 +6884,62 @@ class TestReview(ReviewBase):
 
         assert old_version.reload().needshumanreview_set.filter(is_active=True).exists()
         assert old_version.file.status == amo.STATUS_APPROVED
+
+    @override_switch('enable-policy-review-selection', active=True)
+    def test_review_with_review_with_policy_action_multiple_reject(self):
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}v1/create_decision',
+            json={'uuid': uuid.uuid4().hex},
+            status=201,
+        )
+        self.grant_permission(self.reviewer, 'Addons:Review')
+        policy = CinderPolicy.objects.create(
+            uuid='1',
+            name='policy 1',
+            expose_in_reviewer_tools=True,
+            enforcement_actions=[DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON.api_value],
+        )
+        old_version = self.version
+        self.version = version_factory(addon=self.addon, version='3.0')
+        response = self.client.post(
+            self.url,
+            self.get_dict(
+                action='review_with_policy',
+                cinder_policies=[policy.id],
+                versions=[self.version.pk, old_version.pk],
+            ),
+        )
+        assert response.status_code == 302, response.context['form'].errors
+        assert self.get_addon().status == amo.STATUS_NULL
+        log_entry = ActivityLog.objects.get(action=amo.LOG.REJECT_VERSION.id)
+        decision = log_entry.contentdecisionlog_set.get().decision
+        assert log_entry.arguments == [
+            self.addon,
+            decision,
+            policy,
+            self.version,
+            old_version,
+        ]
+        assert decision.action == DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
+        assert self.version.file.reload().status == amo.STATUS_DISABLED
+        assert old_version.file.reload().status == amo.STATUS_DISABLED
+
+    def test_enforcement_actions_rendered(self):
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+
+        enforcement_actions = doc('#policy-enforcement-actions li')
+        # We have a "No Action li at the top"
+        assert len(enforcement_actions('li')) == len(DECISION_ACTIONS) + 1
+
+        for action in DECISION_ACTIONS:
+            item = enforcement_actions(f'li.action-{action.value}')
+            assert item.length == 1
+            if action not in DECISION_ACTIONS.FOLLOWUP_CINDER_ACTIONS:
+                assert 'primary-enf' in item[0].classes
+            else:
+                assert 'followup-enf' in item[0].classes
 
 
 class TestAbuseReportsView(ReviewerTest):

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -21,7 +21,7 @@ from olympia.abuse.models import (
     ContentDecisionFollowupAction,
 )
 from olympia.abuse.tasks import report_decision_to_cinder_and_notify
-from olympia.abuse.utils import filter_enforcement_actions, hash_addon_negative_actions
+from olympia.abuse.utils import filter_enforcement_actions
 from olympia.access import acl
 from olympia.activity.models import ActivityLog, AttachmentLog
 from olympia.activity.utils import notify_about_activity_log
@@ -577,7 +577,6 @@ class ReviewHelper:
                 policy_selection_enabled
                 and not is_static_theme
                 and not self.content_review
-                and addon_is_reviewable
                 and is_appropriate_reviewer
             ),
             'enforcement_actions': (
@@ -592,10 +591,7 @@ class ReviewHelper:
                 # DECISION_ACTIONS.AMO_IGNORE,
                 DECISION_ACTIONS.AMO_BLOCK_ADDON,
             ),
-            # TODO: allow multiple version selection so we can replace
-            # `reject_multiple_versions` too - we need to handle policies that would
-            # disable the add-on
-            # 'multiple_versions': True,
+            'multiple_versions': can_reject_multiple,
             'resolves_cinder_jobs': True,
             'can_attach': True,
         }
@@ -754,7 +750,7 @@ class ReviewHelper:
                 'This will reject the selected versions. '
                 'The comments will be sent to the developer.'
             ),
-            'available': can_reject_multiple,
+            'available': not policy_selection_enabled and can_reject_multiple,
             'enforcement_actions': (
                 DECISION_ACTIONS.AMO_DISABLE_ADDON,
                 DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
@@ -807,7 +803,10 @@ class ReviewHelper:
                 'admin page.'
             ),
             'available': (
-                not is_static_theme and version_is_unlisted and is_appropriate_reviewer
+                not policy_selection_enabled
+                and not is_static_theme
+                and version_is_unlisted
+                and is_appropriate_reviewer
             ),
         }
         actions['confirm_multiple_versions'] = {
@@ -1144,18 +1143,14 @@ class ReviewBase:
         else:
             policies = []
 
-        if self.review_action and self.review_action.get('policy_enforcement'):
-            # get the most aggressive negative policy
-            # TODO: if we expand to support non-negative policies, we'll need to
-            # change this logic (e.g. most_postive_actions, or something)
-            most_aggressive_policy_actions = sorted(
-                (
-                    filter_enforcement_actions(policy.split_enforcement_actions, Addon)
-                    for policy in policies
-                ),
-                key=lambda actions: hash_addon_negative_actions(actions),
-                reverse=True,
-            )[0]
+        if (
+            self.review_action
+            and self.review_action.get('policy_enforcement')
+            and 'most_aggressive_policy_actions' in self.data
+        ):
+            most_aggressive_policy_actions = self.data.get(
+                'most_aggressive_policy_actions'
+            )
 
             # form validation/cleaning should ensure there is at least one policy
             # with a negative primary enforcement_action
@@ -1954,7 +1949,9 @@ class ReviewBase:
             'Policies selected for %s, [%s]'
             % (self.addon, ', '.join(p.uuid for p in self.data['cinder_policies']))
         )
-        self.record_decision(None, action_completed=False)
+        self.record_decision(
+            None, action_completed=False, versions=self.data.get('versions')
+        )
 
 
 class ReviewAddon(ReviewBase):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -710,6 +710,7 @@ def review(request, addon, channel=None):
             else AddonApprovalsCounter().get_content_review_status_display()
         ),
         count=count,
+        DECISION_ACTIONS=DECISION_ACTIONS,
         flags=flags,
         form=form,
         format_matched_rules=formatted_matched_rules_with_files_and_data,

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1026,7 +1026,8 @@ form.review-form .data-toggle {
 }
 
 .review-actions-comments {
-    width: 70%;
+    width: 60%;
+    order: 1;
     display: flex;
     flex-direction: column;
 
@@ -1045,7 +1046,7 @@ form.review-form .data-toggle {
 }
 
 .review-actions-reasons, .review-actions-policies {
-    width: 28%;
+    width: 38%;
 }
 
 .review-actions-section {

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1080,8 +1080,24 @@ form.review-form .data-toggle {
     width: 100%;
 }
 
-#policy-enforcement-primary-actions {
-    font-weight: bold;
+#policy-enforcement-actions {
+    counter-reset: item;
+    list-style: none;
+
+    li {
+        float: none;
+
+        &.primary-enf {
+            font-weight: bold;
+        }
+    }
+    li:not(.hidden) {
+        counter-increment: item;
+    }
+
+    li:not(.hidden)::before {
+        content: counter(item) ". ";
+    }
 }
 
 .review-actions-reasons-select ul {

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -126,6 +126,9 @@ $(document).ready(function () {
 });
 
 function updatePolicyEnforcementActionsDisplay() {
+  if (!$('#policy-enforcement-actions:visible').length) {
+    return;
+  }
   let policySelectionInputs = $('.review-actions-policies-select input[name="cinder_policies"]');
   let highestCheckedPolicy;
   policySelectionInputs.filter(":visible").filter(":checked").each(function () {
@@ -133,12 +136,36 @@ function updatePolicyEnforcementActionsDisplay() {
       highestCheckedPolicy = $(this);
     }
   });
+  let $primaryActions = $("#policy-enforcement-actions li.primary-enf");
+  let $followupActions = $("#policy-enforcement-actions li.followup-enf");
+  let $data_toggle_enforcement = $(".data-toggle-enforcement");
+
+  $data_toggle_enforcement.filter(':visible').addClass('_visible');
+  $data_toggle_enforcement = $data_toggle_enforcement.filter('._visible');
+  $primaryActions.addClass('hidden');
+  $followupActions.addClass('hidden');
+  $data_toggle_enforcement.hide().prop('disabled', true);
+  $data_toggle_enforcement.parent('label').hide();
+
   if (highestCheckedPolicy) {
-    $("#policy-enforcement-primary-actions").text(highestCheckedPolicy.data('enforcement-primary-actions'));
-    $("#policy-enforcement-followup-actions").text(highestCheckedPolicy.data('enforcement-followup-actions'));
+    highestCheckedPolicy.data('enforcement-primary-actions').forEach(action => {
+      $primaryActions.filter(".action-" + action).removeClass('hidden');
+      let actionString = `'${action}'`;
+      $data_toggle_enforcement
+        .filter('[data-value-enforcement~="' + actionString + '"]')
+        .show()
+        .prop('disabled', false);
+      $data_toggle_enforcement
+        .filter('[data-value-enforcement~="' + actionString + '"]')
+        .parent('label')
+        .show();
+
+    });
+    highestCheckedPolicy.data('enforcement-followup-actions').forEach(action => {
+      $followupActions.filter(".action-" + action).removeClass('hidden');
+    });
   } else {
-    $("#policy-enforcement-primary-actions").text('No Action');
-    $("#policy-enforcement-followup-actions").text('');
+    $primaryActions.filter(".action-0").removeClass('hidden');
   }
 }
 


### PR DESCRIPTION
Fixes mozilla/addons#16240

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Enables version selection for policies with enforcement actions that work on versions (rather than the whole add-on), i.e. amo-reject-version-addon, amo-reject-version-warning-addon at this point.

<img width="2807" height="1683" alt="image" src="https://github.com/user-attachments/assets/859262c2-460f-42f8-8218-dcbc2bb3f9f4" />


### Context

I had to move the version selection section to below the policies for the UX to make sense... for other reviewer actions, and with the waffle switch disabled, it doesn't look _terrible_ moved below either, imo.  If you disagree I'll add some javascript that moves it around depending on the reviewer action selected, I guess. 

Most of this patch ended up being about javascript, and dom stuff to support the javascript...

### Testing

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
