### PR TITLE
Add an enforcement action for legal to use for takedowns with emails or appeals

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -1124,15 +1124,16 @@ class ContentActionTargetAppealApprove(
                 .defer('approval_notes')
                 .order_by('-pk')
             )
-            previous_decision_actions = self.previous_decisions.values_list(
-                'action', flat=True
+            previous_decision_actions = set(
+                self.previous_decisions.values_list('action', flat=True)
             )
             activity_log_action = None
 
-            if (
-                DECISION_ACTIONS.AMO_DISABLE_ADDON in previous_decision_actions
-                or DECISION_ACTIONS.AMO_BLOCK_ADDON in previous_decision_actions
-            ):
+            if {
+                DECISION_ACTIONS.AMO_DISABLE_ADDON,
+                DECISION_ACTIONS.AMO_BLOCK_ADDON,
+                DECISION_ACTIONS.AMO_LEGAL_DISABLE_ADDON,
+            } & previous_decision_actions:
                 # FIXME: we should also automatically revert the block if the
                 # previous decision was AMO_BLOCK_ADDON. (i.e. reverse_action)
                 target_versions = list(target_versions)
@@ -1329,6 +1330,18 @@ class ContentActionAlreadyModerated(AnyTargetMixin, NoActionMixin, ContentAction
     reporter_template_path = 'abuse/emails/reporter_moderated_ignore.txt'
     # no appeal template because no appeals possible
     action = DECISION_ACTIONS.AMO_CLOSED_NO_ACTION
+
+
+class ContentActionLegalTakedownDisableAddon(ContentActionDisableAddon):
+    description = 'Add-on has been disabled, due to legal action'
+    action = DECISION_ACTIONS.AMO_LEGAL_DISABLE_ADDON
+    # This action should not be used to resolve abuse reports
+    reporter_template_path = None
+    reporter_appeal_template_path = None
+
+    def get_owners(self):
+        # For these actions, legal will handle communication themselves
+        return ()
 
 
 class ContentActionNotImplemented(AnyTargetMixin, NoActionMixin, ContentAction):

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -58,6 +58,7 @@ from ..actions import (
     ContentActionDisableAddon,
     ContentActionForwardToLegal,
     ContentActionIgnore,
+    ContentActionLegalTakedownDisableAddon,
     ContentActionOverrideApprove,
     ContentActionRejectListingContent,
     ContentActionRejectVersion,
@@ -690,10 +691,6 @@ class TestContentActionDisableAddon(BaseTestContentAction, TestCase):
 
         self.cinder_job.notify_reporters(action_helper)
         action_helper.notify_owners()
-        subject = f'Mozilla Add-ons: {self.addon.name}'
-        self._test_owner_takedown_email(subject, self.disable_snippet)
-        assert f'Your Extension {self.addon.name}' in mail.outbox[-1].body
-        return subject
 
     def test_log_action_no_notes(self):
         self.decision.update(private_notes='', action=self.takedown_decision_action)
@@ -711,7 +708,10 @@ class TestContentActionDisableAddon(BaseTestContentAction, TestCase):
         assert ActivityLog.objects.count() == 0
 
     def test_execute_action(self):
-        subject = self._process_action_and_notify()
+        self._process_action_and_notify()
+        subject = f'Mozilla Add-ons: {self.addon.name}'
+        self._test_owner_takedown_email(subject, self.disable_snippet)
+        assert f'Your Extension {self.addon.name}' in mail.outbox[-1].body
         assert len(mail.outbox) == 3
         flags = self.addon.reviewerflags.reload()
         assert flags.auto_approval_disabled
@@ -731,7 +731,10 @@ class TestContentActionDisableAddon(BaseTestContentAction, TestCase):
         CinderAppeal.objects.create(
             decision=original_job.final_decision, reporter_report=self.abuse_report_auth
         )
-        subject = self._process_action_and_notify()
+        self._process_action_and_notify()
+        subject = f'Mozilla Add-ons: {self.addon.name}'
+        self._test_owner_takedown_email(subject, self.disable_snippet)
+        assert f'Your Extension {self.addon.name}' in mail.outbox[-1].body
         assert len(mail.outbox) == 2
         self._test_reporter_appeal_takedown_email(subject)
 
@@ -2030,7 +2033,7 @@ class TestContentActionBlockAddon(TestContentActionDisableAddon):
         assert block_version_activity.user == self.task_user
 
     def _process_action_and_notify(self):
-        subject = super()._process_action_and_notify()
+        super()._process_action_and_notify()
 
         assert ActivityLog.objects.count() == 4
         block_activity = ActivityLog.objects.all()[3]
@@ -2045,8 +2048,6 @@ class TestContentActionBlockAddon(TestContentActionDisableAddon):
             self.old_version.blockversion.auto_block_reason
             == BlockReason.FRAUD_DECEPTIVE
         )
-
-        return subject
 
     def test_already_taken_down(self):
         """For a block action, this shouldn't affect the block, only the disable"""
@@ -2682,10 +2683,6 @@ class TestContentActionRejectListingContent(TestContentActionDisableAddon):
         assert action_helper.action == self.takedown_decision_action
         self.cinder_job.notify_reporters(action_helper)
         action_helper.notify_owners()
-        subject = f'Mozilla Add-ons: {self.addon.name}'
-        self._test_owner_takedown_email(subject, self.disable_snippet)
-        assert f'Your Extension {self.addon.name}' in mail.outbox[-1].body
-        return subject
 
     def _test_approve_appeal_or_override(self, ActionClass):
         self.addon.update(status=amo.STATUS_REJECTED)
@@ -2715,7 +2712,10 @@ class TestContentActionRejectListingContent(TestContentActionDisableAddon):
         self._test_owner_restore_email(f'Mozilla Add-ons: {self.addon.name}')
 
     def test_execute_action(self):
-        subject = self._process_action_and_notify()
+        self._process_action_and_notify()
+        subject = f'Mozilla Add-ons: {self.addon.name}'
+        self._test_owner_takedown_email(subject, self.disable_snippet)
+        assert f'Your Extension {self.addon.name}' in mail.outbox[-1].body
         assert len(mail.outbox) == 3
         self._test_reporter_takedown_email(subject)
         # Content-rejection doesn't affect auto-approval disabled flags.
@@ -2817,6 +2817,9 @@ class TestContentActionRejectListingContent(TestContentActionDisableAddon):
         # it should work the same if it's already rejected - the developer can ask for
         # a new review, and we reject it again
         self._process_action_and_notify()
+        subject = f'Mozilla Add-ons: {self.addon.name}'
+        self._test_owner_takedown_email(subject, self.disable_snippet)
+        assert f'Your Extension {self.addon.name}' in mail.outbox[-1].body
 
     def test_target_appeal_decline(self):
         self.addon.update(status=amo.STATUS_REJECTED)
@@ -3224,6 +3227,58 @@ class TestContentActionRating(BaseTestContentAction, TestCase):
         assert second_activity.arguments == [self.rating, self.decision]
         assert second_activity.user == self.task_user
         assert second_activity.details == {'comments': self.decision.private_notes}
+
+
+class TestContentActionLegalTakedownDisableAddon(TestContentActionDisableAddon):
+    ActionClass = ContentActionLegalTakedownDisableAddon
+    takedown_decision_action = DECISION_ACTIONS.AMO_LEGAL_DISABLE_ADDON
+
+    def test_execute_action(self):
+        self._process_action_and_notify()
+        assert len(mail.outbox) == 0
+        flags = self.addon.reviewerflags.reload()
+        assert flags.auto_approval_disabled
+        assert flags.auto_approval_disabled_unlisted
+
+    def test_approve_appeal_success(self):
+        # No appeals
+        pass
+
+    def test_approve_appeal_success_but_listing_rejected(self):
+        # No appeals
+        pass
+
+    def test_approve_appeal_success_but_not_approved(self):
+        # No appeals
+        pass
+
+    def test_email_content_not_escaped(self):
+        # No emails
+        pass
+
+    def test_execute_action_after_reporter_appeal(self):
+        # Not a supported action to use as an override to support a reporter appeal
+        pass
+
+    def test_notify_owners_non_public_url(self):
+        # No emails
+        pass
+
+    def test_notify_owners_with_for_proactive_decision(self):
+        # No emails
+        pass
+
+    def test_notify_owners_with_for_third_party_decision(self):
+        # No emails
+        pass
+
+    def test_notify_owners_with_manual_reasoning_text(self):
+        # No emails
+        pass
+
+    def test_notify_reporters_reporters_provided(self):
+        # No emails
+        pass
 
 
 def test_no_action_duplicates():

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2179,6 +2179,10 @@ class TestContentDecisionCanBeAppealed(TestCase):
         )
         assert not appeal_job.final_decision.can_be_appealed(is_reporter=False)
 
+    def test_author_cant_appeal_legal_disable_addon_decision(self):
+        self.decision.update(action=DECISION_ACTIONS.AMO_LEGAL_DISABLE_ADDON)
+        assert not self.decision.can_be_appealed(is_reporter=False)
+
 
 class TestCinderPolicy(TestCase):
     def test_create_cinder_policy_with_required_fields(self):
@@ -2591,8 +2595,6 @@ class TestContentDecision(TestCase):
             helper = decision.get_action_helper()
             assert helper.reporter_template_path is None
             assert helper.reporter_appeal_template_path is None
-            assert ActionClass.reporter_template_path is not None
-            assert ActionClass.reporter_appeal_template_path is not None
 
     def test_get_action_helper_override(self):
         addon = addon_factory()

--- a/src/olympia/constants/abuse.py
+++ b/src/olympia/constants/abuse.py
@@ -39,6 +39,7 @@ class DECISION_ACTIONS(EnumChoicesApiDash):
     AMO_FU_DELAY_SHORT_HARD_BLOCK_ADDON = 21, '[Follow-up] Short-delayed hard block'
     AMO_FU_DELAY_MID_HARD_BLOCK_ADDON = 22, '[Follow-up] Mid-delayed hard block'
     AMO_FU_DELAY_LONG_HARD_BLOCK_ADDON = 23, '[Follow-up] Long-delayed hard block'
+    AMO_LEGAL_DISABLE_ADDON = 24, 'Add-on disable, due to legal takedown'
 
 
 DECISION_ACTIONS.add_subset(
@@ -54,6 +55,7 @@ DECISION_ACTIONS.add_subset(
         # to be done manually.
         'AMO_BLOCK_ADDON',
         'AMO_REJECT_LISTING_CONTENT',
+        # AMO_LEGAL_DISABLE_ADDON is specifically not appealable via AMO/Cinder
     ),
 )
 DECISION_ACTIONS.add_subset(
@@ -69,6 +71,7 @@ DECISION_ACTIONS.add_subset(
         'AMO_REJECT_VERSION_ADDON',
         'AMO_BLOCK_ADDON',
         'AMO_REJECT_LISTING_CONTENT',
+        'AMO_LEGAL_DISABLE_ADDON',
     ),
 )
 DECISION_ACTIONS.add_subset(


### PR DESCRIPTION
Fixes mozilla/addons#16052

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds an enforcement action for legal takedown policies to use that skips emails (as they will send their own) and prevents appeals.

### Context

Preventing appeals is redundant right now, as its pretty much impossible to guess a decision uuid to craft an appeal url, but we may decide to link to appeals in future devhub.

### Testing

- set up a policy that uses the new enforcement action in Cinder
- resolve an add-on job with that policy from a queue or direct from the investigate entity page
- replay the payload and see the add-on is disabled, but no emails in fake mail

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
