### PR TITLE
versions should be required even where there are no addon versions

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -707,10 +707,9 @@ class ReviewForm(forms.Form):
 
                 if srtd_actions:
                     self.cleaned_data['most_important_policy_actions'] = srtd_actions[0]
-                    if self.cleaned_data['most_important_policy_actions'].primary[
-                        0
-                    ] in DECISION_ACTIONS.VERSION_SPECIFIC and selected_definition.get(
-                        'multiple_versions'
+                    if (
+                        self.cleaned_data['most_important_policy_actions'].primary[0]
+                        in DECISION_ACTIONS.VERSION_SPECIFIC
                     ):
                         # we need versions if the primary enf action is version specific
                         if not self.cleaned_data['versions']:

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -241,8 +241,8 @@
       <div class="review-actions-section">
         <label for="id_versions">{{ form.versions.label }}
           {{ form.versions }}
-          {{ form.versions.errors }}
         </label>
+        {{ form.versions.errors }}
       </div>
 
       <div class="review-actions-section data-toggle review-resolve-abuse-reports"

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -241,8 +241,8 @@
       <div class="review-actions-section">
         <label for="id_versions">{{ form.versions.label }}
           {{ form.versions }}
+          {{ form.versions.errors }}
         </label>
-        {{ form.versions.errors }}
       </div>
 
       <div class="review-actions-section data-toggle review-resolve-abuse-reports"

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -579,10 +579,15 @@ class TestReviewForm(TestCase):
         assert form.is_valid(), form.errors
         assert form.cleaned_data['versions'] == []
 
+        # versions are required for a policy that requires versions
         del data['versions']
         data['cinder_policies'] = [reject_policy.id]
         form = self.get_form(data=data)
         assert not form.is_valid()
+        action = form.cleaned_data['action']
+        assert action == 'review_with_policy'
+        assert form.cleaned_data['cinder_policies'] == [reject_policy]
+        assert form.helper.get_actions()[action]['multiple_versions']
         assert form.errors == {'versions': ['This field is required.']}
 
         data['versions'] = [self.version.id]
@@ -590,6 +595,17 @@ class TestReviewForm(TestCase):
         assert form.is_valid(), form.errors
         assert not form.errors
         assert list(form.cleaned_data['versions']) == [self.version]
+
+        # test that versions is required when there *aren't* any versions
+        self.version.file.update(status=amo.STATUS_DISABLED)
+        del data['versions']
+        form = self.get_form(data=data)
+        assert not form.is_valid()
+        action = form.cleaned_data['action']
+        assert action == 'review_with_policy'
+        assert form.cleaned_data['cinder_policies'] == [reject_policy]
+        assert not form.helper.get_actions()[action]['multiple_versions']
+        assert form.errors == {'versions': ['This field is required.']}
 
     def test_cinder_jobs_filtered_for_resolve_reports_job_and_appeal_deny(self):
         self.grant_permission(self.request.user, 'Addons:Review')


### PR DESCRIPTION
Fixes mozilla/addons#16262

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

If a policy is selected where the enforcement action requires versions (e.g. REJECT_VERSION_ADDON), then the form should still error even when there is no version selection available.

<img width="2754" height="1738" alt="image" src="https://github.com/user-attachments/assets/a90a3577-e947-42e0-968d-e860c5de21d6" />


### Context

<!--
Often a pull request contains changes that are not fully self explanatory. Maybe this PR is a part of a series,
or maybe it is a partial change now with a more ambitious plan for the future. Add this additional context here.
If it is not relevant for your PR, remove this section.
-->

### Testing

- enable waffle switch `'enable-policy-review-selection'`
- set up an add-on with no versions available for rejection (e.g. delete all the versions)
- Choose "Review" reviewer tools action and select a policy that has Reject Version as an enforcement action
- see that there is no version selection UI visible on the form
- submit the form
- see error about versions being a required field

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
