### PR TITLE
Update Devhub footer to match Firefox.com

### DIFF
--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -104,7 +104,7 @@ class TestDashboard(HubTest):
         assert doc('title').text() == (
             'Manage My Submissions :: Developer Hub :: Add-ons for Firefox'
         )
-        assert doc('.Footer-links').length == 4
+        assert doc('.Footer-links').length == 6
         assert doc('.Footer-copyright').length == 1
 
     def get_action_links(self, addon_id):

--- a/src/olympia/templates/photon-footer.html
+++ b/src/olympia/templates/photon-footer.html
@@ -66,11 +66,11 @@
             <h4 class="Footer-links-header">{{ _('Follow') }}</h4>
 
             <ul class="Footer-links">
-                <li><a href="https://www.instagram.com/firefox/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Instagram') }}</a></li>
-                <li><a href="https://www.youtube.com/user/firefoxchannel?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Youtube') }}</a></li>
-                <li><a href="https://www.tiktok.com/@firefox/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('TikTok') }}</a></li>
-                <li><a href="https://bsky.app/profile/firefox.com/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Bluesky') }}</a></li>
-                <li><a href="https://www.youtube.com/@firefox/podcasts/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Podcast') }}</a></li>
+                <li><a href="https://www.instagram.com/firefox">{{ _('Instagram') }}</a></li>
+                <li><a href="https://www.youtube.com/user/firefoxchannel">{{ _('Youtube') }}</a></li>
+                <li><a href="https://www.tiktok.com/@firefox">{{ _('TikTok') }}</a></li>
+                <li><a href="https://bsky.app/profile/firefox.com">{{ _('Bluesky') }}</a></li>
+                <li><a href="https://www.youtube.com/@firefox/podcasts">{{ _('Podcast') }}</a></li>
             </ul>
         </section>
 

--- a/src/olympia/templates/photon-footer.html
+++ b/src/olympia/templates/photon-footer.html
@@ -4,10 +4,10 @@
             <a class="Footer-mozilla-link" href="https://mozilla.org/" title="{% trans %}Go to Mozilla's homepage{% endtrans %}"><span class="Icon Icon-mozilla Footer-mozilla-logo"><span class="visually-hidden">{{ _("Go to Mozilla's homepage") }}</span></span></a>
         </div>
 
-        <section class="Footer-amo-links">
+        <section class="Footer-column Footer-amo-links">
             <h4 class="Footer-links-header"><a href="{{ url('home') }}">{{ _('Add-ons') }}</a></h4>
 
-            <ul class="Footer-links">
+            <ul class="Footer-column Footer-links">
                 <li><a href="{{ url('pages.about') }}">{{ _('About') }}</a></li>
                 <li><a href="{{ settings.EXTERNAL_SITE_URL }}/blog/">{{ _('Firefox Add-ons Blog') }}</a></li>
                 <li><a class="Footer-extension-workshop-link" href="{{ settings.EXTENSION_WORKSHOP_URL }}/?utm_source=addons.mozilla.org&amp;utm_medium=referral&amp;utm_content=footer-link">{{ _('Extension Workshop') }}</a></li>
@@ -20,31 +20,57 @@
             </ul>
         </section>
 
-        <section class="Footer-browsers-links">
-            <h4 class="Footer-links-header">{{ _('Browsers') }}</h4>
+        <section class="Footer-column Footer-download-links">
+            <h4 class="Footer-links-header">{{ _('Download') }}</h4>
 
             <ul class="Footer-links">
-                <li><a href="https://www.mozilla.org/firefox/new/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">{{ _('Desktop') }}</a></li>
-                <li><a href="https://www.mozilla.org/firefox/mobile/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">{{ _('Mobile') }}</a></li>
-                <li><a href="https://www.mozilla.org/firefox/enterprise/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">{{ _('Enterprise') }}</a></li>
+                <li><a href="https://www.firefox.com/thanks/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Download Firefox') }}</a></li>
+                <li><a href="https://www.firefox.com/en-US/download/windows/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Windows') }}</a></li>
+                <li><a href="https://www.firefox.com/en-US/download/mac/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('macOS') }}</a></li>
+                <li><a href="https://www.firefox.com/en-US/download/ios/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('iOS') }}</a></li>
+                <li><a href="https://www.firefox.com/en-US/download/android/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Android') }}</a></li>
+                <li><a href="https://www.firefox.com/en-US/download/linux/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Linux') }}</a></li>
+                <li><a href="https://www.firefox.com/en-US/download/all/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('All') }}</a></li>
             </ul>
         </section>
 
-        <section class="Footer-products-links">
-            <h4 class="Footer-links-header">{{ _('Products') }}</h4>
+        <section class="Footer-column Footer-build-links">
+            <section class="Footer-latest-links">
+            <h4 class="Footer-links-header">{{ _('Latest Builds') }}</h4>
 
             <ul class="Footer-links">
-                <li><a href="https://www.mozilla.org/firefox/browsers/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">{{ _('Browsers') }}</a></li>
-                <li><a href="https://www.mozilla.org/products/vpn/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link#pricing">VPN</a></li>
-                <li><a href="https://relay.firefox.com/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">Relay</a></li>
-                <li><a href="https://monitor.firefox.com/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">Monitor</a></li>
-                <li><a href="https://getpocket.com/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">Pocket</a></li>
+                <li><a href="https://www.firefox.com/en-US/channel/desktop/#nightly?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Nightly') }}</a></li>
+                <li><a href="https://www.firefox.com/en-US/channel/desktop/#beta?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Beta') }}</a></li>
             </ul>
+        </section>
+        <section class="Footer-business-links">
+            <h4 class="Footer-links-header">{{ _('Firefox for Business') }}</h4>
 
-            <ul class="Footer-links Footer-links-social">
-                <li class="Footer-link-social"><a href="https://bsky.app/profile/firefox.com"><span class="Icon Icon-bluesky"><span class="visually-hidden">Bluesky (@firefox.com)</span></span></a></li>
-                <li class="Footer-link-social"><a href="https://www.instagram.com/firefox/"><span class="Icon Icon-instagram"><span class="visually-hidden">Instagram (Firefox)</span></span></a></li>
-                <li class="Footer-link-social"><a href="https://www.youtube.com/firefoxchannel"><span class="Icon Icon-youtube"><span class="visually-hidden">YouTube (firefoxchannel)</span></span></a></li>
+            <ul class="Footer-links">
+                <li><a href="https://www.firefox.com/en-US/browsers/enterprise/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Enterprise') }}</a></li>
+            </ul>
+        </section>
+        </section>
+
+        <section class="Footer-column Footer-community-links">
+            <h4 class="Footer-links-header">{{ _('Community') }}</h4>
+
+            <ul class="Footer-links">
+                <li><a href="https://connect.mozilla.org/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Connect') }}</a></li>
+                <li><a href="https://www.mozilla.org/contribute/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Contribute') }}</a></li>
+                <li><a href="https://www.firefox.com/en-US/channel/desktop/developer/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Developer') }}</a></li>
+            </ul>
+        </section>
+
+        <section class="Footer-column Footer-follow-links">
+            <h4 class="Footer-links-header">{{ _('Follow') }}</h4>
+
+            <ul class="Footer-links">
+                <li><a href="https://www.instagram.com/firefox/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Instagram') }}</a></li>
+                <li><a href="https://www.youtube.com/user/firefoxchannel?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Youtube') }}</a></li>
+                <li><a href="https://www.tiktok.com/@firefox/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('TikTok') }}</a></li>
+                <li><a href="https://bsky.app/profile/firefox.com/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Bluesky') }}</a></li>
+                <li><a href="https://www.youtube.com/@firefox/podcasts/?utm_content=footer-link&utm_medium=referral&utm_source=addons.mozilla.org">{{ _('Podcast') }}</a></li>
             </ul>
         </section>
 

--- a/static/css/common/footer.less
+++ b/static/css/common/footer.less
@@ -31,16 +31,31 @@
 .Footer-wrapper {
     padding: 58px @side-margin;
 
-    @media @medium {
+    @media @large {
         display: grid;
         grid-template-areas:
-          'logo amo-links browsers-links products-links'
-          'legal-links legal-links legal-links legal-links'
-          'copyright copyright language language';
+            'logo amo-links download-links build-links'
+            'logo community-links follow-links follow-links'
+            'legal-links legal-links legal-links legal-links'
+            'copyright copyright copyright language';
         grid-template-columns: 1fr 1fr 1fr 1fr;
         margin: 0 auto;
         max-width: @grid-max;
         width: 100%;
+        gap: 0 2em;
+    }
+
+@media @extraExtraLarge {
+        display: grid;
+        grid-template-areas:
+        'logo amo-links download-links build-links community-links follow-links'
+        'legal-links legal-links legal-links legal-links legal-links legal-links'
+        'copyright copyright copyright copyright copyright language';
+        grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
+        margin: 0 auto;
+        max-width: @grid-max;
+        width: 100%;
+        gap: 0 2em;
     }
 }
 
@@ -81,21 +96,43 @@
     grid-area: amo-links;
 }
 
-.Footer-browsers-links {
-    grid-area: browsers-links;
+.Footer-download-links {
+  grid-area: download-links;
 }
 
-.Footer-products-links {
-    grid-area: products-links;
+.Footer-build-links {
+  grid-area: build-links;
+}
+
+.Footer-community-links {
+  grid-area: community-links;
+}
+
+.Footer-follow-links {
+  grid-area: follow-links;
+}
+
+.Footer-column > section:not(:last-child) {
+  @media @large {
+    padding-bottom: 1em;
+  }
+}
+
+.Footer-column:nth-child(-n + 3 of .Footer-column) .Footer-links-header {
+  @media @large {
+    margin: 0;
+  }
+}
+
+.Footer-column:nth-child(n + 4 of .Footer-column) .Footer-links-header {
+  @media @extraExtraLarge {
+    margin: 0;
+  }
 }
 
 .Footer-links-header {
     margin: 40px 0 0;
     font-weight: 700;
-
-    @media @large {
-      margin: 0;
-    }
 
     a:link,
     a:visited {

--- a/static/css/photon-site/base.less
+++ b/static/css/photon-site/base.less
@@ -1,6 +1,8 @@
 @grid-max: 960px;
 @medium: ~"only screen and (min-width: 700px)";
 @large: ~"only screen and (min-width: 960px)";
+@extraLarge: ~'only screen and (min-width: 900px)';
+@extraExtraLarge: ~'only screen and (min-width: 1150px)';
 @notlarge: ~"only screen and (max-width: 959px)";
 @retina: ~"only screen and (min-resolution: 1.5dppx)";
 @side-margin: 10px;


### PR DESCRIPTION
Relates to https://github.com/mozilla/addons/issues/15925.

### Description

Updates the footer on DevHub to better match Firefox.com. Changes mirror https://github.com/mozilla/addons-frontend/pull/14225.
<img width="1253" height="789" alt="image" src="https://github.com/user-attachments/assets/a691299b-dd00-4825-a68d-fa0d4c9cadc6" />
<img width="954" height="833" alt="image" src="https://github.com/user-attachments/assets/fe1e0a49-7076-4aed-85da-bcbe8645552a" />

### Testing

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->
- [ ] Links redirect to the correct locations.
- [ ] Columns overflow without issue on browser width change.
### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
