### PR TITLE
Correctly capitalize 'YouTube' in DevHub footer

### DIFF
--- a/src/olympia/templates/photon-footer.html
+++ b/src/olympia/templates/photon-footer.html
@@ -67,7 +67,7 @@
 
             <ul class="Footer-links">
                 <li><a href="https://www.instagram.com/firefox">{{ _('Instagram') }}</a></li>
-                <li><a href="https://www.youtube.com/user/firefoxchannel">{{ _('Youtube') }}</a></li>
+                <li><a href="https://www.youtube.com/user/firefoxchannel">{{ _('YouTube') }}</a></li>
                 <li><a href="https://www.tiktok.com/@firefox">{{ _('TikTok') }}</a></li>
                 <li><a href="https://bsky.app/profile/firefox.com">{{ _('Bluesky') }}</a></li>
                 <li><a href="https://www.youtube.com/@firefox/podcasts">{{ _('Podcast') }}</a></li>


### PR DESCRIPTION
Relates to mozilla/addons#15925

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->
Fixes the capitalization on YouTube.

<img width="270" height="256" alt="image" src="https://github.com/user-attachments/assets/2f2f3440-2b0e-4c04-ac8c-b8eb97395ac0" />

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] Add before and after screenshots (Only for changes that impact the UI).