### PR TITLE
Pass a X-AMO-Request-ID header to the webhook scanners

### DIFF
--- a/docs/topics/development/scanner_pipeline.md
+++ b/docs/topics/development/scanner_pipeline.md
@@ -19,6 +19,11 @@ Each service registered as a scanner webhook must be protected with a shared
 secret (api) key. Read [the authentication section](#scanners-authentication)
 for more information.
 
+Every webhook call includes a `X-AMO-Request-ID` header carrying a unique id
+generated for each webhook call. Scanners are encouraged to log it and include
+it in their own logs so a single webhook call can be correlated across AMO and
+the scanner service.
+
 (scanners-authentication)=
 ### Authentication
 

--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -25,6 +25,7 @@ from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.celery import create_chunked_tasks_signatures, task
 from olympia.amo.decorators import use_primary_db
+from olympia.amo.middleware import REQUEST_ID_HEADER
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import (
     attach_trans_dict,
@@ -162,6 +163,7 @@ def _call_webhook(webhook, payload):
             headers={
                 'Content-Type': 'application/json',
                 'Authorization': f'HMAC-SHA256 {digest}',
+                REQUEST_ID_HEADER: uuid.uuid4().hex,
             },
         )
 

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -2573,15 +2573,16 @@ class TestCallWebhook(TestCase):
         expected_digest = (
             '1987be0ea649633a3eaca7c504b9995fe20aa054d7423e490df927b1ede917a1'
         )
-        requests_mock.assert_called_with(
-            url=webhook.url,
-            data=json.dumps(payload),
-            timeout=123,
-            headers={
-                'Content-Type': 'application/json',
-                'Authorization': f'HMAC-SHA256 {expected_digest}',
-            },
+        assert requests_mock.call_count == 1
+        call_kwargs = requests_mock.call_args.kwargs
+        assert call_kwargs['url'] == webhook.url
+        assert call_kwargs['data'] == json.dumps(payload)
+        assert call_kwargs['timeout'] == 123
+        assert call_kwargs['headers']['Content-Type'] == 'application/json'
+        assert (
+            call_kwargs['headers']['Authorization'] == f'HMAC-SHA256 {expected_digest}'
         )
+        assert call_kwargs['headers']['X-AMO-Request-ID']
         assert returned_value == response_data
 
     @override_settings(SCANNER_TIMEOUT=123)


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/16279

---

This PR allows scanners to receive a request ID, and to use it.

We'll need #25033 to allow scanners to pass the request ID back to
AMO (e.g. for async scanners). There is also a [PR for the client-side
of things][1].

[1]: https://github.com/mozilla/addons-scanner-utils/pull/1084