### PR TITLE
Remove escape_all and linkify_with_outgoing

### DIFF
--- a/src/olympia/amo/tests/test_amo_utils.py
+++ b/src/olympia/amo/tests/test_amo_utils.py
@@ -10,7 +10,6 @@ import pytest
 from olympia.amo.tests import TestCase, get_temp_filename
 from olympia.amo.utils import (
     SafeStorage,
-    escape_all,
     find_language,
     from_string,
     no_jinja_autoescape,
@@ -261,40 +260,6 @@ class TestSafeStorage(TestCase):
         self.stor.delete(fn)
         assert not os.path.exists(fn)
         assert os.path.exists(dp)
-
-
-@pytest.mark.parametrize(
-    'test_input,expected',
-    [
-        (
-            '<script>alert("BALL SO HARD")</script>',
-            '&lt;script&gt;alert("BALL SO HARD")&lt;/script&gt;',
-        ),
-        ('Foo"', 'Foo"'),
-        ('Bän...g (bang)', 'Bän...g (bang)'),
-        (u, u),
-        ('-'.join([u, u]), '-'.join([u, u])),
-        (' - '.join([u, u]), ' - '.join([u, u])),
-        ('x荿', 'x\u837f'),
-        ('ϧ΃蒬蓣', '\u03e7\u0383\u84ac\u84e3'),
-        ('¿x', '¿x'),
-    ],
-)
-def test_escape_all(test_input, expected):
-    assert escape_all(test_input) == expected
-
-
-@mock.patch('olympia.amo.templatetags.jinja_helpers.urlresolvers.get_outgoing_url')
-def test_escape_all_linkify_only_full(mock_get_outgoing_url):
-    mock_get_outgoing_url.return_value = 'https://outgoing.firefox.com'
-
-    assert escape_all('http://firefox.com') == (
-        '<a href="https://outgoing.firefox.com" rel="nofollow">http://firefox.com</a>'
-    )
-
-    assert escape_all('firefox.com') == (
-        '<a href="https://outgoing.firefox.com" rel="nofollow">firefox.com</a>'
-    )
 
 
 def test_no_jinja_autoescape():

--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -10,7 +10,6 @@ from django.urls import NoReverseMatch
 from django.utils.encoding import force_bytes
 
 import pytest
-from pyquery import PyQuery
 
 import olympia
 from olympia import amo
@@ -312,38 +311,6 @@ def test_linkify_bounce_url_callback(mock_get_outgoing_url):
     # Make sure get_outgoing_url was called.
     assert node.attrs['href'] == 'bar'
     mock_get_outgoing_url.assert_called_with('foo')
-
-
-@patch(
-    'olympia.amo.templatetags.jinja_helpers.urlresolvers.linkify_bounce_url_callback'
-)
-def test_linkify_with_outgoing_text_links(mock_linkify_bounce_url_callback):
-    def side_effect(node):
-        node.attrs['href'] = 'bar'
-
-    mock_linkify_bounce_url_callback.side_effect = side_effect
-
-    res = urlresolvers.linkify_with_outgoing('a text http://example.com link')
-    # Use PyQuery because the attributes could be rendered in any order.
-    doc = PyQuery(res)
-    assert doc('a[href="bar"][rel="nofollow"]')[0].text == 'http://example.com'
-
-
-@patch(
-    'olympia.amo.templatetags.jinja_helpers.urlresolvers.linkify_bounce_url_callback'
-)
-def test_linkify_with_outgoing_markup_links(mock_linkify_bounce_url_callback):
-    def side_effect(node):
-        node.attrs['href'] = 'bar'
-
-    mock_linkify_bounce_url_callback.side_effect = side_effect
-
-    res = urlresolvers.linkify_with_outgoing(
-        'a markup <a href="http://example.com">link</a> with text'
-    )
-    # Use PyQuery because the attributes could be rendered in any order.
-    doc = PyQuery(res)
-    assert doc('a[href="bar"][rel="nofollow"]')[0].text == 'link'
 
 
 def get_image_path(name):

--- a/src/olympia/amo/urlresolvers.py
+++ b/src/olympia/amo/urlresolvers.py
@@ -9,7 +9,6 @@ from django.utils.translation.trans_real import parse_accept_lang_header
 
 import markupsafe
 from justhtml import (
-    Edit,
     JustHTML,
     Linkify,
     SanitizationPolicy,
@@ -159,21 +158,6 @@ def linkify_bounce_url_callback(node):
     """Linkify callback that uses get_outgoing_url."""
     if 'href' in node.attrs.keys():
         node.attrs['href'] = get_outgoing_url(node.attrs['href'])
-
-
-def linkify_with_outgoing(text):
-    """Wrapper around justhtml's linkify: uses get_outgoing_url."""
-    fragment = JustHTML(
-        text,
-        fragment=True,
-        sanitize=False,
-        transforms=[
-            Linkify(),
-            Edit('a', linkify_bounce_url_callback),
-            SetAttrs('a', rel='nofollow'),
-        ],
-    )
-    return fragment.to_html(pretty=False)
 
 
 def linkify_and_clean(text):

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -45,7 +45,6 @@ import basket
 import colorgram
 import homoglyphs_fork
 import html5lib
-import markupsafe
 import pytz
 from babel import Locale
 from django_statsd.clients import statsd
@@ -56,7 +55,6 @@ from PIL import Image
 from rest_framework.utils.encoders import JSONEncoder
 from rest_framework.utils.formatting import lazy_format
 
-from olympia.amo.urlresolvers import linkify_with_outgoing
 from olympia.amo.validators import OneOrMorePrintableCharacterValidator
 from olympia.constants.abuse import REPORTED_MEDIA_BACKUP_EXPIRATION_DAYS
 from olympia.core.languages import LANGUAGES_NOT_IN_BABEL
@@ -894,27 +892,6 @@ def get_email_backend(real_email=False):
     else:
         backend = 'olympia.amo.mail.DevEmailBackend'
     return django.core.mail.get_connection(backend)
-
-
-def escape_all(value):
-    """Escape html in JSON value, including nested items.
-
-    Only linkify full urls, including a scheme, if "linkify_only_full" is True.
-
-    """
-    if isinstance(value, str):
-        value = markupsafe.escape(force_str(value))
-        value = linkify_with_outgoing(value)
-        return value
-    elif isinstance(value, list):
-        for i, lv in enumerate(value):
-            value[i] = escape_all(lv)
-    elif isinstance(value, dict):
-        for k, lv in value.items():
-            value[k] = escape_all(lv)
-    elif isinstance(value, Translation):
-        value = markupsafe.escape(force_str(value))
-    return value
 
 
 class SafeStorage(FileSystemStorage):

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -49,11 +49,11 @@ from olympia.amo import messages, utils as amo_utils
 from olympia.amo.decorators import json_view, login_required, post_required
 from olympia.amo.reverse import get_url_prefix
 from olympia.amo.templatetags.jinja_helpers import absolutify, urlparams
+from olympia.amo.urlresolvers import linkify_and_clean
 from olympia.amo.utils import (
     MenuItem,
     SafeStorage,
     StopWatch,
-    escape_all,
     is_safe_url,
     send_mail,
     send_mail_jinja,
@@ -785,7 +785,7 @@ def json_upload_detail(request, upload, addon_slug=None):
                         # already escaped because they are coming from
                         # `processed_validation`, but we need to do that for
                         # those coming from ValidationError exceptions as well.
-                        'message': escape_all(msg),
+                        'message': linkify_and_clean(msg),
                         'tier': 1,
                         'fatal': True,
                     },

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -691,7 +691,7 @@ $.fn.addonUploader = function (options) {
               // Note: validation messages can contain HTML, in the form of
               // links or entities, because devhub.views.json_upload_detail()
               // uses processed_validation with escapes and linkifies linter
-              // messages (and escape_all() on non-linter messages).
+              // messages (and linkify_and_clean() on non-linter messages).
               // So we need to use html() and not text() to display them.
               $('<li>').html(checklistMessages[i]).appendTo(messages_ul);
             });


### PR DESCRIPTION
Fixes mozilla/addons#16267

### Description

Removes `escape_all()` and `linkify_with_outgoing()` functions, replacing `escape_all()` with `linkify_and_clean()`.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
