### PR TITLE
Enable Serbian locale on addons-server, add doc

### DIFF
--- a/docs/topics/development/localization_and_internationalization.md
+++ b/docs/topics/development/localization_and_internationalization.md
@@ -2,6 +2,17 @@
 
 Localization and internationalization are important aspects of the **addons-server** project, ensuring that the application can support multiple languages and locales. This section covers the key concepts and processes for managing localization and internationalization.
 
+## Locale Availibility
+
+Locales are defined in two parts. In [`src/olympia/core/languages.py`](https://github.com/mozilla/addons-server/blob/master/src/olympia/core/languages.py) --
+
+1. Entirely new locales are added via the `ALL_LANGUAGES` list.
+2. Enabled locales are defined separately via the `PROD_LANGUAGES` list.
+
+These lists should always be kept in sync with `addons-frontend`. See the documentation [here](https://github.com/mozilla/addons-frontend/blob/master/docs/i18n.md) for details.
+
+Dev shows the full language list defined by `ALL_LANGUAGES`. Stage and production only show locales explicitly enabled by `PROD_LANGUAGES`. Locales are enabled when the completion rate for both `AMO` and `AMO Frontend` projects on [Pontoon](https://pontoon.mozilla.org/projects/) are high enough.
+
 ## Locale Management
 
 Locale management involves compiling and managing translation files. The **addons-server** project uses a structured approach to handle localization files efficiently.

--- a/docs/topics/development/localization_and_internationalization.md
+++ b/docs/topics/development/localization_and_internationalization.md
@@ -4,7 +4,7 @@ Localization and internationalization are important aspects of the **addons-serv
 
 ## Locale Availibility
 
-Locales are defined in two parts. In [`src/olympia/core/languages.py`](https://github.com/mozilla/addons-server/blob/master/src/olympia/core/languages.py) --
+Locales are defined in two parts. In [`src/olympia/core/languages.py`](https://github.com/mozilla/addons-server/blob/master/src/olympia/core/languages.py):
 
 1. Entirely new locales are added via the `ALL_LANGUAGES` list.
 2. Enabled locales are defined separately via the `PROD_LANGUAGES` list.

--- a/docs/topics/development/localization_and_internationalization.md
+++ b/docs/topics/development/localization_and_internationalization.md
@@ -11,7 +11,7 @@ Locales are defined in two parts. In [`src/olympia/core/languages.py`](https://g
 
 These lists should always be kept in sync with `addons-frontend`. See the documentation [here](https://github.com/mozilla/addons-frontend/blob/master/docs/i18n.md) for details.
 
-Dev shows the full language list defined by `ALL_LANGUAGES`. Stage and production only show locales explicitly enabled by `PROD_LANGUAGES`. Locales are enabled when the completion rate for both `AMO` and `AMO Frontend` projects on [Pontoon](https://pontoon.mozilla.org/projects/) are high enough.
+Dev shows the full language list defined by `ALL_LANGUAGES`. Stage and production only show locales explicitly enabled by `PROD_LANGUAGES`. Locales are enabled when their completion rate for both [AMO](https://pontoon.mozilla.org/projects/amo/) and [AMO Frontend](https://pontoon.mozilla.org/projects/amo-frontend/) projects on [Pontoon](https://pontoon.mozilla.org/) are high enough.
 
 ## Locale Management
 

--- a/src/olympia/core/languages.py
+++ b/src/olympia/core/languages.py
@@ -209,6 +209,7 @@ PROD_LANGUAGES = [
     'sk',
     'sl',
     'sq',
+    'sr',
     'sv-SE',
     'tr',
     'uk',


### PR DESCRIPTION

Relates to https://github.com/mozilla/addons/issues/16275

Enables Serbian on addons-server side, updates documentation.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
