### PR TITLE
Allow reviewers to select policies with different negative enforcement actions

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -675,25 +675,18 @@ class ReviewForm(forms.Form):
                     'action.',
                 )
 
-            if not is_policy_enforcement:
-                if len(all_primary_actions) > 1:
-                    self.add_error(
-                        'cinder_policies',
-                        'Multiple policies selected with different cinder actions.',
-                    )
-            else:
-                negative_primary_actions = {
-                    ea
-                    for ea in all_primary_actions
-                    if len(ea) and ea[0] in DECISION_ACTIONS.ADDON_NEGATIVE_SORTED
-                }
-                if not negative_primary_actions and len(all_primary_actions) > 1:
-                    self.add_error(
-                        'cinder_policies',
-                        'Selecting multiple policies selected with different '
-                        'non-negative cinder actions is not supported.',
-                    )
-
+            negative_primary_actions = {
+                ea
+                for ea in all_primary_actions
+                if len(ea) and ea[0] in DECISION_ACTIONS.ADDON_NEGATIVE_SORTED
+            }
+            if not negative_primary_actions and len(all_primary_actions) > 1:
+                self.add_error(
+                    'cinder_policies',
+                    'Selecting multiple policies with different non-negative '
+                    'enforcement actions is not supported.',
+                )
+            if is_policy_enforcement:
                 srtd_actions = sorted(
                     (
                         filter_enforcement_actions(

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -401,22 +401,13 @@ class TestReviewForm(TestCase):
             ]
         }
 
+        # Fine: those are not positive actions
         data['cinder_policies'] = [action_policy_a.id, action_policy_c.id]
         form = self.get_form(data=data)
-        assert not form.is_valid()
-        assert form.errors == {
-            'cinder_policies': [
-                'Multiple policies selected with different cinder actions.'
-            ]
-        }
-
-        # But it's fine if there are no jobs selected
-        data['cinder_jobs_to_resolve'] = []
-        form = self.get_form(data=data)
-        assert form.is_valid(), form.errors
+        assert form.is_valid()
         assert not form.errors
 
-        # And it's fine if the poicies have the same action
+        # Also fine if the policies have the same action
         data['cinder_jobs_to_resolve'] = [job.id]
         data['cinder_policies'] = [action_policy_a.id, action_policy_b.id]
         form = self.get_form(data=data)
@@ -442,6 +433,41 @@ class TestReviewForm(TestCase):
             'cinder_policies': [
                 'Invalid policies selected with more than one primary enforcement '
                 'action.'
+            ]
+        }
+
+    def test_policy_actions_multiple_positive(self):
+        # Selecting policies that result in multiple positive enforcement
+        # actions should raise an error.
+        self.grant_permission(self.request.user, 'Addons:Review')
+        self.addon.update(status=amo.STATUS_NOMINATED)
+        self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
+        job = CinderJob.objects.create(
+            job_id='1', resolvable_in_reviewer_tools=True, target_addon=self.addon
+        )
+        action_policy_approve = CinderPolicy.objects.create(
+            uuid='approve',
+            name='approve',
+            expose_in_reviewer_tools=True,
+            enforcement_actions=[DECISION_ACTIONS.AMO_APPROVE.api_value],
+        )
+        action_policy_ignore = CinderPolicy.objects.create(
+            uuid='ignore',
+            name='ignore',
+            expose_in_reviewer_tools=True,
+            enforcement_actions=[DECISION_ACTIONS.AMO_IGNORE.api_value],
+        )
+        data = {
+            'action': 'resolve_reports_job',
+            'cinder_jobs_to_resolve': [job.id],
+            'cinder_policies': [action_policy_ignore.id, action_policy_approve.id],
+        }
+        form = self.get_form(data=data)
+        assert not form.is_valid()
+        assert form.errors == {
+            'cinder_policies': [
+                'Selecting multiple policies with different non-negative '
+                'enforcement actions is not supported.'
             ]
         }
 
@@ -537,8 +563,8 @@ class TestReviewForm(TestCase):
         assert not form.is_valid()
         assert form.errors == {
             'cinder_policies': [
-                'Selecting multiple policies selected with different '
-                'non-negative cinder actions is not supported.'
+                'Selecting multiple policies with different non-negative '
+                'enforcement actions is not supported.'
             ]
         }
 

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -408,7 +408,6 @@ class TestReviewForm(TestCase):
         assert not form.errors
 
         # Also fine if the policies have the same action
-        data['cinder_jobs_to_resolve'] = [job.id]
         data['cinder_policies'] = [action_policy_a.id, action_policy_b.id]
         form = self.get_form(data=data)
         assert form.is_valid(), form.errors


### PR DESCRIPTION
It's only when there are multiple different *positive* enforcement actions that we don't know what do do (Approve + Ignore).

Fixes https://github.com/mozilla/addons/issues/16286