### PR TITLE
Simplify __heartbeat__ endpoint

### DIFF
--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -416,8 +416,9 @@ class CacheControlMiddleware:
         return response
 
 
-class LBHeartbeatMiddleware:
-    """Middleware to capture request to /__lbheartbeat__ and return a 200.
+class HeartbeatMiddleware:
+    """Middleware to capture request to /__lbheartbeat__ and
+    __heartbeat__ and return a 200.
     Must be placed above CommonMiddleware to work with ELB.
     """
 
@@ -425,7 +426,7 @@ class LBHeartbeatMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if request.path == '/__lbheartbeat__':
+        if request.path in ('/__lbheartbeat__', '/__heartbeat__'):
             response = HttpResponse(status=200)
             add_never_cache_headers(response)
             return response

--- a/src/olympia/amo/tests/test_middleware.py
+++ b/src/olympia/amo/tests/test_middleware.py
@@ -72,11 +72,23 @@ class TestMiddleware(TestCase):
         assert process_request.call_count == 3
 
     def test_lbheartbeat_middleware(self):
-        # /__lbheartbeat__ should be return a 200 from middleware, bypassing later
+        # /__lbheartbeat__ should return a 200 from middleware, bypassing later
         # middleware and view code.
 
         with self.assertNumQueries(0):
             response = test.Client().get('/__lbheartbeat__', SERVER_NAME='elb-internal')
+        assert response.status_code == 200
+        assert response.content == b''
+        assert response['Cache-Control'] == (
+            'max-age=0, no-cache, no-store, must-revalidate, private'
+        )
+
+    def test_heartbeat_middleware(self):
+        # /__heartbeat__ should return a 200 from middleware, bypassing later
+        # middleware and view code.
+
+        with self.assertNumQueries(0):
+            response = test.Client().get('/__heartbeat__', SERVER_NAME='elb-internal')
         assert response.status_code == 200
         assert response.content == b''
         assert response['Cache-Control'] == (

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -370,9 +370,10 @@ class TestOtherStuff(TestCase):
         assert e.text == 'Firefox Add-ons'
 
 
-class TestHeartbeat(TestCase):
+class TestServicesMonitor(TestCase):
     def setUp(self):
         super().setUp()
+        self.url = reverse('amo.services_monitor')
 
         self.mocks = {}
         for check in [
@@ -391,46 +392,34 @@ class TestHeartbeat(TestCase):
             self.mocks[check].return_value = ('', None)
             self.addCleanup(patcher.stop)
 
-    def test_front_heartbeat_success(self):
-        response = self.client.get(reverse('amo.front_heartbeat'))
-        assert response.status_code == 200
-
-    def test_front_heartbeat_failure(self):
+    def test_services_monitor_database_failure(self):
         self.mocks['database'].return_value = ('boom', None)
 
-        response = self.client.get(reverse('amo.front_heartbeat'))
+        response = self.client.get(self.url)
 
         assert response.status_code >= 500
         assert response.json()['database']['status'] == 'boom'
 
-    @override_switch('dummy-monitor-fails', True)
-    def test_front_heartbeat_dummy_monitor_no_failure(self):
-        url = reverse('amo.front_heartbeat')
-        response = self.client.get(url)
-
-        assert response.status_code == 200
-
     def test_services_monitor_success(self):
-        response = self.client.get(reverse('amo.services_monitor'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
 
     def test_services_monitor_failure(self):
         self.mocks['rabbitmq'].return_value = ('boom', None)
 
-        response = self.client.get(reverse('amo.services_monitor'))
+        response = self.client.get(self.url)
 
         assert response.status_code >= 500
         assert response.json()['rabbitmq']['status'] == 'boom'
 
     def test_services_monitor_dummy_monitor_failure(self):
-        url = reverse('amo.services_monitor')
-        response = self.client.get(url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         self.assertTrue(response.json()['dummy_monitor']['state'])
 
         with override_switch('dummy-monitor-fails', True):
-            response = self.client.get(url)
+            response = self.client.get(self.url)
 
             assert response.status_code >= 500
             assert response.json()['dummy_monitor']['status'] == 'Dummy monitor failed'

--- a/src/olympia/amo/urls.py
+++ b/src/olympia/amo/urls.py
@@ -31,7 +31,6 @@ urlpatterns = [
     re_path(r'^services/', include(services_patterns)),
     re_path(r'^services/', include(shared_services_api_patterns)),
     re_path(r'^__version__$', views.version, name='version.json'),
-    re_path(r'^__heartbeat__$', views.front_heartbeat, name='amo.front_heartbeat'),
     re_path(
         r'^opensearch\.xml$',
         TemplateView.as_view(

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -56,13 +56,6 @@ MONITORS = {
 
 @never_cache
 @non_atomic_requests
-def front_heartbeat(request):
-    """Check internal monitors only."""
-    return _exec_monitors(MONITORS['internal'])
-
-
-@never_cache
-@non_atomic_requests
 def services_monitor(request):
     """Check all monitors."""
     return _exec_monitors(

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -507,7 +507,7 @@ MIDDLEWARE = (
     # Enable conditional processing, e.g ETags.
     'django.middleware.http.ConditionalGetMiddleware',
     'olympia.amo.middleware.NoVarySessionMiddleware',
-    'olympia.amo.middleware.LBHeartbeatMiddleware',
+    'olympia.amo.middleware.HeartbeatMiddleware',
     'olympia.amo.middleware.CommonMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'olympia.amo.middleware.AuthenticationMiddlewareWithoutAPI',


### PR DESCRIPTION
Don't check database, elasticsearch, memcache or execute CPU-intensive tasks in `__heartbeat__`, it should just return 200 when the addons-server container itself is ready.

Complete health check are still performed through the `monitors.json` endpoint.

First half of https://github.com/mozilla/addons/issues/16297

It should help MySQL 8.4 upgrade as it will stop pods from restarting if they can't immediately reach MySQL during the upgrade.