### PR TITLE
Clears NHR on held disable add-on action

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -510,7 +510,15 @@ class ContentActionDisableAddon(ContentActionAddon):
     def hold_action(self):
         self.prevent_auto_approval()
         if self.target.status != amo.STATUS_DISABLED:
+            from olympia.reviewers.models import NeedsHumanReview
+
             self.decision.target_versions.set(self.versions_force_disable_will_affect)
+            NeedsHumanReview.objects.filter(
+                version__in=self.target.versions(
+                    manager='unfiltered_for_relations'
+                ).all()
+            ).update(is_active=False)
+            self.target.update_all_due_dates()
             return self.log_action(amo.LOG.HELD_ACTION_FORCE_DISABLE)
         return None
 

--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -440,7 +440,7 @@ class ContentActionAddon(ContentAction):
         # explicitly.
         version.reset_due_date()
 
-    def _clear_all_needs_human_review_flags_in_channel(self, channel):
+    def _clear_all_needs_human_review_flags_in_channel(self, channel=None):
         """Clear needs_human_review flags on all versions in the same channel.
 
         Doesn't clear abuse or appeal related flags.
@@ -455,7 +455,9 @@ class ContentActionAddon(ContentAction):
         # are only cleared in ContentDecision.execute_action() if the
         # reviewer has selected to resolve all jobs of that type though.
         NeedsHumanReview.objects.filter(
-            version__addon=self.target, version__channel=channel, is_active=True
+            version__addon=self.target,
+            is_active=True,
+            **({'version__channel': channel} if channel else {}),
         ).exclude(
             reason__in=NeedsHumanReview.REASONS.ABUSE_OR_APPEAL_RELATED.values
         ).update(is_active=False)
@@ -510,15 +512,8 @@ class ContentActionDisableAddon(ContentActionAddon):
     def hold_action(self):
         self.prevent_auto_approval()
         if self.target.status != amo.STATUS_DISABLED:
-            from olympia.reviewers.models import NeedsHumanReview
-
             self.decision.target_versions.set(self.versions_force_disable_will_affect)
-            NeedsHumanReview.objects.filter(
-                version__in=self.target.versions(
-                    manager='unfiltered_for_relations'
-                ).all()
-            ).update(is_active=False)
-            self.target.update_all_due_dates()
+            self._clear_all_needs_human_review_flags_in_channel()
             return self.log_action(amo.LOG.HELD_ACTION_FORCE_DISABLE)
         return None
 

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -926,6 +926,32 @@ class TestContentActionDisableAddon(
         assert flags.auto_approval_disabled
         assert flags.auto_approval_disabled_unlisted
 
+    def test_hold_action_clears_all_nhr(self):
+        version1 = version_factory(addon=self.addon)
+        version2 = version_factory(addon=self.addon)
+        NeedsHumanReview.objects.create(version=version1, is_active=True)
+        NeedsHumanReview.objects.create(version=version2, is_active=True)
+
+        assert (
+            NeedsHumanReview.objects.filter(
+                version__in=self.addon.versions.all(), is_active=True
+            ).count()
+            == 2
+        )
+        assert version1.due_date
+        assert version2.due_date
+
+        action_helper = self.ActionClass(self.decision)
+        action_helper.hold_action()
+        version1.reload()
+        version2.reload()
+
+        assert not NeedsHumanReview.objects.filter(
+            version__in=self.addon.versions.all(), is_active=True
+        ).exists()
+        assert not version1.due_date
+        assert not version2.due_date
+
     def test_forward_from_reviewers_no_job(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_LEGAL_FORWARD, cinder_job=None)
         action_helper = ContentActionForwardToLegal(self.decision)

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -943,14 +943,12 @@ class TestContentActionDisableAddon(
 
         action_helper = self.ActionClass(self.decision)
         action_helper.hold_action()
-        version1.reload()
-        version2.reload()
 
         assert not NeedsHumanReview.objects.filter(
             version__in=self.addon.versions.all(), is_active=True
         ).exists()
-        assert not version1.due_date
-        assert not version2.due_date
+        assert not version1.reload().due_date
+        assert not version2.reload().due_date
 
     def test_forward_from_reviewers_no_job(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_LEGAL_FORWARD, cinder_job=None)
@@ -1175,6 +1173,17 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
         # Set up another_version as approved so that the rejection of the other
         # 2 versions leaves one version approved and the add-on stays public.
         self.another_version.file.update(status=amo.STATUS_APPROVED)
+
+    def test_hold_action_clears_all_nhr(self):
+        # Only force-disable action clears unconditionally.
+        version = version_factory(addon=self.addon)
+        nhr = NeedsHumanReview.objects.create(version=version, is_active=True)
+
+        action_helper = self.ActionClass(self.decision)
+        action_helper.hold_action()
+
+        assert nhr.reload().is_active
+        assert version.reload().due_date
 
     def _test_reject_version(self, *, content_review, expected_emails_from_action=0):
         old_version_original_status = self.old_version.file.status
@@ -2037,6 +2046,17 @@ class TestContentActionBlockAddon(TestContentActionDisableAddon):
         )
         block = Block.objects.create(addon=self.addon, updated_by=self.task_user)
         BlockVersion.objects.create(block=block, version=self.another_version)
+
+    def test_hold_action_clears_all_nhr(self):
+        # Only force-disable action clears unconditionally.
+        version = version_factory(addon=self.addon)
+        nhr = NeedsHumanReview.objects.create(version=version, is_active=True)
+
+        action_helper = self.ActionClass(self.decision)
+        action_helper.hold_action()
+
+        assert nhr.reload().is_active
+        assert version.reload().due_date
 
     def _check_block_activity_logs(self, block_activity, block_version_activity):
         assert block_activity.log == amo.LOG.BLOCKLIST_BLOCK_EDITED
@@ -3045,6 +3065,17 @@ class TestContentActionRejectListingContent(TestContentActionDisableAddon):
     default_decision_action = DECISION_ACTIONS.AMO_REJECT_LISTING_CONTENT
     disable_snippet = 'until you address the violations and request a further review'
     activity_log_action = amo.LOG.REJECT_LISTING_CONTENT
+
+    def test_hold_action_clears_all_nhr(self):
+        # Only force-disable action clears unconditionally.
+        version = version_factory(addon=self.addon)
+        nhr = NeedsHumanReview.objects.create(version=version, is_active=True)
+
+        action_helper = self.ActionClass(self.decision)
+        action_helper.hold_action()
+
+        assert nhr.reload().is_active
+        assert version.reload().due_date
 
     def _process_action_and_notify(self):
         self.decision.update(action=self.default_decision_action)


### PR DESCRIPTION
Fixes mozilla/addons#16041

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Clears NHR ('Needs Human Review') when the disable add-on enforcement action is triggered.

### Testing

1. Create a high-profile add-on (i.e any promotion that's not strategic)
- Create (or upload a new version of) an add-on.
- Add the promotion via admin in `Discovery Addon`.
- Approve that version.
3. In reviewer tools, set NHR.
4. It should be in the manual review queue. Its NHR in admin should have `is_active=true`.
5. In reviewer tools, Review add-on with 'Add-on disable' enforcement action
6. Should no longer be in manual queue. Its NHR in admin should have `is_active=false`.
7. Should be in second-level approval queue.

For 4), Using `./manage.py fake_cinder_webhook` to send a mock `amo-legal-disable-addon` [payload](https://mozilla-staging.cinderapp.com/job/cf66e365-1fb5-49c2-a3f9-befbe1b1e0d8?) should behave similarly. 


<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
