### PR TITLE
rewrite auto_reject to bypass ReviewHelper

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -626,6 +626,9 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
                 defaults=auto_approval_flags,
             )
 
+    def get_activity_action(self):
+        return amo.LOG.REJECT_CONTENT if self.content_review else amo.LOG.REJECT_VERSION
+
     def process_action(self, release_hold=False):
         if not self.decision.reviewer_user:
             # This action should only be used by reviewer tools, not cinder webhook
@@ -661,9 +664,7 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
         self.prevent_auto_approval()
         self.target.update_status()
         self.notify_stakeholders('Rejection')
-        return self.log_action(
-            amo.LOG.REJECT_CONTENT if self.content_review else amo.LOG.REJECT_VERSION
-        )
+        return self.log_action(self.get_activity_action())
 
     def hold_action(self):
         # Even if the action is held, we want to always prevent auto-approval
@@ -717,6 +718,13 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
 
     # should_hold_action as ContentActionRejectVersion
 
+    def get_activity_action(self):
+        return (
+            amo.LOG.REJECT_CONTENT_DELAYED
+            if self.content_review
+            else amo.LOG.REJECT_VERSION_DELAYED
+        )
+
     def process_action(self, release_hold=False):
         if not self.decision.reviewer_user:
             # This action should only be used by reviewer tools, not cinder webhook
@@ -761,11 +769,7 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
             defaults={'notified_about_expiring_delayed_rejections': False},
         )
         self.notify_stakeholders(f'{self.delayed_rejection_days} day delayed rejection')
-        return self.log_action(
-            amo.LOG.REJECT_CONTENT_DELAYED
-            if self.content_review
-            else amo.LOG.REJECT_VERSION_DELAYED
-        )
+        return self.log_action(self.get_activity_action())
 
     def hold_action(self):
         # Even if the action is held, we want to always prevent auto-approval
@@ -780,6 +784,25 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
             amo.LOG.HELD_ACTION_REJECT_CONTENT_DELAYED
             if self.content_review
             else amo.LOG.HELD_ACTION_REJECT_VERSIONS_DELAYED
+        )
+
+
+class ContentActionRejectVersionAfterDelay(ContentActionRejectVersion):
+    action = None  # This should only be used specifically from auto_reject
+
+    def prevent_auto_approval(self):
+        # We don't want to change auto-approval for the final rejection
+        pass
+
+    def is_human_reviewer(self):
+        # When executed, this is always non-human.
+        return False
+
+    def get_activity_action(self):
+        return (
+            amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED
+            if self.content_review
+            else amo.LOG.AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED
         )
 
 

--- a/src/olympia/reviewers/management/commands/auto_reject.py
+++ b/src/olympia/reviewers/management/commands/auto_reject.py
@@ -4,9 +4,18 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
+import waffle
+
 import olympia.core.logger
 from olympia import amo
-from olympia.abuse.models import CinderJob, CinderPolicy
+from olympia.abuse.actions import ContentActionRejectVersionAfterDelay
+from olympia.abuse.models import (
+    CinderJob,
+    CinderPolicy,
+    ContentDecision,
+    ContentDecisionFollowupAction,
+)
+from olympia.abuse.tasks import report_decision_to_cinder_and_notify
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon
 from olympia.amo.decorators import use_primary_db
@@ -60,7 +69,8 @@ class Command(BaseCommand):
         )
 
     def reject_versions(self, *, addon, versions, latest_version):
-        """Reject specific versions for an addon."""
+        """Reject specific versions, either by calling ReviewHelper or by creating a
+        ContentDecision and calling its execute_action() method."""
         if self.dry_run:
             log.info(
                 'Would reject versions %s from add-on %s but this is a dry run.',
@@ -68,6 +78,15 @@ class Command(BaseCommand):
                 addon,
             )
             return
+        if waffle.switch_is_active('enable-policy-review-selection'):
+            self.reject_versions_with_action_class(addon=addon, versions=versions)
+        else:
+            self.reject_versions_with_review_helper(
+                addon=addon, versions=versions, latest_version=latest_version
+            )
+
+    def reject_versions_with_review_helper(self, *, addon, versions, latest_version):
+        """Reject specific versions for an addon, via reviwer tools ReviewHelper."""
         helper = ReviewHelper(
             addon=addon, version=latest_version, human_review=False, channel=None
         )
@@ -101,6 +120,51 @@ class Command(BaseCommand):
             pending_rejection_by=None,
             pending_content_rejection=None,
         )
+
+    def reject_versions_with_action_class(self, *, addon, versions):
+        """Reject specific versions for an addon, via reviwer tools ReviewHelper."""
+        previous_decisions = ContentDecision.objects.filter(
+            action_date__isnull=False,
+            overridden_by__isnull=True,
+            target_versions__in=versions,
+            action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON,
+        ).distinct()
+
+        for previous_decision in previous_decisions:
+            if not versions or not previous_decision.target_versions.exists():
+                log.info(
+                    'Skipping rejection for add-on %s since there are no versions '
+                    'to reject or no previous decision to override.',
+                    addon.pk,
+                )
+                continue
+            decision_versions = previous_decision.target_versions.filter(
+                id__in=versions
+            )
+            new_decision = ContentDecision.objects.create(
+                cinder_job=previous_decision.cinder_job,
+                override_of=previous_decision,
+                addon=addon,
+                action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
+                action_date=datetime.now(),
+                reasoning=previous_decision.reasoning,
+                reviewer_user_id=previous_decision.reviewer_user_id,
+                metadata=previous_decision.metadata,
+            )
+            new_decision.policies.set(previous_decision.policies.all())
+            new_decision.target_versions.set(decision_versions)
+            # We copy the follow-up actions, but we don't need to re-execute them.
+            ContentDecisionFollowupAction.objects.bulk_create(
+                ContentDecisionFollowupAction(decision=new_decision, action=action)
+                for action in previous_decision.followup_actions.all()
+            )
+            action_helper = ContentActionRejectVersionAfterDelay(decision=new_decision)
+            action_helper.process_action()
+
+            if new_decision.cinder_job:
+                new_decision.cinder_job.pending_rejections.clear()
+
+            report_decision_to_cinder_and_notify.delay(decision_id=new_decision.id)
 
     def process_addon(self, *, addon, now):
         try:

--- a/src/olympia/reviewers/management/commands/auto_reject.py
+++ b/src/olympia/reviewers/management/commands/auto_reject.py
@@ -155,8 +155,10 @@ class Command(BaseCommand):
             new_decision.target_versions.set(decision_versions)
             # We copy the follow-up actions, but we don't need to re-execute them.
             ContentDecisionFollowupAction.objects.bulk_create(
-                ContentDecisionFollowupAction(decision=new_decision, action=action)
-                for action in previous_decision.followup_actions.all()
+                ContentDecisionFollowupAction(
+                    decision=new_decision, action=followup_action.action
+                )
+                for followup_action in previous_decision.followup_actions.all()
             )
             action_helper = ContentActionRejectVersionAfterDelay(decision=new_decision)
             action_helper.process_action()

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1656,6 +1656,18 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
             pending_rejection_by=self.user,
             pending_content_rejection=True,
         )
+        decision = ContentDecision.objects.create(
+            action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON,
+            addon=self.addon,
+            action_date=self.yesterday,
+            reviewer_user=self.user,
+            metadata={
+                'content_review': True,
+                ContentDecision.POLICY_DYNAMIC_VALUES: {},
+            },
+        )
+        decision.target_versions.add(self.version, another_pending_rejection)
+        decision.policies.set(policies)
         ActivityLog.objects.for_addons(self.addon).exclude(
             id__in=[a.pk for a in activity_logs_to_keep]
         ).delete()
@@ -1664,7 +1676,9 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
         command.dry_run = False
         command.reject_versions(
             addon=self.addon,
-            versions=[self.version, another_pending_rejection],
+            versions=Version.objects.filter(
+                id__in=[self.version.id, another_pending_rejection.id]
+            ),
             latest_version=another_pending_rejection,
         )
 
@@ -1676,23 +1690,29 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
 
         # There should be a single new activity log for the rejection
         # and one because the add-on is changing status as a result.
-        logs = ActivityLog.objects.for_addons(self.addon).exclude(
-            id__in=[a.pk for a in activity_logs_to_keep]
+        logs = (
+            ActivityLog.objects.for_addons(self.addon)
+            .exclude(id__in=[a.pk for a in activity_logs_to_keep])
+            .order_by('action')
         )
-        decision = ContentDecision.objects.filter(action_date__isnull=False).get()
+        decision = (
+            ContentDecision.objects.filter(action_date__isnull=False)
+            .exclude(action_date=self.yesterday)
+            .get()
+        )
         assert len(logs) == 2
         assert logs[0].action == amo.LOG.CHANGE_STATUS.id
         assert logs[0].arguments == [self.addon, amo.STATUS_NULL]
         assert logs[0].user == self.task_user
         assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
-        expected_arguments = [
+        expected_arguments = {
             self.addon,
             self.version,
             another_pending_rejection,
             *policies,
             decision,
-        ]
-        assert logs[1].arguments == expected_arguments
+        }
+        assert set(logs[1].arguments) == expected_arguments
         assert logs[1].user == self.user
         # All pending rejections flags in the past should have been dropped
         # when the rejection was applied (there are no other pending rejections
@@ -1991,6 +2011,19 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
         assert len(mail.outbox) == 2
         assert 'right to appeal' in mail.outbox[0].body
         assert 'right to appeal' in mail.outbox[1].body
+
+    @override_switch('enable-policy-review-selection', active=True)
+    def test_reject_with_action_class(self):
+        policy = CinderPolicy.objects.create(
+            name='some policy', uuid='12345678', text='Bad stuff'
+        )
+        self._test_reject_versions(policies=[policy])
+        self._ensure_auto_approval_until_next_approval_is_not_set()
+        assert len(mail.outbox) == 1
+        new_decision = ContentDecision.objects.exclude(action_date=self.yesterday).get()
+        assert list(new_decision.policies.all()) == [policy]
+        assert 'right to appeal' in mail.outbox[0].body
+        assert 'Bad stuff' in mail.outbox[0].body
 
     def test_addon_locked(self):
         set_reviewing_cache(self.addon.pk, 42)

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -12,7 +12,13 @@ import responses
 from waffle.testutils import override_switch
 
 from olympia import amo
-from olympia.abuse.models import AbuseReport, CinderJob, CinderPolicy, ContentDecision
+from olympia.abuse.models import (
+    AbuseReport,
+    CinderJob,
+    CinderPolicy,
+    ContentDecision,
+    ContentDecisionFollowupAction,
+)
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import AddonApprovalsCounter, AddonReviewerFlags
 from olympia.amo.tests import (
@@ -1668,6 +1674,12 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
         )
         decision.target_versions.add(self.version, another_pending_rejection)
         decision.policies.set(policies)
+        decision.followup_actions.add(
+            ContentDecisionFollowupAction.objects.create(
+                decision=decision,
+                action=DECISION_ACTIONS.AMO_FU_DELAY_SHORT_HARD_BLOCK_ADDON,
+            )
+        )
         ActivityLog.objects.for_addons(self.addon).exclude(
             id__in=[a.pk for a in activity_logs_to_keep]
         ).delete()
@@ -2024,6 +2036,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
         assert list(new_decision.policies.all()) == [policy]
         assert 'right to appeal' in mail.outbox[0].body
         assert 'Bad stuff' in mail.outbox[0].body
+        assert 'Blocked' in mail.outbox[0].body
 
     def test_addon_locked(self):
         set_reviewing_cache(self.addon.pk, 42)


### PR DESCRIPTION
Fixes mozilla/addons#16271 (and fixes mozilla/addons#15619)

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Rewrites the auto_reject command to create and execute the rejection decisions directly, rather than calling the (deprecated) `ReviewHelper.auto_multiple_reject` method, so reject with the policies and follow-up actions the original decision had.

### Context

This wasn't strictly necessary to fix the issue, but it was a good opportunity to do the same thing I did with auto_approve, and reduce another dependency on ReviewHelper codepaths.

### Testing

Requirements:
- Some Cinder policies to reject a version - see [syncing Cinder policies](https://mozilla.github.io/addons-server/topics/runbooks/services/cinder.html#syncing-cinder-policies-to-amo) to your local env.
- Cinder [API key](https://mozilla.github.io/addons-server/topics/runbooks/services/cinder.html#api-key) in settings, for the emails (needed to sync Cinder policies anyway)

Testing
- enable waffle switch `enable-policy-review-selection` (in django admin or [cmd line](https://mozilla.github.io/addons-server/topics/development/waffle.html))
- Enable at least one policies with enforcement action amo-reject-version-warning-addon - and preferably with a follow-up action - for the reviewer tools.  e.g. policy with uuid `0d2d9701-80c4-40ff-840c-dfe1d1cadd75`.  Use django admin or django shell to `CinderPolicy.get(uuid='0d2d9701-80c4-40ff-840c-dfe1d1cadd75').update(expose_in_reviewer_tools=True)`
- in reviewer tools, navigate to the review page for an extension, select `Negative Review` reviewer action, choose a policy (e.g. "Acceptable Use, specifically Minor exploitation") that has a "Add-on version delayed reject warning" enforcement action.
- choose one or more versions to reject and save the review
- see the email to the developer(s) in [fake email](https://mozilla.github.io/addons-server/topics/models/amo/FakeEmail.html) in django admin or django shell.  It should mention the policy that was violated; that the version will be rejected in X days; (and the follow-up actions from the policy)
- we need to update the delayed rejection date so we can trigger the rejection immediately.  Easiest way is to update the VersionReviewerFlags instance(s) that hold the dates.  Use django admin, something like `VersionReviewerFlags.objects.filter(version__addon_id=<the pk of the addon you reviewed>, pending_rejection__isnull=False).update(pending_rejection=datetime.now())`
- run the auto_reject command (`./manage.py auto_reject'`)
- the version should now be rejected (see reviewer tools, django admin, or django shell)
- see the final rejection email in fake email.  This email should also mention the policy that was violated, and follow-up actions - i.e. it should contain the same information from the first email.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
