### PR TITLE
Expose more relevant information for developer appeals

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -13,7 +13,6 @@ from django.forms.models import (
     ModelMultipleChoiceField,
     modelformset_factory,
 )
-from django.utils.html import format_html, format_html_join
 
 import markupsafe
 
@@ -24,7 +23,6 @@ from olympia.abuse.utils import filter_enforcement_actions, hash_addon_negative_
 from olympia.access import acl
 from olympia.addons.models import Addon
 from olympia.amo.forms import AMOModelForm
-from olympia.amo.templatetags.jinja_helpers import format_datetime
 from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.reviewers import (
     HELD_DECISION_CHOICES,
@@ -223,7 +221,7 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
     select elements with additional attribute to allow toggling.
     """
 
-    option_template_name = 'reviewers/includes/input_option_with_label_attrs.html'
+    option_template_name = 'reviewers/widgets/cinder_job.html'
 
     def create_option(
         self, name, value, label, selected, index, subindex=None, attrs=None
@@ -242,14 +240,7 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
         forwarded = queue_moves[0].created if queue_moves else None
         requeued = requeued_decisions[0].created if requeued_decisions else None
         reports = obj.all_abuse_reports
-        reasons_set = {(report.REASONS(report.reason).label,) for report in reports}
-        messages_gen = (
-            (
-                (f'v[{report.addon_version}]: ' if report.addon_version else ''),
-                report.message or '<no message>',
-            )
-            for report in reports
-        )
+        reasons = {report.REASONS(report.reason).label for report in reports}
         forwarded_or_requeued_notes = (
             [
                 *(move.notes for move in queue_moves),
@@ -258,47 +249,27 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
             if requeued or forwarded
             else []
         )
-        internal_notes = (
-            ((f'Reasoning: {"; ".join(forwarded_or_requeued_notes)}',),)
-            if forwarded_or_requeued_notes
-            else ()
-        )
+
         appeals = (
             (
-                (appeal_obj.text, appeal_obj.reporter_report_id is not None)
+                appeal_obj
                 for appealed_decision in obj.appealed_decisions.all()
                 for appeal_obj in appealed_decision.appeals.all()
             )
             if is_reporter_appeal or is_developer_appeal
             else ()
         )
-        subtexts_gen = [
-            *internal_notes,
-            *(
-                (f'{"Reporter" if is_reporter else "Developer"} Appeal: {text}',)
-                for text, is_reporter in appeals
-            ),
-        ]
 
-        label = format_html(
-            '(Created on {}) {}{}{}{}<br/><span>{}</span>'
-            '<details><summary>Show detail on {} reports</summary><ul>{}</ul>'
-            '</details>',
-            format_datetime(obj.created),
-            '[Appeal] ' if (is_reporter_appeal or is_developer_appeal) else '',
-            format_html('[Forwarded on {}] ', format_datetime(forwarded))
-            if forwarded
-            else '',
-            format_html('[Requeued on {}] ', format_datetime(requeued))
-            if requeued
-            else '',
-            format_html_join(', ', '"{}"', reasons_set),
-            format_html_join('', '{}<br/>', subtexts_gen),
-            len(reports),
-            format_html_join('', '<li>{}{}</li>', messages_gen),
-        )
-
-        attrs = attrs or {}
+        label = {
+            'job_created': obj.created,
+            'is_appeal': is_reporter_appeal or is_developer_appeal,
+            'forwarded_date': forwarded,
+            'requeued_date': requeued,
+            'reasons': reasons,
+            'internal_notes': forwarded_or_requeued_notes,
+            'appeals': appeals,
+            'reports': reports,
+        }
         # Reviewers shouldn't use appeal_deny to resolve "regular" jobs,
         # and conversely shouldn't use resolve_reports_job to resolve appeals,
         # as resolving appeals is a bit more involved.
@@ -319,7 +290,8 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
             ]
         else:
             hide_for_these_actions = ['appeal_deny', 'appeal_override']
-        attrs['data-value'] = ' '.join(hide_for_these_actions)
+        attrs = attrs or {}
+        attrs['data_value'] = ' '.join(hide_for_these_actions)
         return super().create_option(
             name, value, label, selected, index, subindex, attrs
         )

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -229,18 +229,22 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
         # label_from_instance() on WidgetRenderedModelMultipleChoiceField returns the
         # full object, not a label, this is what makes this work.
         obj = label
-        is_developer_appeal = obj.is_developer_appeal
-        is_reporter_appeal = not is_developer_appeal and obj.is_appeal
-        queue_moves = list(obj.queue_moves.order_by('-created'))
-        requeued_decisions = list(
-            obj.decisions.filter(action=DECISION_ACTIONS.AMO_REQUEUE).order_by(
-                '-created'
-            )
+        queue_moves = sorted(
+            obj.queue_moves.all(), key=lambda m: m.created, reverse=True
         )
+        requeued_decisions = getattr(
+            obj,
+            'prefetched_requeue_decisions',
+            None,
+        )
+        if requeued_decisions is None:
+            requeued_decisions = list(
+                obj.decisions.filter(action=DECISION_ACTIONS.AMO_REQUEUE).order_by(
+                    '-created'
+                )
+            )
         forwarded = queue_moves[0].created if queue_moves else None
         requeued = requeued_decisions[0].created if requeued_decisions else None
-        reports = obj.all_abuse_reports
-        reasons = {report.REASONS(report.reason).label for report in reports}
         forwarded_or_requeued_notes = (
             [
                 *(move.notes for move in queue_moves),
@@ -249,26 +253,24 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
             if requeued or forwarded
             else []
         )
-
-        appeals = (
-            (
-                appeal_obj
-                for appealed_decision in obj.appealed_decisions.all()
-                for appeal_obj in appealed_decision.appeals.all()
-            )
-            if is_reporter_appeal or is_developer_appeal
-            else ()
-        )
+        appealed_decisions = list(obj.appealed_decisions.all())
+        is_developer_appeal = appealed_decisions and obj.is_developer_appeal
+        # optimization: we don't show the original reports for a developer appeal
+        reports = obj.all_abuse_reports if not is_developer_appeal else []
+        reasons = {report.REASONS(report.reason).label for report in reports}
 
         label = {
-            'job_created': obj.created,
-            'is_appeal': is_reporter_appeal or is_developer_appeal,
+            'appealed_decisions': appealed_decisions,
+            'created_date': obj.created,
             'forwarded_date': forwarded,
-            'requeued_date': requeued,
-            'reasons': reasons,
             'internal_notes': forwarded_or_requeued_notes,
-            'appeals': appeals,
+            'is_developer_appeal': is_developer_appeal,
+            'reasons': reasons,
+            'requeued_date': requeued,
             'reports': reports,
+            'version_count': sum(
+                len(decision.target_versions.all()) for decision in appealed_decisions
+            ),
         }
         # Reviewers shouldn't use appeal_deny to resolve "regular" jobs,
         # and conversely shouldn't use resolve_reports_job to resolve appeals,
@@ -278,16 +280,17 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
         # that's not always what we want.
         # The parent element will have `data-toggle-hide`, so data-value is
         # used to hide actions that are not supposed to be used for this job.
-        if is_reporter_appeal:
-            hide_for_these_actions = ['appeal_override', 'resolve_reports_job']
-        elif is_developer_appeal:
-            hide_for_these_actions = [
-                'review_with_policy_approve',
-                'review_with_policy',
-                'reject',
-                'reject_multiple_versions',
-                'resolve_reports_job',
-            ]
+        if appealed_decisions:
+            if is_developer_appeal:
+                hide_for_these_actions = [
+                    'review_with_policy_approve',
+                    'review_with_policy',
+                    'reject',
+                    'reject_multiple_versions',
+                    'resolve_reports_job',
+                ]
+            else:
+                hide_for_these_actions = ['appeal_override', 'resolve_reports_job']
         else:
             hide_for_these_actions = ['appeal_deny', 'appeal_override']
         attrs = attrs or {}

--- a/src/olympia/reviewers/templates/reviewers/includes/input_option_with_label_attrs.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/input_option_with_label_attrs.html
@@ -1,1 +1,0 @@
-<label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %} {% include "django/forms/widgets/attrs.html" %}>{% include "django/forms/widgets/input.html" %} {{ widget.label }}</label>

--- a/src/olympia/reviewers/templates/reviewers/widgets/cinder_job.html
+++ b/src/olympia/reviewers/templates/reviewers/widgets/cinder_job.html
@@ -1,0 +1,20 @@
+<label for="{{ widget.attrs.id }}" data-value="{{ widget.attrs.data_value }}" class="{{ widget.attrs.class }}">{% include "django/forms/widgets/input.html" %}
+(Created on {{ widget.label.job_created|date:'DATETIME_FORMAT' }})
+{% if widget.label.is_appeal %}[Appeal] {% endif %}
+{% if widget.label.forwarded_date %}[Forwarded on {{ widget.label.forwarded_date|date:'DATETIME_FORMAT' }}] {% endif %}
+{% if widget.label.requeued_date %}[Requeued on {{ widget.label.requeued_date|date:'DATETIME_FORMAT' }}] {% endif %}
+{% for reason in widget.label.reasons %}"{{ reason }}" {% endfor %}
+<br/>
+<span>
+    {% if widget.label.internal_notes %}Reasoning: {{ widget.label.internal_notes|join:'; ' }}{% endif %}
+    {% for appeal in widget.label.appeals %}
+        {% if appeal.reporter_report_id %}Reporter{% else %}Developer{% endif %} Appeal: {{ appeal.text }}<br>
+    {% endfor %}
+</span>
+<details>
+    <summary>Show detail on {{ widget.label.reports|length }} reports</summary>
+    <ul>{% for report in widget.label.reports %}
+        <li>{% if report.addon_version %}v[{{ report.addon_version }}]: {% endif %}{{ report.message|default:'&lt;no message&gt;' }}</li>
+        {% endfor %}</ul>
+</details>
+</label>

--- a/src/olympia/reviewers/templates/reviewers/widgets/cinder_job.html
+++ b/src/olympia/reviewers/templates/reviewers/widgets/cinder_job.html
@@ -41,9 +41,11 @@
   </span>
   <details>
     <summary>Show detail on {{ widget.label.reports|length }} reports</summary>
-    <ul>{% for report in widget.label.reports %}
-        <li>{% if report.addon_version %}v[{{ report.addon_version }}]: {% endif %}{{ report.message|default:'&lt;no message&gt;' }}</li>
-        {% endfor %}</ul>
+    <ul>
+        {% for report in widget.label.reports %}
+            <li>{% if report.addon_version %}v[{{ report.addon_version }}]: {% endif %}{{ report.message|default:'&lt;no message&gt;' }}</li>
+        {% endfor %}
+    </ul>
 </details>
 {% endif %}
 </label>

--- a/src/olympia/reviewers/templates/reviewers/widgets/cinder_job.html
+++ b/src/olympia/reviewers/templates/reviewers/widgets/cinder_job.html
@@ -1,20 +1,49 @@
-<label for="{{ widget.attrs.id }}" data-value="{{ widget.attrs.data_value }}" class="{{ widget.attrs.class }}">{% include "django/forms/widgets/input.html" %}
-(Created on {{ widget.label.job_created|date:'DATETIME_FORMAT' }})
-{% if widget.label.is_appeal %}[Appeal] {% endif %}
+{% load reviewers %}
+<label for="{{ widget.attrs.id }}" data-value="{{ widget.attrs.data_value }}" class="{{ widget.attrs.class }}{% if widget.label.appealed_decisions %} appeal{% endif %}">{% include "django/forms/widgets/input.html" %}
+(&#x25F7; {{ widget.label.created_date|date:'DATETIME_FORMAT' }})
 {% if widget.label.forwarded_date %}[Forwarded on {{ widget.label.forwarded_date|date:'DATETIME_FORMAT' }}] {% endif %}
 {% if widget.label.requeued_date %}[Requeued on {{ widget.label.requeued_date|date:'DATETIME_FORMAT' }}] {% endif %}
-{% for reason in widget.label.reasons %}"{{ reason }}" {% endfor %}
+{% if widget.label.is_developer_appeal %}
+[Developer Appeal]
+{% for decision in widget.label.appealed_decisions %}{{ decision.action|decision_action_label }}; {% endfor %}
 <br/>
 <span>
-    {% if widget.label.internal_notes %}Reasoning: {{ widget.label.internal_notes|join:'; ' }}{% endif %}
-    {% for appeal in widget.label.appeals %}
-        {% if appeal.reporter_report_id %}Reporter{% else %}Developer{% endif %} Appeal: {{ appeal.text }}<br>
+    {% if widget.label.internal_notes %}Forward/Requeue Reasoning: {{ widget.label.internal_notes|join:'; ' }}{% endif %}
+    {% for decision in widget.label.appealed_decisions %}
+    {% for appeal in decision.appeals.all %}
+        Appeal Justification: {{ appeal.text }}<br>
+    {% endfor %}
     {% endfor %}
 </span>
 <details>
+    <summary>{{ widget.label.appealed_decisions|length }} decisions affecting {{ widget.label.version_count }} versions</summary>
+    <ul>{% for decision in widget.label.appealed_decisions %}
+        <li>{{ decision.action|decision_action_label }}:
+            <ul>
+                {% for version in decision.target_versions.all %}
+                <li>{{ version }}</li>
+                {% endfor %}
+            </ul>
+        </li>
+        {% endfor %}
+    </ul>
+</details>
+{% else %}
+{% for reason in widget.label.reasons %}"{{ reason }}" {% endfor %}
+<br/>
+<span>
+    {% if widget.label.internal_notes %}Forward/Requeue Reasoning: {{ widget.label.internal_notes|join:'; ' }}{% endif %}
+    {% for decision in widget.label.appealed_decisions %}
+    {% for appeal in decision.appeals.all %}
+        Reporter Appeal Justification: {{ appeal.text }}<br>
+    {% endfor %}
+    {% endfor %}
+  </span>
+  <details>
     <summary>Show detail on {{ widget.label.reports|length }} reports</summary>
     <ul>{% for report in widget.label.reports %}
         <li>{% if report.addon_version %}v[{{ report.addon_version }}]: {% endif %}{{ report.message|default:'&lt;no message&gt;' }}</li>
         {% endfor %}</ul>
 </details>
+{% endif %}
 </label>

--- a/src/olympia/reviewers/templatetags/reviewers.py
+++ b/src/olympia/reviewers/templatetags/reviewers.py
@@ -1,0 +1,11 @@
+from django import template
+
+from olympia.constants.abuse import DECISION_ACTIONS
+
+
+register = template.Library()
+
+
+@register.filter
+def decision_action_label(action):
+    return DECISION_ACTIONS(action).label

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -1520,7 +1520,7 @@ class TestReviewForm(TestCase):
             '[Forwarded on May 22, 2025, 11:42 a.m.] '
             '[Requeued on May 23, 2025, 10:54 p.m.] '
             '"DSA: It violates Mozilla\'s Add-on Policies"\n'
-            'Reasoning: Zee de zee; Why o why\n\n'
+            'Reasoning: Zee de zee; Why o why\n'
             'Show detail on 1 reports\n'
             'v[<script>alert()</script>]: ddd'
         )

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -1401,12 +1401,13 @@ class TestReviewForm(TestCase):
         assert form.is_valid(), form.errors
 
     def test_cinder_jobs_to_resolve_choices(self):
+        # A job with two abuse reports.
         abuse_kw = {
             'guid': self.addon.guid,
             'location': AbuseReport.LOCATION.ADDON,
             'reason': AbuseReport.REASONS.POLICY_VIOLATION,
         }
-        cinder_job_2_reports = CinderJob.objects.create(
+        job_two_reports = CinderJob.objects.create(
             created=datetime(2025, 5, 22, 11, 27, 42, 123456),
             job_id='2 reports',
             resolvable_in_reviewer_tools=True,
@@ -1414,14 +1415,15 @@ class TestReviewForm(TestCase):
         )
         AbuseReport.objects.create(
             **abuse_kw,
-            cinder_job=cinder_job_2_reports,  # no message
+            cinder_job=job_two_reports,  # no message
         )
         AbuseReport.objects.create(
-            **abuse_kw, cinder_job=cinder_job_2_reports, message='bbb'
+            **abuse_kw, cinder_job=job_two_reports, message='bbb'
         )
 
-        cinder_job_appealed = CinderJob.objects.create(
-            job_id='appealed',
+        # An appeal job from a developer
+        job_dev_appealed = CinderJob.objects.create(
+            job_id='dev_appealed',
             decision=ContentDecision.objects.create(
                 action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
                 addon=self.addon,
@@ -1429,32 +1431,51 @@ class TestReviewForm(TestCase):
             resolvable_in_reviewer_tools=True,
             target_addon=self.addon,
         )
-        appealed_abuse_report = AbuseReport.objects.create(
-            **abuse_kw,
-            cinder_job=cinder_job_appealed,
-            message='ccc',
-            addon_version='1.2',
-        )
-        cinder_job_appeal = CinderJob.objects.create(
+        job_dev_appealed.final_decision.target_versions.add(self.version)
+
+        job_dev_appeal = CinderJob.objects.create(
             created=datetime(2025, 5, 6, 1, 24, 2, 194875),
-            job_id='appeal',
+            job_id='dev_appeal',
             resolvable_in_reviewer_tools=True,
             target_addon=self.addon,
         )
-        cinder_job_appealed.final_decision.update(appeal_job=cinder_job_appeal)
-        appeal_obj = CinderAppeal.objects.create(
-            text='some justification',
-            decision=cinder_job_appealed.final_decision,
-        )
-        # This wouldn't happen - a reporter can't appeal a disable decision
-        # - but we want to test the rendering of reporter vs. developer appeal text
+        job_dev_appealed.final_decision.update(appeal_job=job_dev_appeal)
         CinderAppeal.objects.create(
-            text='some other justification',
-            decision=cinder_job_appealed.final_decision,
-            reporter_report=appealed_abuse_report,
+            text='some justification',
+            decision=job_dev_appealed.final_decision,
         )
 
-        cinder_job_forwarded = CinderJob.objects.create(
+        # An appeal job from a reporter
+        job_reporter_appealed = CinderJob.objects.create(
+            job_id='rep_appealed',
+            decision=ContentDecision.objects.create(
+                action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+                addon=self.addon,
+            ),
+            resolvable_in_reviewer_tools=True,
+            target_addon=self.addon,
+        )
+        rep_appealed_abuse_report = AbuseReport.objects.create(
+            **abuse_kw,
+            cinder_job=job_reporter_appealed,
+            message='ccc',
+            addon_version='1.2',
+        )
+        job_reporter_appeal = CinderJob.objects.create(
+            created=datetime(2025, 5, 5, 1, 24, 2, 194875),
+            job_id='rep_appeal',
+            resolvable_in_reviewer_tools=True,
+            target_addon=self.addon,
+        )
+        job_reporter_appealed.final_decision.update(appeal_job=job_reporter_appeal)
+        CinderAppeal.objects.create(
+            text='some other justification',
+            decision=job_reporter_appealed.final_decision,
+            reporter_report=rep_appealed_abuse_report,
+        )
+
+        # A job that was forwarded to another queue, then requeued.
+        job_forwarded_moved = CinderJob.objects.create(
             created=datetime(2025, 4, 8, 15, 16, 3, 550090),
             job_id='forwarded',
             resolvable_in_reviewer_tools=True,
@@ -1465,21 +1486,23 @@ class TestReviewForm(TestCase):
             action=DECISION_ACTIONS.AMO_REQUEUE,
             private_notes='Why o why',
             addon=self.addon,
-            cinder_job=cinder_job_forwarded,
+            cinder_job=job_forwarded_moved,
         )
         CinderQueueMove.objects.create(
             created=datetime(2025, 5, 22, 11, 42, 5, 541216),
-            cinder_job=cinder_job_forwarded,
+            cinder_job=job_forwarded_moved,
             notes='Zee de zee',
             to_queue='amo-env-content-infringment',
         )
         AbuseReport.objects.create(
             **{**abuse_kw, 'location': AbuseReport.LOCATION.AMO},
             message='ddd',
-            cinder_job=cinder_job_forwarded,
+            cinder_job=job_forwarded_moved,
             addon_version='<script>alert()</script>',
         )
 
+        # And two more jobs; one that isn't reviewer handled, and one that is already
+        # resolved.
         AbuseReport.objects.create(
             **{**abuse_kw, 'location': AbuseReport.LOCATION.AMO},
             message='eee',
@@ -1507,45 +1530,58 @@ class TestReviewForm(TestCase):
         qs_list = list(choices.queryset)
         assert qs_list == [
             # Only unresolved, reviewer handled, jobs are shown
-            cinder_job_forwarded,
-            cinder_job_appeal,
-            cinder_job_2_reports,
+            job_forwarded_moved,
+            job_reporter_appeal,
+            job_dev_appeal,
+            job_two_reports,
         ]
 
         content = str(form['cinder_jobs_to_resolve'])
         doc = pq(content)
-        label_0 = doc('label[for="id_cinder_jobs_to_resolve_0"]')
-        assert label_0.text() == (
-            '(Created on April 8, 2025, 3:16 p.m.) '
+        label_forward = doc('label[for="id_cinder_jobs_to_resolve_0"]')
+        assert label_forward.text() == (
+            '(\u25f7 April 8, 2025, 3:16 p.m.) '
             '[Forwarded on May 22, 2025, 11:42 a.m.] '
             '[Requeued on May 23, 2025, 10:54 p.m.] '
             '"DSA: It violates Mozilla\'s Add-on Policies"\n'
-            'Reasoning: Zee de zee; Why o why\n'
+            'Forward/Requeue Reasoning: Zee de zee; Why o why\n'
             'Show detail on 1 reports\n'
             'v[<script>alert()</script>]: ddd'
         )
         assert '<script>alert()</script>' not in content  # should be escaped
         assert '&lt;script&gt;alert()&lt;/script&gt' in content  # should be escaped
-        label_1 = doc('label[for="id_cinder_jobs_to_resolve_1"]')
-        assert label_1.text() == (
-            '(Created on May 6, 2025, 1:24 a.m.) '
-            '[Appeal] "DSA: It violates Mozilla\'s Add-on Policies"\n'
-            'Developer Appeal: some justification\n'
-            'Reporter Appeal: some other justification\n\n'
+        label_rep_appeal = doc('label[for="id_cinder_jobs_to_resolve_1"]')
+        assert label_rep_appeal.text() == (
+            '(\u25f7 May 5, 2025, 1:24 a.m.) '
+            '"DSA: It violates Mozilla\'s Add-on Policies"\n'
+            'Reporter Appeal Justification: some other justification\n\n'
             'Show detail on 1 reports\n'
             'v[1.2]: ccc'
         )
-        label_2 = doc('label[for="id_cinder_jobs_to_resolve_2"]')
-        assert label_2.text() == (
-            '(Created on May 22, 2025, 11:27 a.m.) '
+        label_dev_appeal = doc('label[for="id_cinder_jobs_to_resolve_2"]')
+        assert label_dev_appeal.text() == (
+            '(\u25f7 May 6, 2025, 1:24 a.m.) '
+            '[Developer Appeal] Add-on disable;\n'
+            'Appeal Justification: some justification\n\n'
+            '1 decisions affecting 1 versions\n'
+            'Add-on disable:\n'
+            f'{self.version.version}'
+        )
+        label_two_reports = doc('label[for="id_cinder_jobs_to_resolve_3"]')
+        assert label_two_reports.text() == (
+            '(\u25f7 May 22, 2025, 11:27 a.m.) '
             '"DSA: It violates Mozilla\'s Add-on Policies"\n\n'
             'Show detail on 2 reports\n<no message>\nbbb'
         )
 
-        assert label_0.attr['class'] == 'data-toggle-hide'
-        assert label_0.attr['data-value'] == 'appeal_deny appeal_override'
-        assert label_1.attr['class'] == 'data-toggle-hide'
-        assert label_1.attr['data-value'] == ' '.join(
+        assert label_forward.attr['class'] == 'data-toggle-hide'
+        assert label_forward.attr['data-value'] == 'appeal_deny appeal_override'
+        assert label_rep_appeal.attr['class'] == 'data-toggle-hide appeal'
+        assert label_rep_appeal.attr['data-value'] == ' '.join(
+            ('appeal_override', 'resolve_reports_job')
+        )
+        assert label_dev_appeal.attr['class'] == 'data-toggle-hide appeal'
+        assert label_dev_appeal.attr['data-value'] == ' '.join(
             (
                 'review_with_policy_approve',
                 'review_with_policy',
@@ -1554,21 +1590,8 @@ class TestReviewForm(TestCase):
                 'resolve_reports_job',
             )
         )
-        assert label_2.attr['class'] == 'data-toggle-hide'
-        assert label_2.attr['data-value'] == 'appeal_deny appeal_override'
-
-        # If we make the developer appeal a reporter appeal instead, suddenly
-        # the widget option is shown for reject/reject_multiple_versions.
-        appeal_obj.update(
-            reporter_report=AbuseReport.objects.create(
-                **abuse_kw, cinder_job=cinder_job_appealed
-            )
-        )
-        form = self.get_form()
-        doc = pq(str(form['cinder_jobs_to_resolve']))
-        label_1 = doc('label[for="id_cinder_jobs_to_resolve_1"]')
-        assert label_1.attr['class'] == 'data-toggle-hide'
-        assert label_1.attr['data-value'] == 'appeal_override resolve_reports_job'
+        assert label_two_reports.attr['class'] == 'data-toggle-hide'
+        assert label_two_reports.attr['data-value'] == 'appeal_deny appeal_override'
 
     def test_cinder_policies_choices(self):
         policy_exposed = CinderPolicy.objects.create(

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.files.base import ContentFile
+from django.db.models import Prefetch
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
 from django.utils.http import urlencode
@@ -520,6 +521,15 @@ class ReviewHelper:
                 'appealed_decisions__cinder_job',
                 'appealed_decisions__override_of__cinder_job',
                 'appealed_decisions__appeals',
+                'appealed_decisions__target_versions',
+                'queue_moves',
+                Prefetch(
+                    'decisions',
+                    queryset=ContentDecision.objects.filter(
+                        action=DECISION_ACTIONS.AMO_REQUEUE
+                    ).order_by('-created'),
+                    to_attr='prefetched_requeue_decisions',
+                ),
             )
         )
         unresolved_cinder_jobs = list(self.unresolved_cinderjob_qs)


### PR DESCRIPTION
Fixes mozilla/addons#16266

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Refactors the widget for CinderJobs to be more maintainable, and separates rendering of developer appeal jobs to show information about the appealed decision(s).
<img width="1486" height="330" alt="image" src="https://github.com/user-attachments/assets/186dd59e-9788-4f4a-b83c-f40caba57f68" />

### Context

- This patch focuses on developer appeals  because a reporter appeal is only possible on an approval decision, information about that decision isn't really relevant - it's the original reports that are important.  Whereas for developer appeals, we care more about how the add-on/versions were affected.  So this PR only (functionally) changes developer appeals.

### Testing

- set up your cinder [integration](https://mozilla.github.io/addons-server/topics/runbooks/services/cinder.html)
- enable waffle switch `enable-policy-review-selection` (and the [Cinder related](https://mozilla.github.io/addons-server/topics/runbooks/services/cinder.html#useful-waffle-switches-to-enable)d waffle switches)
- report an add-on for abuse via frontend for policy violation
- edit the CinderJob that was created in django shell to set `resolvable_in_reviewer_tools=True`
- navigate to the review page for that add-on
- open the Negative Review reviewer tools action, and see the job shown below, with details of the abuse report you made (all existing functionality - checking no regressions)
- made a decision on that add-on, resolving the job, for some policy that does something negative to the addon/version
- check in fakeemail for the email to the developer, and appeal that decision with the link in email.  
  - (You will need to add yourself as an author of the add-on first.  Easiest way is via django shell `AddonUser.objects.create(addon_id=<id>, user_id=<your userid>)`)
- go back to the review page.  
- open `Resolve Appeals with Denial` or `Resolve Appeals with Override` and see the appeal job for the appeal you submitted.  It should show the decision that was made, along with your appeal justification, and any versions that were affected

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
