### PR TITLE
Add scanner query api

### DIFF
--- a/docs/topics/api/scanners.rst
+++ b/docs/topics/api/scanners.rst
@@ -50,3 +50,166 @@ This endpoint allows to update scanner results.
     :statuscode 204: Results successfully updated.
     :statuscode 400: Invalid payload.
     :statuscode 409: Scanner results already recorded.
+
+
+------------
+Query rules
+------------
+
+.. _scanner-query-rules:
+
+These endpoints allow authorized users to create and run ``ScannerQueryRule``
+objects and to read their matches.
+
+    .. note::
+        Requires JWT authentication. The authenticated user must belong to a
+        group with the ``Admin:ScannersQueryView`` permission for read
+        operations, and ``Admin:ScannersQueryEdit`` for create, update, delete,
+        run and abort operations.
+
+A rule can only be edited while it is in the ``New`` state; once it has been
+scheduled or run its definition is frozen and a new rule should be created to
+iterate on it.
+
+The ``scanner`` field accepts ``3`` (yara) or ``5`` (narc). The ``state`` field
+is one of ``1`` (New), ``2`` (Running), ``3`` (Aborted), ``4`` (Completed),
+``5`` (Aborting) or ``6`` (Scheduled).
+
+
+List / create rules
+-------------------
+
+.. http:get:: /api/v5/scanner/query-rules/
+
+    Return a paginated list of query rules, most recently created first.
+
+    :>json int count: The number of rules.
+    :>json array results: The array of rules (see the fields below).
+    :statuscode 200: Rules returned successfully.
+    :statuscode 401: Authentication failed.
+    :statuscode 403: The authenticated user lacks the required permission.
+
+.. http:post:: /api/v5/scanner/query-rules/
+
+    Create a new query rule. The definition is validated (YARA/NARC
+    compilation and, for YARA, that the rule name matches the ``name`` field).
+
+    :<json string name: The exact name of the rule used by the scanner (required).
+    :<json int scanner: ``3`` (yara) or ``5`` (narc) (required).
+    :<json string definition: The rule definition (required).
+    :<json string pretty_name: Human-readable name (optional).
+    :<json string description: Human-readable description (optional).
+    :<json object configuration: Scanner-specific configuration (optional).
+    :<json boolean run_on_disabled_addons: Run on force-disabled add-ons too (optional).
+    :<json boolean run_on_current_version_only: Run on the current listed version only (optional).
+    :<json int run_on_specific_channel: Restrict to a channel, ``1`` (unlisted) or ``2`` (listed) (optional).
+    :<json boolean exclude_promoted_addons: Exclude promoted add-ons (optional).
+    :>json int id: The primary key of the created rule.
+    :>json int state: The rule state (``1`` / New for a freshly created rule).
+    :>json string state_display: Human-readable state.
+    :>json string scanner_display: Human-readable scanner name.
+    :>json string completion_rate: Progress string while running, otherwise ``null``.
+    :>json int results_count: Number of matches recorded so far.
+    :statuscode 201: Rule created successfully.
+    :statuscode 400: Invalid payload (e.g. the definition does not compile).
+    :statuscode 401: Authentication failed.
+    :statuscode 403: The authenticated user lacks the required permission.
+
+
+Retrieve / update / delete a rule
+---------------------------------
+
+.. http:get:: /api/v5/scanner/query-rules/(int:pk)/
+
+    Return a single query rule. Poll this endpoint to track a run via the
+    ``state``, ``completion_rate`` and ``completed`` fields.
+
+    :statuscode 200: Rule returned successfully.
+    :statuscode 401: Authentication failed.
+    :statuscode 403: The authenticated user lacks the required permission.
+    :statuscode 404: No rule with that id.
+
+.. http:patch:: /api/v5/scanner/query-rules/(int:pk)/
+
+    Update a query rule. Only allowed while the rule is in the ``New`` state.
+    Accepts the same writable fields as the create endpoint.
+
+    :statuscode 200: Rule updated successfully.
+    :statuscode 400: Invalid payload, or the rule is not in the ``New`` state.
+    :statuscode 401: Authentication failed.
+    :statuscode 403: The authenticated user lacks the required permission.
+    :statuscode 404: No rule with that id.
+
+.. http:delete:: /api/v5/scanner/query-rules/(int:pk)/
+
+    Delete a query rule and its results.
+
+    :statuscode 204: Rule deleted successfully.
+    :statuscode 401: Authentication failed.
+    :statuscode 403: The authenticated user lacks the required permission.
+    :statuscode 404: No rule with that id.
+
+
+Run / abort a rule
+------------------
+
+.. http:post:: /api/v5/scanner/query-rules/(int:pk)/run/
+
+    Schedule the rule to run. The rule transitions to the ``Scheduled`` state
+    and a background task is enqueued.
+
+    :>json int state: The updated state (``6`` / Scheduled).
+    :statuscode 202: Run scheduled successfully.
+    :statuscode 401: Authentication failed.
+    :statuscode 403: The authenticated user lacks the required permission.
+    :statuscode 404: No rule with that id.
+    :statuscode 409: The rule is not in a state from which it can be run.
+
+.. http:post:: /api/v5/scanner/query-rules/(int:pk)/abort/
+
+    Abort a scheduled or running rule. The rule transitions to the
+    ``Aborting`` state.
+
+    :statuscode 200: Abort requested successfully.
+    :statuscode 401: Authentication failed.
+    :statuscode 403: The authenticated user lacks the required permission.
+    :statuscode 404: No rule with that id.
+    :statuscode 409: The rule is not in a state from which it can be aborted.
+
+
+Rule results
+------------
+
+.. http:get:: /api/v5/scanner/query-rules/(int:query_rule_pk)/results/
+
+    Return a paginated list of the matches for a rule. Only the
+    definition-safe match information is exposed (the files and metadata that
+    hit), not the raw scanner output.
+
+    The list can be filtered and ordered with the query parameters below.
+    Invalid filter values return a ``400``.
+
+    :query boolean was_blocked: Only results whose version was blocked.
+    :query boolean was_promoted: Only results whose add-on was promoted.
+    :query boolean was_signed: Only results whose file is signed.
+    :query boolean addon_disabled_by_user: Only results whose add-on listing is
+        invisible (``true``) or visible (``false``).
+    :query int channel: Version channel, ``1`` (unlisted) or ``2`` (listed).
+    :query int addon_status: Filter by the add-on status.
+    :query int file_status: Filter by the file status.
+    :query string sort: Ordering field. One of ``id``, ``addon_adu``
+        (add-on average daily users) or ``version_created``. Prefix with ``-``
+        for descending order (e.g. ``-addon_adu``). Defaults to ``-id``.
+    :>json int count: The number of results.
+    :>json array results: The array of results.
+    :>json int results[].id: The result id.
+    :>json int results[].matched_rule: The id of the rule that matched.
+    :>json string results[].addon_guid: The add-on GUID (may be ``null``).
+    :>json int results[].version_id: The version id (may be ``null``).
+    :>json string results[].version_string: The version number (may be ``null``).
+    :>json string results[].channel: The version channel (may be ``null``).
+    :>json object results[].matches: The matched files and metadata, keyed by rule name.
+    :statuscode 200: Results returned successfully.
+    :statuscode 401: Authentication failed.
+    :statuscode 403: The authenticated user lacks the required permission.
+    :statuscode 404: No rule with that id.

--- a/docs/topics/api/scanners.rst
+++ b/docs/topics/api/scanners.rst
@@ -67,13 +67,43 @@ objects and to read their matches.
         operations, and ``Admin:ScannersQueryEdit`` for create, update, delete,
         run and abort operations.
 
-A rule can only be edited while it is in the ``New`` state; once it has been
+A rule can only be edited while it is in the ``new`` state; once it has been
 scheduled or run its definition is frozen and a new rule should be created to
-iterate on it.
+iterate on it. ``name`` and ``scanner`` are also frozen after creation and can
+only be set when the rule is created.
 
-The ``scanner`` field accepts ``3`` (yara) or ``5`` (narc). The ``state`` field
-is one of ``1`` (New), ``2`` (Running), ``3`` (Aborted), ``4`` (Completed),
-``5`` (Aborting) or ``6`` (Scheduled).
+For ``yara`` rules the ``name`` is inferred from the definition (the
+``rule <name>`` identifier); any ``name`` sent by the client is ignored. For
+``narc`` rules the ``name`` is required.
+
+The ``scanner`` field accepts ``yara`` or ``narc``. The ``state`` field is one
+of ``new``, ``running``, ``aborted``, ``completed``, ``aborting`` or
+``scheduled``.
+
+Configuration
+-------------
+
+Only ``narc`` rules have configuration options. ``configuration`` is an object
+whose keys are booleans; unknown keys or non-boolean values are rejected. When
+omitted at creation, it is populated with the defaults noted below. ``yara``
+rules must not have any configuration.
+
+* ``examine_slug`` (default ``false``): Run the rule against the add-on slug
+  used for the listing on AMO.
+* ``examine_listing_names`` (default ``true``): Run against the add-on name(s)
+  used for the listing on AMO.
+* ``examine_listing_summaries`` (default ``false``): Run against the add-on
+  summary/summaries used for the listing on AMO.
+* ``examine_xpi_names`` (default ``true``): Run against the add-on name(s) in
+  the XPI.
+* ``examine_xpi_descriptions`` (default ``false``): Run against the add-on
+  description(s) in the XPI.
+* ``examine_authors_names`` (default ``true``): Run against the name of each
+  author attached to the add-on.
+* ``examine_normalized_variants`` (default ``true``): For each string being
+  examined, also examine a normalized variant.
+* ``examine_homoglyphs_variants`` (default ``true``): For each string being
+  examined, also examine homoglyph variants.
 
 
 List / create rules
@@ -94,20 +124,19 @@ List / create rules
     Create a new query rule. The definition is validated (YARA/NARC
     compilation and, for YARA, that the rule name matches the ``name`` field).
 
-    :<json string name: The exact name of the rule used by the scanner (required).
-    :<json int scanner: ``3`` (yara) or ``5`` (narc) (required).
+    :<json string name: The exact name of the rule (frozen after creation). Required for ``narc``; ignored and inferred from the definition for ``yara``.
+    :<json string scanner: ``yara`` or ``narc`` (required, frozen after creation).
     :<json string definition: The rule definition (required).
     :<json string pretty_name: Human-readable name (optional).
     :<json string description: Human-readable description (optional).
-    :<json object configuration: Scanner-specific configuration (optional).
+    :<json object configuration: Scanner-specific configuration (optional, see above).
     :<json boolean run_on_disabled_addons: Run on force-disabled add-ons too (optional).
     :<json boolean run_on_current_version_only: Run on the current listed version only (optional).
-    :<json int run_on_specific_channel: Restrict to a channel, ``1`` (unlisted) or ``2`` (listed) (optional).
+    :<json string run_on_specific_channel: Restrict to a channel, ``unlisted`` or ``listed`` (optional).
     :<json boolean exclude_promoted_addons: Exclude promoted add-ons (optional).
     :>json int id: The primary key of the created rule.
-    :>json int state: The rule state (``1`` / New for a freshly created rule).
-    :>json string state_display: Human-readable state.
-    :>json string scanner_display: Human-readable scanner name.
+    :>json string scanner: The scanner (``yara`` or ``narc``).
+    :>json string state: The rule state (``new`` for a freshly created rule).
     :>json string completion_rate: Progress string while running, otherwise ``null``.
     :>json int results_count: Number of matches recorded so far.
     :statuscode 201: Rule created successfully.
@@ -158,7 +187,7 @@ Run / abort a rule
     Schedule the rule to run. The rule transitions to the ``Scheduled`` state
     and a background task is enqueued.
 
-    :>json int state: The updated state (``6`` / Scheduled).
+    :>json string state: The updated state (``scheduled``).
     :statuscode 202: Run scheduled successfully.
     :statuscode 401: Authentication failed.
     :statuscode 403: The authenticated user lacks the required permission.
@@ -194,21 +223,25 @@ Rule results
     :query boolean was_signed: Only results whose file is signed.
     :query boolean addon_disabled_by_user: Only results whose add-on listing is
         invisible (``true``) or visible (``false``).
-    :query int channel: Version channel, ``1`` (unlisted) or ``2`` (listed).
-    :query int addon_status: Filter by the add-on status.
-    :query int file_status: Filter by the file status.
+    :query string channel: Version channel, ``unlisted`` or ``listed``.
+    :query string addon_status: Add-on status (e.g. ``public``, ``disabled``).
+    :query string file_status: File status (e.g. ``public``, ``disabled``).
     :query string sort: Ordering field. One of ``id``, ``addon_adu``
         (add-on average daily users) or ``version_created``. Prefix with ``-``
         for descending order (e.g. ``-addon_adu``). Defaults to ``-id``.
     :>json int count: The number of results.
     :>json array results: The array of results.
     :>json int results[].id: The result id.
-    :>json int results[].matched_rule: The id of the rule that matched.
-    :>json string results[].addon_guid: The add-on GUID (may be ``null``).
-    :>json int results[].version_id: The version id (may be ``null``).
-    :>json string results[].version_string: The version number (may be ``null``).
-    :>json string results[].channel: The version channel (may be ``null``).
+    :>json boolean results[].was_blocked: Whether the version was blocked.
+    :>json boolean results[].was_promoted: Whether the add-on was promoted.
+    :>json object results[].version: Minimal version representation (may be ``null``).
+    :>json int results[].version.id: The version id.
+    :>json string results[].version.version: The version number.
+    :>json string results[].version.channel: The version channel (``listed`` or ``unlisted``).
+    :>json string results[].version.created: When the version was created.
+    :>json object results[].version.addon: The add-on (``id``, ``guid``, ``average_daily_users``).
     :>json object results[].matches: The matched files and metadata, keyed by rule name.
+    :>json string results[].created: When the result was recorded.
     :statuscode 200: Results returned successfully.
     :statuscode 401: Authentication failed.
     :statuscode 403: The authenticated user lacks the required permission.

--- a/src/olympia/constants/scanners.py
+++ b/src/olympia/constants/scanners.py
@@ -57,6 +57,21 @@ QUERY_RULE_STATES = {
     SCHEDULED: 'Scheduled',
 }
 
+# Query rules currently only support yara and narc.
+SCANNER_CHOICES_API = {
+    YARA: 'yara',
+    NARC: 'narc',
+}
+
+QUERY_RULE_STATES_CHOICES_API = {
+    NEW: 'new',
+    RUNNING: 'running',
+    ABORTED: 'aborted',
+    ABORTING: 'aborting',
+    COMPLETED: 'completed',
+    SCHEDULED: 'scheduled',
+}
+
 # Scanner service accounts group
 SCANNER_SERVICE_ACCOUNTS_GROUP = 'Service accounts for scanners'
 

--- a/src/olympia/scanners/api_urls.py
+++ b/src/olympia/scanners/api_urls.py
@@ -1,7 +1,25 @@
-from django.urls import re_path
+from django.urls import include, re_path
 
-from .views import patch_scanner_result, push_scanner_result
+from rest_framework.routers import SimpleRouter
+from rest_framework_nested.routers import NestedSimpleRouter
 
+from .views import (
+    ScannerQueryResultViewSet,
+    ScannerQueryRuleViewSet,
+    patch_scanner_result,
+    push_scanner_result,
+)
+
+
+router = SimpleRouter()
+router.register(r'query-rules', ScannerQueryRuleViewSet, basename='scanner-query-rule')
+
+# Results are nested under their parent rule:
+# /scanner/query-rules/{query_rule_pk}/results/
+sub_rules = NestedSimpleRouter(router, r'query-rules', lookup='query_rule')
+sub_rules.register(
+    r'results', ScannerQueryResultViewSet, basename='scanner-query-rule-result'
+)
 
 urlpatterns = [
     re_path(r'^results/$', push_scanner_result, name='scanner-result-push'),
@@ -10,4 +28,6 @@ urlpatterns = [
         patch_scanner_result,
         name='scanner-result-patch',
     ),
+    re_path(r'', include(router.urls)),
+    re_path(r'', include(sub_rules.urls)),
 ]

--- a/src/olympia/scanners/serializers.py
+++ b/src/olympia/scanners/serializers.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.urls import reverse
 
 import jsonschema
@@ -9,7 +10,10 @@ from olympia.addons.serializers import (
     VersionSerializer,
 )
 from olympia.amo.templatetags.jinja_helpers import absolutify
+from olympia.constants.scanners import NEW
 from olympia.versions.models import Version
+
+from .models import ScannerQueryResult, ScannerQueryRule
 
 
 class WebhookAddonSerializer(AddonSerializer):
@@ -135,3 +139,145 @@ class PatchScannerResultSerializer(
     """Serializer for updating scanner result data via PATCH endpoint."""
 
     results = serializers.JSONField()
+
+    def validate(self, data):
+        # Validate that no extra fields are present in the initial data.
+        if hasattr(self, 'initial_data'):
+            extra_fields = set(self.initial_data.keys()) - set(self.fields.keys())
+            if extra_fields:
+                raise serializers.ValidationError(
+                    {field: 'Unexpected field.' for field in extra_fields}
+                )
+
+        return data
+
+
+class ScannerQueryRuleSerializer(serializers.ModelSerializer):
+    """Serializer to create, read and iterate on ScannerQueryRules.
+
+    The rule can only be modified while it is still in the ``NEW`` state (the
+    same invariant the admin enforces): once it has been scheduled or run, its
+    definition is frozen and a new rule should be created to iterate."""
+
+    state_display = serializers.CharField(source='get_state_display', read_only=True)
+    scanner_display = serializers.CharField(
+        source='get_scanner_display', read_only=True
+    )
+    completion_rate = serializers.SerializerMethodField()
+    results_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ScannerQueryRule
+        fields = (
+            'id',
+            'name',
+            'pretty_name',
+            'description',
+            'scanner',
+            'scanner_display',
+            'definition',
+            'configuration',
+            'run_on_disabled_addons',
+            'run_on_current_version_only',
+            'run_on_specific_channel',
+            'exclude_promoted_addons',
+            'state',
+            'state_display',
+            'task_count',
+            'completed',
+            'completion_rate',
+            'results_count',
+            'created',
+            'modified',
+        )
+        read_only_fields = (
+            'id',
+            'scanner_display',
+            'state',
+            'state_display',
+            'task_count',
+            'completed',
+            'completion_rate',
+            'results_count',
+            'created',
+            'modified',
+        )
+
+    def get_completion_rate(self, obj):
+        return obj.completion_rate()
+
+    def get_results_count(self, obj):
+        return obj.results.count()
+
+    def validate(self, data):
+        # Build/patch the instance and call the model's clean(), which compiles
+        # the YARA/NARC definition and checks the name matches. We deliberately
+        # call clean() and not full_clean(): field-level constraints are already
+        # enforced by the serializer fields, and the (name, scanner) uniqueness
+        # is handled by the UniqueTogetherValidator DRF adds automatically.
+        if self.instance is None:
+            instance = ScannerQueryRule(**data)
+        else:
+            if self.instance.state != NEW:
+                raise serializers.ValidationError(
+                    'A scanner query rule can only be modified while it is in '
+                    'the "New" state. Create a new rule to iterate on it.'
+                )
+            instance = self.instance
+            for attr, value in data.items():
+                setattr(instance, attr, value)
+
+        try:
+            instance.clean()
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(
+                exc.message_dict if hasattr(exc, 'error_dict') else exc.messages
+            ) from exc
+
+        return data
+
+
+class ScannerQueryResultSerializer(serializers.ModelSerializer):
+    """Read-only serializer exposing the matches of a ScannerQueryRule.
+
+    ``matches`` is the structured, per-file view of the hits produced by
+    ``get_files_and_data_by_matched_rules()`` (the same representation the
+    admin surfaces), which is the convenient shape for iterating on a rule."""
+
+    scanner_display = serializers.CharField(
+        source='get_scanner_display', read_only=True
+    )
+    addon_id = serializers.IntegerField(
+        source='version.addon_id', read_only=True, allow_null=True
+    )
+    addon_guid = serializers.CharField(
+        source='version.addon.guid', read_only=True, allow_null=True
+    )
+    version_string = serializers.CharField(
+        source='version.version', read_only=True, allow_null=True
+    )
+    channel = serializers.CharField(
+        source='version.get_channel_display', read_only=True, allow_null=True
+    )
+    matches = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ScannerQueryResult
+        fields = (
+            'id',
+            'scanner',
+            'scanner_display',
+            'matched_rule',
+            'was_blocked',
+            'was_promoted',
+            'addon_id',
+            'addon_guid',
+            'version_id',
+            'version_string',
+            'channel',
+            'matches',
+            'created',
+        )
+
+    def get_matches(self, obj):
+        return dict(obj.get_files_and_data_by_matched_rules())

--- a/src/olympia/scanners/serializers.py
+++ b/src/olympia/scanners/serializers.py
@@ -1,19 +1,33 @@
+import re
+
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.urls import reverse
 
 import jsonschema
 from rest_framework import serializers
 
+from olympia import amo
 from olympia.addons.models import Addon
 from olympia.addons.serializers import (
     AddonSerializer,
     VersionSerializer,
 )
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.constants.scanners import NEW
+from olympia.api.fields import ReverseChoiceField
+from olympia.constants.scanners import (
+    NEW,
+    QUERY_RULE_STATES_CHOICES_API,
+    SCANNER_CHOICES_API,
+    YARA,
+)
 from olympia.versions.models import Version
 
-from .models import ScannerQueryResult, ScannerQueryRule
+from .models import ScannerQueryResult, ScannerQueryRule, rule_schema
+
+
+# Same pattern the admin's change-form JS uses to infer the rule name from a
+# yara definition (`rule some_rule {`).
+YARA_RULE_NAME_RE = re.compile(r'rule\s+(.+?)\s+{')
 
 
 class WebhookAddonSerializer(AddonSerializer):
@@ -157,11 +171,21 @@ class ScannerQueryRuleSerializer(serializers.ModelSerializer):
 
     The rule can only be modified while it is still in the ``NEW`` state (the
     same invariant the admin enforces): once it has been scheduled or run, its
-    definition is frozen and a new rule should be created to iterate."""
+    definition is frozen and a new rule should be created to iterate. ``name``
+    and ``scanner`` are also frozen after creation, matching the admin.
 
-    state_display = serializers.CharField(source='get_state_display', read_only=True)
-    scanner_display = serializers.CharField(
-        source='get_scanner_display', read_only=True
+    For yara rules, ``name`` is inferred from the definition (the ``rule
+    <name>`` identifier) and any value provided by the client is ignored, again
+    matching the admin. For narc rules, ``name`` is required."""
+
+    scanner = ReverseChoiceField(choices=list(SCANNER_CHOICES_API.items()))
+    state = ReverseChoiceField(
+        choices=list(QUERY_RULE_STATES_CHOICES_API.items()), read_only=True
+    )
+    run_on_specific_channel = ReverseChoiceField(
+        choices=list(amo.CHANNEL_CHOICES_API.items()),
+        required=False,
+        allow_null=True,
     )
     completion_rate = serializers.SerializerMethodField()
     results_count = serializers.SerializerMethodField()
@@ -174,7 +198,6 @@ class ScannerQueryRuleSerializer(serializers.ModelSerializer):
             'pretty_name',
             'description',
             'scanner',
-            'scanner_display',
             'definition',
             'configuration',
             'run_on_disabled_addons',
@@ -182,7 +205,6 @@ class ScannerQueryRuleSerializer(serializers.ModelSerializer):
             'run_on_specific_channel',
             'exclude_promoted_addons',
             'state',
-            'state_display',
             'task_count',
             'completed',
             'completion_rate',
@@ -192,9 +214,7 @@ class ScannerQueryRuleSerializer(serializers.ModelSerializer):
         )
         read_only_fields = (
             'id',
-            'scanner_display',
             'state',
-            'state_display',
             'task_count',
             'completed',
             'completion_rate',
@@ -202,6 +222,23 @@ class ScannerQueryRuleSerializer(serializers.ModelSerializer):
             'created',
             'modified',
         )
+        # Not required at the field level: for yara it is derived from the
+        # definition, for narc it is enforced in validate().
+        extra_kwargs = {'name': {'required': False}}
+        # Drop the auto (name, scanner) UniqueTogetherValidator: it runs before
+        # validate() and would require `name` up-front, before we get a chance
+        # to derive it from the definition for yara. Uniqueness is enforced via
+        # instance.validate_unique() in validate() instead.
+        validators = []
+
+    def get_fields(self):
+        fields = super().get_fields()
+        # `name` and `scanner` are only editable at creation time, like in the
+        # admin (they are part of the rule's identity and change its schema).
+        if self.instance is not None:
+            fields['name'].read_only = True
+            fields['scanner'].read_only = True
+        return fields
 
     def get_completion_rate(self, obj):
         return obj.completion_rate()
@@ -209,19 +246,50 @@ class ScannerQueryRuleSerializer(serializers.ModelSerializer):
     def get_results_count(self, obj):
         return obj.results.count()
 
+    def validate_configuration_against_schema(self, instance, configuration):
+        """Validate the configuration against the schema for the rule's scanner
+        (only NARC has options; anything else expects an empty object)."""
+        allowed = rule_schema(instance).get('keys', {})
+        unknown = sorted(set(configuration) - set(allowed))
+        if unknown:
+            raise serializers.ValidationError(
+                {'configuration': f'Unknown configuration keys: {unknown}.'}
+            )
+        for key, value in configuration.items():
+            if allowed[key].get('type') == 'boolean' and not isinstance(value, bool):
+                raise serializers.ValidationError(
+                    {'configuration': f'"{key}" must be a boolean.'}
+                )
+
+    def validate_name_for_scanner(self, data):
+        """On creation, derive the name from the definition for yara (ignoring
+        any client-provided value, like the admin does), and require an explicit
+        name for narc."""
+        if data.get('scanner') == YARA:
+            match = YARA_RULE_NAME_RE.search(data.get('definition') or '')
+            if match:
+                data['name'] = match.group(1)
+            # If it didn't match, leave name as-is; clean() will surface a
+            # helpful error about the definition.
+        elif not data.get('name'):
+            raise serializers.ValidationError(
+                {'name': 'This field is required for this scanner.'}
+            )
+
     def validate(self, data):
         # Build/patch the instance and call the model's clean(), which compiles
         # the YARA/NARC definition and checks the name matches. We deliberately
         # call clean() and not full_clean(): field-level constraints are already
-        # enforced by the serializer fields, and the (name, scanner) uniqueness
-        # is handled by the UniqueTogetherValidator DRF adds automatically.
+        # enforced by the serializer fields. We do call validate_unique() to
+        # enforce the (name, scanner) uniqueness constraint (see Meta.validators).
         if self.instance is None:
+            self.validate_name_for_scanner(data)
             instance = ScannerQueryRule(**data)
         else:
             if self.instance.state != NEW:
                 raise serializers.ValidationError(
                     'A scanner query rule can only be modified while it is in '
-                    'the "New" state. Create a new rule to iterate on it.'
+                    'the "new" state. Create a new rule to iterate on it.'
                 )
             instance = self.instance
             for attr, value in data.items():
@@ -229,12 +297,39 @@ class ScannerQueryRuleSerializer(serializers.ModelSerializer):
 
         try:
             instance.clean()
+            instance.validate_unique()
         except DjangoValidationError as exc:
             raise serializers.ValidationError(
                 exc.message_dict if hasattr(exc, 'error_dict') else exc.messages
             ) from exc
 
+        if 'configuration' in data:
+            self.validate_configuration_against_schema(instance, data['configuration'])
+
         return data
+
+
+class ScannerQueryResultAddonSerializer(serializers.ModelSerializer):
+    """Minimal add-on representation for a scanner query result."""
+
+    class Meta:
+        model = Addon
+        fields = ('id', 'guid', 'average_daily_users')
+        read_only_fields = fields
+
+
+class ScannerQueryResultVersionSerializer(serializers.ModelSerializer):
+    """Minimal version representation for a scanner query result."""
+
+    addon = ScannerQueryResultAddonSerializer(read_only=True)
+    channel = ReverseChoiceField(
+        choices=list(amo.CHANNEL_CHOICES_API.items()), read_only=True
+    )
+
+    class Meta:
+        model = Version
+        fields = ('id', 'version', 'channel', 'created', 'addon')
+        read_only_fields = fields
 
 
 class ScannerQueryResultSerializer(serializers.ModelSerializer):
@@ -244,40 +339,20 @@ class ScannerQueryResultSerializer(serializers.ModelSerializer):
     ``get_files_and_data_by_matched_rules()`` (the same representation the
     admin surfaces), which is the convenient shape for iterating on a rule."""
 
-    scanner_display = serializers.CharField(
-        source='get_scanner_display', read_only=True
-    )
-    addon_id = serializers.IntegerField(
-        source='version.addon_id', read_only=True, allow_null=True
-    )
-    addon_guid = serializers.CharField(
-        source='version.addon.guid', read_only=True, allow_null=True
-    )
-    version_string = serializers.CharField(
-        source='version.version', read_only=True, allow_null=True
-    )
-    channel = serializers.CharField(
-        source='version.get_channel_display', read_only=True, allow_null=True
-    )
+    version = ScannerQueryResultVersionSerializer(read_only=True)
     matches = serializers.SerializerMethodField()
 
     class Meta:
         model = ScannerQueryResult
         fields = (
             'id',
-            'scanner',
-            'scanner_display',
-            'matched_rule',
             'was_blocked',
             'was_promoted',
-            'addon_id',
-            'addon_guid',
-            'version_id',
-            'version_string',
-            'channel',
+            'version',
             'matches',
             'created',
         )
+        read_only_fields = fields
 
     def get_matches(self, obj):
         return dict(obj.get_files_and_data_by_matched_rules())

--- a/src/olympia/scanners/tests/test_serializers.py
+++ b/src/olympia/scanners/tests/test_serializers.py
@@ -3,9 +3,13 @@ from django.urls import reverse
 from olympia import amo
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import TestCase, addon_factory, reverse_ns, version_factory
+from olympia.constants.scanners import NEW, RUNNING, WEBHOOK, YARA
+from olympia.scanners.models import ScannerQueryResult, ScannerQueryRule
 from olympia.scanners.serializers import (
     PatchScannerResultSerializer,
     PushScannerResultSerializer,
+    ScannerQueryResultSerializer,
+    ScannerQueryRuleSerializer,
     WebhookAddonSerializer,
     WebhookVersionSerializer,
 )
@@ -264,3 +268,99 @@ class TestPatchScannerResultSerializer(TestCase):
             {'results': self.valid_results, 'unexpected': 'value'}
         )
         assert 'unexpected' in serializer.errors
+
+
+VALID_YARA_DEFINITION = 'rule some_rule { condition: true }'
+
+
+class TestScannerQueryRuleSerializer(TestCase):
+    def test_create_valid(self):
+        serializer = ScannerQueryRuleSerializer(
+            data={
+                'name': 'some_rule',
+                'scanner': YARA,
+                'definition': VALID_YARA_DEFINITION,
+            }
+        )
+        assert serializer.is_valid(), serializer.errors
+        rule = serializer.save()
+        assert rule.pk
+        assert rule.name == 'some_rule'
+        assert rule.state == NEW
+
+    def test_invalid_definition(self):
+        serializer = ScannerQueryRuleSerializer(
+            data={
+                'name': 'some_rule',
+                'scanner': YARA,
+                # Name in definition does not match rule name.
+                'definition': 'rule other { condition: true }',
+            }
+        )
+        assert not serializer.is_valid()
+        assert 'definition' in serializer.errors
+
+    def test_scanner_choices_limited(self):
+        serializer = ScannerQueryRuleSerializer(
+            data={
+                'name': 'some_rule',
+                # WEBHOOK is not a valid query-rule scanner.
+                'scanner': WEBHOOK,
+                'definition': VALID_YARA_DEFINITION,
+            }
+        )
+        assert not serializer.is_valid()
+        assert 'scanner' in serializer.errors
+
+    def test_read_only_fields_serialized(self):
+        rule = ScannerQueryRule.objects.create(
+            name='some_rule', scanner=YARA, definition=VALID_YARA_DEFINITION
+        )
+        data = ScannerQueryRuleSerializer(rule).data
+        assert data['state'] == NEW
+        assert data['state_display'] == 'New'
+        assert data['scanner_display'] == 'yara'
+        assert data['results_count'] == 0
+        assert data['completion_rate'] is None
+
+    def test_cannot_update_when_not_new(self):
+        rule = ScannerQueryRule.objects.create(
+            name='some_rule', scanner=YARA, definition=VALID_YARA_DEFINITION
+        )
+        rule.update(state=RUNNING)
+        serializer = ScannerQueryRuleSerializer(
+            instance=rule, data={'description': 'updated'}, partial=True
+        )
+        assert not serializer.is_valid()
+
+    def test_can_update_when_new(self):
+        rule = ScannerQueryRule.objects.create(
+            name='some_rule', scanner=YARA, definition=VALID_YARA_DEFINITION
+        )
+        serializer = ScannerQueryRuleSerializer(
+            instance=rule, data={'description': 'updated'}, partial=True
+        )
+        assert serializer.is_valid(), serializer.errors
+        rule = serializer.save()
+        assert rule.description == 'updated'
+
+
+class TestScannerQueryResultSerializer(TestCase):
+    def test_serialize(self):
+        ScannerQueryRule.objects.create(
+            name='some_rule', scanner=YARA, definition=VALID_YARA_DEFINITION
+        )
+        version = version_factory(addon=addon_factory(guid='@some-guid'))
+        result = ScannerQueryResult(scanner=YARA, version=version)
+        result.add_yara_result(rule='some_rule', meta={'filename': 'foo.js'})
+        result.save()
+
+        data = ScannerQueryResultSerializer(result).data
+        assert data['id'] == result.pk
+        assert data['scanner_display'] == 'yara'
+        assert data['addon_guid'] == '@some-guid'
+        assert data['version_id'] == version.pk
+        assert data['version_string'] == version.version
+        assert 'some_rule' in data['matches']
+        # Raw results are not exposed, only definition-safe match info.
+        assert 'results' not in data

--- a/src/olympia/scanners/tests/test_serializers.py
+++ b/src/olympia/scanners/tests/test_serializers.py
@@ -3,7 +3,13 @@ from django.urls import reverse
 from olympia import amo
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import TestCase, addon_factory, reverse_ns, version_factory
-from olympia.constants.scanners import NEW, RUNNING, WEBHOOK, YARA
+from olympia.constants.scanners import (
+    NARC,
+    NARC_RULE_CONFIGURATION_SCHEMA,
+    NEW,
+    RUNNING,
+    YARA,
+)
 from olympia.scanners.models import ScannerQueryResult, ScannerQueryRule
 from olympia.scanners.serializers import (
     PatchScannerResultSerializer,
@@ -13,6 +19,7 @@ from olympia.scanners.serializers import (
     WebhookAddonSerializer,
     WebhookVersionSerializer,
 )
+from olympia.scanners.utils import default_from_schema
 
 
 class TestWebhookAddonSerializer(TestCase):
@@ -274,11 +281,16 @@ VALID_YARA_DEFINITION = 'rule some_rule { condition: true }'
 
 
 class TestScannerQueryRuleSerializer(TestCase):
+    def _create_narc_rule(self):
+        return ScannerQueryRule.objects.create(
+            name='narc_rule', scanner=NARC, definition='test'
+        )
+
     def test_create_valid(self):
         serializer = ScannerQueryRuleSerializer(
             data={
                 'name': 'some_rule',
-                'scanner': YARA,
+                'scanner': 'yara',
                 'definition': VALID_YARA_DEFINITION,
             }
         )
@@ -286,26 +298,68 @@ class TestScannerQueryRuleSerializer(TestCase):
         rule = serializer.save()
         assert rule.pk
         assert rule.name == 'some_rule'
+        assert rule.scanner == YARA
         assert rule.state == NEW
+
+    def test_yara_name_derived_from_definition(self):
+        # name is not provided; it is inferred from the definition.
+        serializer = ScannerQueryRuleSerializer(
+            data={
+                'scanner': 'yara',
+                'definition': 'rule derived_name { condition: true }',
+            }
+        )
+        assert serializer.is_valid(), serializer.errors
+        rule = serializer.save()
+        assert rule.name == 'derived_name'
+
+    def test_yara_ignores_provided_name(self):
+        # Any client-provided name is ignored for yara; the definition wins.
+        serializer = ScannerQueryRuleSerializer(
+            data={
+                'name': 'ignored',
+                'scanner': 'yara',
+                'definition': 'rule derived_name { condition: true }',
+            }
+        )
+        assert serializer.is_valid(), serializer.errors
+        rule = serializer.save()
+        assert rule.name == 'derived_name'
+
+    def test_narc_requires_name(self):
+        serializer = ScannerQueryRuleSerializer(
+            data={'scanner': 'narc', 'definition': 'test'}
+        )
+        assert not serializer.is_valid()
+        assert 'name' in serializer.errors
 
     def test_invalid_definition(self):
         serializer = ScannerQueryRuleSerializer(
             data={
-                'name': 'some_rule',
-                'scanner': YARA,
-                # Name in definition does not match rule name.
-                'definition': 'rule other { condition: true }',
+                'scanner': 'yara',
+                # Missing condition, so it does not compile.
+                'definition': 'rule some_rule { }',
             }
         )
         assert not serializer.is_valid()
         assert 'definition' in serializer.errors
 
+    def test_duplicate_name_and_scanner_rejected(self):
+        ScannerQueryRule.objects.create(
+            name='some_rule', scanner=YARA, definition=VALID_YARA_DEFINITION
+        )
+        # Derives name 'some_rule' from the definition -> collides with above.
+        serializer = ScannerQueryRuleSerializer(
+            data={'scanner': 'yara', 'definition': VALID_YARA_DEFINITION}
+        )
+        assert not serializer.is_valid()
+
     def test_scanner_choices_limited(self):
         serializer = ScannerQueryRuleSerializer(
             data={
                 'name': 'some_rule',
-                # WEBHOOK is not a valid query-rule scanner.
-                'scanner': WEBHOOK,
+                # webhook is not a valid query-rule scanner.
+                'scanner': 'webhook',
                 'definition': VALID_YARA_DEFINITION,
             }
         )
@@ -317,9 +371,10 @@ class TestScannerQueryRuleSerializer(TestCase):
             name='some_rule', scanner=YARA, definition=VALID_YARA_DEFINITION
         )
         data = ScannerQueryRuleSerializer(rule).data
-        assert data['state'] == NEW
-        assert data['state_display'] == 'New'
-        assert data['scanner_display'] == 'yara'
+        assert data['scanner'] == 'yara'
+        assert data['state'] == 'new'
+        assert 'scanner_display' not in data
+        assert 'state_display' not in data
         assert data['results_count'] == 0
         assert data['completion_rate'] is None
 
@@ -344,23 +399,124 @@ class TestScannerQueryRuleSerializer(TestCase):
         rule = serializer.save()
         assert rule.description == 'updated'
 
+    def test_name_and_scanner_read_only_after_create(self):
+        rule = ScannerQueryRule.objects.create(
+            name='some_rule', scanner=YARA, definition=VALID_YARA_DEFINITION
+        )
+        serializer = ScannerQueryRuleSerializer(
+            instance=rule,
+            data={'name': 'renamed', 'scanner': 'narc'},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        rule = serializer.save()
+        # Both are ignored: they are read-only once the rule exists.
+        assert rule.name == 'some_rule'
+        assert rule.scanner == YARA
+
+    def test_configuration_default_after_create(self):
+        serializer = ScannerQueryRuleSerializer(
+            data={'name': 'narc_rule', 'scanner': 'narc', 'definition': 'test'}
+        )
+        assert serializer.is_valid(), serializer.errors
+        rule = serializer.save()
+        assert rule.configuration == default_from_schema(NARC_RULE_CONFIGURATION_SCHEMA)
+
+    def test_configuration_can_be_modified(self):
+        rule = self._create_narc_rule()
+        serializer = ScannerQueryRuleSerializer(
+            instance=rule,
+            data={'configuration': {'examine_slug': True}},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        rule = serializer.save()
+        assert rule.configuration == {'examine_slug': True}
+
+    def test_configuration_unknown_key_rejected(self):
+        rule = self._create_narc_rule()
+        serializer = ScannerQueryRuleSerializer(
+            instance=rule,
+            data={'configuration': {'not_a_real_option': True}},
+            partial=True,
+        )
+        assert not serializer.is_valid()
+        assert 'configuration' in serializer.errors
+
+    def test_configuration_wrong_type_rejected(self):
+        rule = self._create_narc_rule()
+        serializer = ScannerQueryRuleSerializer(
+            instance=rule,
+            data={'configuration': {'examine_slug': 'not a boolean'}},
+            partial=True,
+        )
+        assert not serializer.is_valid()
+        assert 'configuration' in serializer.errors
+
+    def test_configuration_rejected_for_yara(self):
+        # yara rules have no configuration options.
+        serializer = ScannerQueryRuleSerializer(
+            data={
+                'name': 'some_rule',
+                'scanner': 'yara',
+                'definition': VALID_YARA_DEFINITION,
+                'configuration': {'examine_slug': True},
+            }
+        )
+        assert not serializer.is_valid()
+        assert 'configuration' in serializer.errors
+
+    def test_run_on_specific_channel_uses_string_constant(self):
+        serializer = ScannerQueryRuleSerializer(
+            data={
+                'name': 'some_rule',
+                'scanner': 'yara',
+                'definition': VALID_YARA_DEFINITION,
+                'run_on_specific_channel': 'listed',
+            }
+        )
+        assert serializer.is_valid(), serializer.errors
+        rule = serializer.save()
+        assert rule.run_on_specific_channel == amo.CHANNEL_LISTED
+        data = ScannerQueryRuleSerializer(rule).data
+        assert data['run_on_specific_channel'] == 'listed'
+
 
 class TestScannerQueryResultSerializer(TestCase):
     def test_serialize(self):
         ScannerQueryRule.objects.create(
             name='some_rule', scanner=YARA, definition=VALID_YARA_DEFINITION
         )
-        version = version_factory(addon=addon_factory(guid='@some-guid'))
+        addon = addon_factory(guid='@some-guid', average_daily_users=123)
+        version = version_factory(addon=addon)
         result = ScannerQueryResult(scanner=YARA, version=version)
         result.add_yara_result(rule='some_rule', meta={'filename': 'foo.js'})
         result.save()
 
         data = ScannerQueryResultSerializer(result).data
+        assert data.keys() == {
+            'id',
+            'was_blocked',
+            'was_promoted',
+            'version',
+            'matches',
+            'created',
+        }
         assert data['id'] == result.pk
-        assert data['scanner_display'] == 'yara'
-        assert data['addon_guid'] == '@some-guid'
-        assert data['version_id'] == version.pk
-        assert data['version_string'] == version.version
+        assert data['was_blocked'] == result.was_blocked
+        assert data['was_promoted'] == result.was_promoted
+        assert data['version'].keys() == {
+            'id',
+            'version',
+            'channel',
+            'created',
+            'addon',
+        }
+        assert data['version']['id'] == version.pk
+        assert data['version']['channel'] == 'listed'
+        assert data['version']['addon'] == {
+            'id': addon.id,
+            'guid': '@some-guid',
+            'average_daily_users': 123,
+        }
         assert 'some_rule' in data['matches']
-        # Raw results are not exposed, only definition-safe match info.
-        assert 'results' not in data

--- a/src/olympia/scanners/tests/test_views.py
+++ b/src/olympia/scanners/tests/test_views.py
@@ -9,12 +9,19 @@ from olympia.amo.tests import (
 from olympia.api.models import APIKey
 from olympia.api.tests.utils import APIKeyAuthTestMixin
 from olympia.constants.scanners import (
+    ABORTING,
+    COMPLETED,
+    NEW,
+    RUNNING,
+    SCHEDULED,
     WEBHOOK,
     WEBHOOK_DURING_VALIDATION,
     WEBHOOK_PUSH,
     YARA,
 )
 from olympia.scanners.models import (
+    ScannerQueryResult,
+    ScannerQueryRule,
     ScannerResult,
     ScannerRule,
     ScannerWebhook,
@@ -419,3 +426,223 @@ class TestPushScannerResult(APIKeyAuthTestMixin, TestCase):
 
         assert response.status_code == 400
         assert response.json() == {'results': ['This field is required.']}
+
+
+VALID_YARA_DEFINITION = 'rule some_rule { condition: true }'
+
+
+class TestScannerQueryRuleViewSet(APIKeyAuthTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.create_api_user()
+        self.grant_permission(
+            self.user, 'Admin:ScannersQueryEdit', 'Scanner query editors'
+        )
+        self.grant_permission(
+            self.user, 'Admin:ScannersQueryView', 'Scanner query viewers'
+        )
+        self.list_url = reverse_ns('scanner-query-rule-list', api_version='v5')
+
+    def _detail_url(self, rule, action=None):
+        name = 'scanner-query-rule-detail'
+        if action:
+            name = f'scanner-query-rule-{action}'
+        return reverse_ns(name, api_version='v5', kwargs={'pk': rule.pk})
+
+    def _create_rule(self, **kwargs):
+        defaults = {
+            'name': 'some_rule',
+            'scanner': YARA,
+            'definition': VALID_YARA_DEFINITION,
+        }
+        defaults.update(kwargs)
+        return ScannerQueryRule.objects.create(**defaults)
+
+    def test_auth_required(self):
+        response = self.client.get(self.list_url)
+        assert response.status_code == 401
+
+    def test_permission_required(self):
+        self.user.groupuser_set.all().delete()
+        response = self.get(self.list_url)
+        assert response.status_code == 403
+
+    def test_view_permission_cannot_create(self):
+        self.user.groupuser_set.all().delete()
+        self.grant_permission(
+            self.user, 'Admin:ScannersQueryView', 'Scanner query viewers'
+        )
+        response = self.post(
+            self.list_url,
+            data={
+                'name': 'some_rule',
+                'scanner': YARA,
+                'definition': VALID_YARA_DEFINITION,
+            },
+            format='json',
+        )
+        assert response.status_code == 403
+
+    def test_list(self):
+        self._create_rule()
+        response = self.get(self.list_url)
+        assert response.status_code == 200
+        assert response.json()['count'] == 1
+
+    def test_create(self):
+        response = self.post(
+            self.list_url,
+            data={
+                'name': 'some_rule',
+                'pretty_name': 'Some rule',
+                'scanner': YARA,
+                'definition': VALID_YARA_DEFINITION,
+            },
+            format='json',
+        )
+        assert response.status_code == 201, response.content
+        rule = ScannerQueryRule.objects.get()
+        assert rule.name == 'some_rule'
+        assert rule.scanner == YARA
+        assert rule.state == NEW
+        data = response.json()
+        assert data['id'] == rule.pk
+        assert data['state_display'] == 'New'
+        # The definition should be echoed back (creator has view access).
+        assert data['definition'] == VALID_YARA_DEFINITION
+
+    def test_create_invalid_definition(self):
+        response = self.post(
+            self.list_url,
+            data={
+                'name': 'some_rule',
+                'scanner': YARA,
+                # Name in definition doesn't match the rule name.
+                'definition': 'rule other_rule { condition: true }',
+            },
+            format='json',
+        )
+        assert response.status_code == 400
+        assert 'definition' in response.json()
+
+    def test_patch_while_new(self):
+        rule = self._create_rule()
+        response = self.patch(
+            self._detail_url(rule),
+            data={'description': 'updated'},
+            format='json',
+        )
+        assert response.status_code == 200, response.content
+        rule.refresh_from_db()
+        assert rule.description == 'updated'
+
+    def test_cannot_patch_once_not_new(self):
+        rule = self._create_rule()
+        rule.update(state=RUNNING)
+        response = self.patch(
+            self._detail_url(rule),
+            data={'description': 'updated'},
+            format='json',
+        )
+        assert response.status_code == 400
+        rule.refresh_from_db()
+        assert rule.description == ''
+
+    def test_delete(self):
+        rule = self._create_rule()
+        response = self.delete(self._detail_url(rule))
+        assert response.status_code == 204
+        assert not ScannerQueryRule.objects.exists()
+
+    @mock.patch('olympia.scanners.views.run_scanner_query_rule')
+    def test_run(self, run_task_mock):
+        rule = self._create_rule()
+        response = self.post(self._detail_url(rule, action='run'))
+        assert response.status_code == 202, response.content
+        rule.refresh_from_db()
+        assert rule.state == SCHEDULED
+        run_task_mock.delay.assert_called_once_with(rule.pk)
+
+    @mock.patch('olympia.scanners.views.run_scanner_query_rule')
+    def test_run_invalid_state(self, run_task_mock):
+        rule = self._create_rule()
+        rule.update(state=COMPLETED)
+        response = self.post(self._detail_url(rule, action='run'))
+        assert response.status_code == 409
+        run_task_mock.delay.assert_not_called()
+
+    def test_abort(self):
+        rule = self._create_rule()
+        rule.update(state=RUNNING)
+        response = self.post(self._detail_url(rule, action='abort'))
+        assert response.status_code == 200
+        rule.refresh_from_db()
+        assert rule.state == ABORTING
+
+    def test_abort_invalid_state(self):
+        rule = self._create_rule()
+        rule.update(state=COMPLETED)
+        response = self.post(self._detail_url(rule, action='abort'))
+        assert response.status_code == 409
+
+
+class TestScannerQueryResultViewSet(APIKeyAuthTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.create_api_user()
+        self.grant_permission(
+            self.user, 'Admin:ScannersQueryView', 'Scanner query viewers'
+        )
+        self.rule = ScannerQueryRule.objects.create(
+            name='some_rule', scanner=YARA, definition=VALID_YARA_DEFINITION
+        )
+        version = version_factory(addon=addon_factory())
+        self.result = ScannerQueryResult(scanner=YARA, version=version)
+        self.result.add_yara_result(rule='some_rule', meta={'filename': 'foo.js'})
+        self.result.save()
+        assert self.result.matched_rule == self.rule
+        self.list_url = self._list_url(self.rule)
+
+    def _list_url(self, rule):
+        return reverse_ns(
+            'scanner-query-rule-result-list',
+            api_version='v5',
+            kwargs={'query_rule_pk': rule.pk},
+        )
+
+    def test_auth_required(self):
+        response = self.client.get(self.list_url)
+        assert response.status_code == 401
+
+    def test_permission_required(self):
+        self.user.groupuser_set.all().delete()
+        response = self.get(self.list_url)
+        assert response.status_code == 403
+
+    def test_list(self):
+        response = self.get(self.list_url)
+        assert response.status_code == 200
+        data = response.json()
+        assert data['count'] == 1
+        assert data['results'][0]['id'] == self.result.pk
+        assert data['results'][0]['matched_rule'] == self.rule.pk
+        assert 'some_rule' in data['results'][0]['matches']
+
+    def test_unknown_rule_returns_404(self):
+        url = reverse_ns(
+            'scanner-query-rule-result-list',
+            api_version='v5',
+            kwargs={'query_rule_pk': 999999},
+        )
+        response = self.get(url)
+        assert response.status_code == 404
+
+    def test_scoped_to_parent_rule(self):
+        other_rule = ScannerQueryRule.objects.create(
+            name='other_rule',
+            scanner=YARA,
+            definition='rule other_rule { condition: true }',
+        )
+        response = self.get(self._list_url(other_rule))
+        assert response.status_code == 200
+        assert response.json()['count'] == 0

--- a/src/olympia/scanners/tests/test_views.py
+++ b/src/olympia/scanners/tests/test_views.py
@@ -468,22 +468,32 @@ class TestScannerQueryRuleViewSet(APIKeyAuthTestMixin, TestCase):
         response = self.get(self.list_url)
         assert response.status_code == 403
 
-    def test_view_permission_cannot_create(self):
+    def test_write_operations_require_edit_permission(self):
+        rule = self._create_rule()
         self.user.groupuser_set.all().delete()
+        # Read-only permission, no write access
         self.grant_permission(
             self.user, 'Admin:ScannersQueryView', 'Scanner query viewers'
         )
-        response = self.post(
-            self.list_url,
-            data={
-                'name': 'some_rule',
-                'scanner': 'yara',
-                'definition': VALID_YARA_DEFINITION,
-            },
-            format='json',
+        detail_url = self._detail_url(rule)
+        payload = {'scanner': 'yara', 'definition': VALID_YARA_DEFINITION}
+
+        assert self.post(self.list_url, data=payload, format='json').status_code == 403
+        assert (
+            self.patch(detail_url, data={'description': 'x'}, format='json').status_code
+            == 403
         )
-        assert response.status_code == 403
-        assert not ScannerQueryRule.objects.exists()
+        assert self.put(detail_url, data=payload, format='json').status_code == 403
+        assert self.delete(detail_url).status_code == 403
+        assert self.post(self._detail_url(rule, action='run')).status_code == 403
+        assert self.post(self._detail_url(rule, action='abort')).status_code == 403
+
+        # Reads still work, and nothing was created, modified or deleted:
+        assert self.get(detail_url).status_code == 200
+        assert ScannerQueryRule.objects.count() == 1
+        rule.refresh_from_db()
+        assert rule.description == ''
+        assert rule.state == NEW
 
     def test_list(self):
         rule = self._create_rule()

--- a/src/olympia/scanners/tests/test_views.py
+++ b/src/olympia/scanners/tests/test_views.py
@@ -477,18 +477,21 @@ class TestScannerQueryRuleViewSet(APIKeyAuthTestMixin, TestCase):
             self.list_url,
             data={
                 'name': 'some_rule',
-                'scanner': YARA,
+                'scanner': 'yara',
                 'definition': VALID_YARA_DEFINITION,
             },
             format='json',
         )
         assert response.status_code == 403
+        assert not ScannerQueryRule.objects.exists()
 
     def test_list(self):
-        self._create_rule()
+        rule = self._create_rule()
         response = self.get(self.list_url)
         assert response.status_code == 200
-        assert response.json()['count'] == 1
+        data = response.json()
+        assert data['count'] == 1
+        assert data['results'][0]['id'] == rule.pk
 
     def test_create(self):
         response = self.post(
@@ -496,7 +499,7 @@ class TestScannerQueryRuleViewSet(APIKeyAuthTestMixin, TestCase):
             data={
                 'name': 'some_rule',
                 'pretty_name': 'Some rule',
-                'scanner': YARA,
+                'scanner': 'yara',
                 'definition': VALID_YARA_DEFINITION,
             },
             format='json',
@@ -508,7 +511,8 @@ class TestScannerQueryRuleViewSet(APIKeyAuthTestMixin, TestCase):
         assert rule.state == NEW
         data = response.json()
         assert data['id'] == rule.pk
-        assert data['state_display'] == 'New'
+        assert data['scanner'] == 'yara'
+        assert data['state'] == 'new'
         # The definition should be echoed back (creator has view access).
         assert data['definition'] == VALID_YARA_DEFINITION
 
@@ -516,15 +520,15 @@ class TestScannerQueryRuleViewSet(APIKeyAuthTestMixin, TestCase):
         response = self.post(
             self.list_url,
             data={
-                'name': 'some_rule',
-                'scanner': YARA,
-                # Name in definition doesn't match the rule name.
-                'definition': 'rule other_rule { condition: true }',
+                'scanner': 'yara',
+                # Missing condition, so it does not compile.
+                'definition': 'rule some_rule { }',
             },
             format='json',
         )
         assert response.status_code == 400
         assert 'definition' in response.json()
+        assert not ScannerQueryRule.objects.exists()
 
     def test_patch_while_new(self):
         rule = self._create_rule()
@@ -548,6 +552,19 @@ class TestScannerQueryRuleViewSet(APIKeyAuthTestMixin, TestCase):
         assert response.status_code == 400
         rule.refresh_from_db()
         assert rule.description == ''
+
+    def test_name_and_scanner_read_only_after_create(self):
+        rule = self._create_rule()
+        response = self.patch(
+            self._detail_url(rule),
+            data={'name': 'renamed', 'scanner': 'narc'},
+            format='json',
+        )
+        assert response.status_code == 200, response.content
+        rule.refresh_from_db()
+        # Both were ignored: read-only once the rule exists.
+        assert rule.name == 'some_rule'
+        assert rule.scanner == YARA
 
     def test_delete(self):
         rule = self._create_rule()
@@ -585,6 +602,8 @@ class TestScannerQueryRuleViewSet(APIKeyAuthTestMixin, TestCase):
         rule.update(state=COMPLETED)
         response = self.post(self._detail_url(rule, action='abort'))
         assert response.status_code == 409
+        rule.refresh_from_db()
+        assert rule.state == COMPLETED
 
 
 class TestScannerQueryResultViewSet(APIKeyAuthTestMixin, TestCase):
@@ -626,7 +645,6 @@ class TestScannerQueryResultViewSet(APIKeyAuthTestMixin, TestCase):
         data = response.json()
         assert data['count'] == 1
         assert data['results'][0]['id'] == self.result.pk
-        assert data['results'][0]['matched_rule'] == self.rule.pk
         assert 'some_rule' in data['results'][0]['matches']
 
     def test_unknown_rule_returns_404(self):
@@ -654,15 +672,26 @@ class TestScannerQueryResultViewSet(APIKeyAuthTestMixin, TestCase):
         adu=0,
         channel=amo.CHANNEL_LISTED,
         was_blocked=None,
+        was_promoted=None,
         is_signed=False,
+        addon_status=amo.STATUS_APPROVED,
+        file_status=amo.STATUS_APPROVED,
+        disabled_by_user=False,
     ):
         version = version_factory(
-            addon=addon_factory(average_daily_users=adu),
+            addon=addon_factory(
+                average_daily_users=adu,
+                status=addon_status,
+                disabled_by_user=disabled_by_user,
+            ),
             channel=channel,
-            file_kw={'is_signed': is_signed},
+            file_kw={'is_signed': is_signed, 'status': file_status},
         )
         result = ScannerQueryResult(
-            scanner=YARA, version=version, was_blocked=was_blocked
+            scanner=YARA,
+            version=version,
+            was_blocked=was_blocked,
+            was_promoted=was_promoted,
         )
         result.add_yara_result(rule='some_rule')
         result.save()
@@ -680,6 +709,14 @@ class TestScannerQueryResultViewSet(APIKeyAuthTestMixin, TestCase):
         assert response.status_code == 200
         assert self._ids(response) == [blocked.pk]
 
+    def test_filter_was_promoted(self):
+        promoted = self._create_result(was_promoted=True)
+        self._create_result(was_promoted=False)
+
+        response = self.get(self.list_url, data={'was_promoted': 'true'})
+        assert response.status_code == 200
+        assert self._ids(response) == [promoted.pk]
+
     def test_filter_was_signed(self):
         signed = self._create_result(is_signed=True)
         self._create_result(is_signed=False)
@@ -689,11 +726,35 @@ class TestScannerQueryResultViewSet(APIKeyAuthTestMixin, TestCase):
         # self.result (setUp) is unsigned, so only the signed one matches.
         assert self._ids(response) == [signed.pk]
 
+    def test_filter_addon_disabled_by_user(self):
+        invisible = self._create_result(disabled_by_user=True)
+        self._create_result(disabled_by_user=False)
+
+        response = self.get(self.list_url, data={'addon_disabled_by_user': 'true'})
+        assert response.status_code == 200
+        assert self._ids(response) == [invisible.pk]
+
+    def test_filter_addon_status(self):
+        disabled = self._create_result(addon_status=amo.STATUS_DISABLED)
+        self._create_result(addon_status=amo.STATUS_APPROVED)
+
+        response = self.get(self.list_url, data={'addon_status': 'disabled'})
+        assert response.status_code == 200
+        assert self._ids(response) == [disabled.pk]
+
+    def test_filter_file_status(self):
+        disabled = self._create_result(file_status=amo.STATUS_DISABLED)
+        self._create_result(file_status=amo.STATUS_APPROVED)
+
+        response = self.get(self.list_url, data={'file_status': 'disabled'})
+        assert response.status_code == 200
+        assert self._ids(response) == [disabled.pk]
+
     def test_filter_channel(self):
         unlisted = self._create_result(channel=amo.CHANNEL_UNLISTED)
         self._create_result(channel=amo.CHANNEL_LISTED)
 
-        response = self.get(self.list_url, data={'channel': amo.CHANNEL_UNLISTED})
+        response = self.get(self.list_url, data={'channel': 'unlisted'})
         assert response.status_code == 200
         assert self._ids(response) == [unlisted.pk]
 
@@ -713,6 +774,18 @@ class TestScannerQueryResultViewSet(APIKeyAuthTestMixin, TestCase):
 
         ids = self._ids(self.get(self.list_url, data={'sort': '-addon_adu'}))
         assert ids.index(high.pk) < ids.index(low.pk)
+
+    def test_order_by_version_created(self):
+        older = self._create_result()
+        newer = self._create_result()
+        older.version.update(created=self.days_ago(10))
+        newer.version.update(created=self.days_ago(1))
+
+        ids = self._ids(self.get(self.list_url, data={'sort': 'version_created'}))
+        assert ids.index(older.pk) < ids.index(newer.pk)
+
+        ids = self._ids(self.get(self.list_url, data={'sort': '-version_created'}))
+        assert ids.index(newer.pk) < ids.index(older.pk)
 
     def test_default_ordering_is_newest_first(self):
         newer = self._create_result()

--- a/src/olympia/scanners/tests/test_views.py
+++ b/src/olympia/scanners/tests/test_views.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from olympia import amo
 from olympia.amo.tests import (
     TestCase,
     addon_factory,
@@ -646,3 +647,75 @@ class TestScannerQueryResultViewSet(APIKeyAuthTestMixin, TestCase):
         response = self.get(self._list_url(other_rule))
         assert response.status_code == 200
         assert response.json()['count'] == 0
+
+    def _create_result(
+        self,
+        *,
+        adu=0,
+        channel=amo.CHANNEL_LISTED,
+        was_blocked=None,
+        is_signed=False,
+    ):
+        version = version_factory(
+            addon=addon_factory(average_daily_users=adu),
+            channel=channel,
+            file_kw={'is_signed': is_signed},
+        )
+        result = ScannerQueryResult(
+            scanner=YARA, version=version, was_blocked=was_blocked
+        )
+        result.add_yara_result(rule='some_rule')
+        result.save()
+        assert result.matched_rule == self.rule
+        return result
+
+    def _ids(self, response):
+        return [r['id'] for r in response.json()['results']]
+
+    def test_filter_was_blocked(self):
+        blocked = self._create_result(was_blocked=True)
+        self._create_result(was_blocked=False)
+
+        response = self.get(self.list_url, data={'was_blocked': 'true'})
+        assert response.status_code == 200
+        assert self._ids(response) == [blocked.pk]
+
+    def test_filter_was_signed(self):
+        signed = self._create_result(is_signed=True)
+        self._create_result(is_signed=False)
+
+        response = self.get(self.list_url, data={'was_signed': 'true'})
+        assert response.status_code == 200
+        # self.result (setUp) is unsigned, so only the signed one matches.
+        assert self._ids(response) == [signed.pk]
+
+    def test_filter_channel(self):
+        unlisted = self._create_result(channel=amo.CHANNEL_UNLISTED)
+        self._create_result(channel=amo.CHANNEL_LISTED)
+
+        response = self.get(self.list_url, data={'channel': amo.CHANNEL_UNLISTED})
+        assert response.status_code == 200
+        assert self._ids(response) == [unlisted.pk]
+
+    def test_invalid_filter_value_returns_400(self):
+        response = self.get(self.list_url, data={'was_blocked': 'notabool'})
+        assert response.status_code == 400
+
+        response = self.get(self.list_url, data={'channel': 'notanint'})
+        assert response.status_code == 400
+
+    def test_order_by_adu(self):
+        low = self._create_result(adu=1)
+        high = self._create_result(adu=1000)
+
+        ids = self._ids(self.get(self.list_url, data={'sort': 'addon_adu'}))
+        assert ids.index(low.pk) < ids.index(high.pk)
+
+        ids = self._ids(self.get(self.list_url, data={'sort': '-addon_adu'}))
+        assert ids.index(high.pk) < ids.index(low.pk)
+
+    def test_default_ordering_is_newest_first(self):
+        newer = self._create_result()
+        # self.result (setUp) is older, self.result.pk < newer.pk.
+        ids = self._ids(self.get(self.list_url))
+        assert ids.index(newer.pk) < ids.index(self.result.pk)

--- a/src/olympia/scanners/views.py
+++ b/src/olympia/scanners/views.py
@@ -1,20 +1,37 @@
+from django.shortcuts import get_object_or_404
+
 from rest_framework import status
 from rest_framework.decorators import (
+    action,
     api_view,
     authentication_classes,
     permission_classes,
 )
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
 import olympia.core.logger
 from olympia import amo
 from olympia.api.authentication import JWTKeyAuthentication
 from olympia.api.permissions import GroupPermission
-from olympia.constants.scanners import WEBHOOK, WEBHOOK_PUSH
+from olympia.constants.scanners import ABORTING, SCHEDULED, WEBHOOK, WEBHOOK_PUSH
 
-from .models import ScannerResult, ScannerWebhook, ScannerWebhookEvent
-from .serializers import PatchScannerResultSerializer, PushScannerResultSerializer
+from .models import (
+    ImproperScannerQueryRuleStateError,
+    ScannerQueryResult,
+    ScannerQueryRule,
+    ScannerResult,
+    ScannerWebhook,
+    ScannerWebhookEvent,
+)
+from .serializers import (
+    PatchScannerResultSerializer,
+    PushScannerResultSerializer,
+    ScannerQueryResultSerializer,
+    ScannerQueryRuleSerializer,
+)
+from .tasks import run_scanner_query_rule
 
 
 log = olympia.core.logger.getLogger('z.scanners.views')
@@ -106,3 +123,97 @@ def patch_scanner_result(request, pk=None):
     )
 
     return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ScannerQueryRuleViewSet(ModelViewSet):
+    """CRUD API for ScannerQueryRules, plus run/abort actions.
+
+    Lets an operator programmatically author a query rule, kick off a run
+    (and abort it) and iterate on the definition. The matches are exposed by
+    the nested ScannerQueryResultViewSet. Only accessible with an API key
+    whose user is in the appropriate admin group.
+
+    Rules can only be edited (PUT/PATCH) while still in the NEW state; once a
+    run has been scheduled the definition is frozen (enforced in the
+    serializer) and a new rule should be created to iterate.
+    """
+
+    authentication_classes = [JWTKeyAuthentication]
+    queryset = ScannerQueryRule.objects.all().order_by('-pk')
+    serializer_class = ScannerQueryRuleSerializer
+
+    def get_permissions(self):
+        if self.action in ('list', 'retrieve'):
+            permission = amo.permissions.ADMIN_SCANNERS_QUERY_VIEW
+        else:
+            permission = amo.permissions.ADMIN_SCANNERS_QUERY_EDIT
+        return [GroupPermission(permission)]
+
+    @action(detail=True, methods=['post'])
+    def run(self, request, pk=None):
+        rule = self.get_object()
+        try:
+            # SCHEDULED is a transitional state (mirroring the admin) allowing
+            # the state to be updated right away; the task switches it to
+            # RUNNING once it starts being processed.
+            rule.change_state_to(SCHEDULED)
+        except ImproperScannerQueryRuleStateError:
+            return Response(
+                {
+                    'detail': (
+                        f'Scanner query rule could not be queued for execution '
+                        f'because it was in "{rule.get_state_display()}" state.'
+                    )
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        run_scanner_query_rule.delay(rule.pk)
+        log.info('Scanner query rule %s has been queued for execution.', rule.pk)
+        return Response(
+            self.get_serializer(rule).data, status=status.HTTP_202_ACCEPTED
+        )
+
+    @action(detail=True, methods=['post'])
+    def abort(self, request, pk=None):
+        rule = self.get_object()
+        try:
+            rule.change_state_to(ABORTING)
+        except ImproperScannerQueryRuleStateError:
+            return Response(
+                {
+                    'detail': (
+                        f'Scanner query rule could not be aborted because it '
+                        f'was in "{rule.get_state_display()}" state.'
+                    )
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        log.info('Scanner query rule %s is being aborted.', rule.pk)
+        return Response(self.get_serializer(rule).data, status=status.HTTP_200_OK)
+
+
+class ScannerQueryResultViewSet(ReadOnlyModelViewSet):
+    """Read-only API to browse the matches (ScannerQueryResults) of a rule.
+
+    Nested under ScannerQueryRuleViewSet, so the results are always scoped to
+    a single parent rule: ``/scanner/query-rules/{query_rule_pk}/results/``."""
+
+    authentication_classes = [JWTKeyAuthentication]
+    serializer_class = ScannerQueryResultSerializer
+
+    def get_permissions(self):
+        return [GroupPermission(amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)]
+
+    def get_rule_object(self):
+        if not hasattr(self, 'rule_object'):
+            self.rule_object = get_object_or_404(
+                ScannerQueryRule, pk=self.kwargs['query_rule_pk']
+            )
+        return self.rule_object
+
+    def get_queryset(self):
+        return (
+            self.get_rule_object()
+            .results.select_related('version__addon')
+            .order_by('-pk')
+        )

--- a/src/olympia/scanners/views.py
+++ b/src/olympia/scanners/views.py
@@ -1,7 +1,6 @@
-from django.db.models import F
 from django.shortcuts import get_object_or_404
 
-from rest_framework import filters, serializers, status
+from rest_framework import serializers, status
 from rest_framework.decorators import (
     action,
     api_view,
@@ -15,6 +14,7 @@ from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 import olympia.core.logger
 from olympia import amo
 from olympia.api.authentication import JWTKeyAuthentication
+from olympia.api.filters import OrderingAliasFilter
 from olympia.api.permissions import GroupPermission
 from olympia.constants.scanners import ABORTING, SCHEDULED, WEBHOOK, WEBHOOK_PUSH
 
@@ -197,31 +197,33 @@ class ScannerQueryResultViewSet(ReadOnlyModelViewSet):
     a single parent rule: ``/scanner/query-rules/{query_rule_pk}/results/``.
 
     Supports filtering by the query params in ``boolean_filters`` and
-    ``integer_filters``, and ordering via ``?sort=`` (see ``ordering_fields``).
+    ``choice_filters``, and ordering via ``?sort=`` (see
+    ``ordering_field_aliases``).
     """
 
     authentication_classes = [JWTKeyAuthentication]
+    permission_classes = [GroupPermission(amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)]
     serializer_class = ScannerQueryResultSerializer
-    filter_backends = [filters.OrderingFilter]
-    # `addon_adu` and `version_created` are annotations added in get_queryset().
-    ordering_fields = ('id', 'addon_adu', 'version_created')
+    filter_backends = [OrderingAliasFilter]
+    ordering_fields = ('id',)
+    # `?sort= names`` mapping to the underlying (related) fields.
+    ordering_field_aliases = {
+        'addon_adu': 'version__addon__average_daily_users',
+        'version_created': 'version__created',
+    }
     ordering = ('-id',)
 
-    # Public query param -> ORM lookup.
     boolean_filters = {
         'was_blocked': 'was_blocked',
         'was_promoted': 'was_promoted',
         'was_signed': 'version__file__is_signed',
         'addon_disabled_by_user': 'version__addon__disabled_by_user',
     }
-    integer_filters = {
-        'channel': 'version__channel',
-        'addon_status': 'version__addon__status',
-        'file_status': 'version__file__status',
+    choice_filters = {
+        'channel': ('version__channel', amo.CHANNEL_CHOICES_LOOKUP),
+        'addon_status': ('version__addon__status', amo.STATUS_CHOICES_API_LOOKUP),
+        'file_status': ('version__file__status', amo.STATUS_CHOICES_API_LOOKUP),
     }
-
-    def get_permissions(self):
-        return [GroupPermission(amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)]
 
     def get_rule_object(self):
         if not hasattr(self, 'rule_object'):
@@ -234,10 +236,6 @@ class ScannerQueryResultViewSet(ReadOnlyModelViewSet):
         qs = self.get_rule_object().results.select_related(
             'version__addon', 'version__file'
         )
-        qs = qs.annotate(
-            addon_adu=F('version__addon__average_daily_users'),
-            version_created=F('version__created'),
-        )
         return self.filter_by_params(qs)
 
     def filter_by_params(self, qs):
@@ -245,9 +243,10 @@ class ScannerQueryResultViewSet(ReadOnlyModelViewSet):
         for param, lookup in self.boolean_filters.items():
             if param in params:
                 qs = qs.filter(**{lookup: self._parse_bool(param, params[param])})
-        for param, lookup in self.integer_filters.items():
+        for param, (lookup, mapping) in self.choice_filters.items():
             if param in params:
-                qs = qs.filter(**{lookup: self._parse_int(param, params[param])})
+                value = self._parse_choice(param, params[param], mapping)
+                qs = qs.filter(**{lookup: value})
         return qs
 
     @staticmethod
@@ -258,8 +257,11 @@ class ScannerQueryResultViewSet(ReadOnlyModelViewSet):
             raise ParseError(f'Invalid boolean value for "{param}".') from exc
 
     @staticmethod
-    def _parse_int(param, value):
+    def _parse_choice(param, value, mapping):
         try:
-            return int(value)
-        except (TypeError, ValueError) as exc:
-            raise ParseError(f'Invalid integer value for "{param}".') from exc
+            return mapping[value]
+        except KeyError as exc:
+            allowed = ', '.join(sorted(mapping))
+            raise ParseError(
+                f'Invalid value for "{param}". Allowed values: {allowed}.'
+            ) from exc

--- a/src/olympia/scanners/views.py
+++ b/src/olympia/scanners/views.py
@@ -19,7 +19,6 @@ from olympia.constants.scanners import ABORTING, SCHEDULED, WEBHOOK, WEBHOOK_PUS
 
 from .models import (
     ImproperScannerQueryRuleStateError,
-    ScannerQueryResult,
     ScannerQueryRule,
     ScannerResult,
     ScannerWebhook,
@@ -169,9 +168,7 @@ class ScannerQueryRuleViewSet(ModelViewSet):
             )
         run_scanner_query_rule.delay(rule.pk)
         log.info('Scanner query rule %s has been queued for execution.', rule.pk)
-        return Response(
-            self.get_serializer(rule).data, status=status.HTTP_202_ACCEPTED
-        )
+        return Response(self.get_serializer(rule).data, status=status.HTTP_202_ACCEPTED)
 
     @action(detail=True, methods=['post'])
     def abort(self, request, pk=None):

--- a/src/olympia/scanners/views.py
+++ b/src/olympia/scanners/views.py
@@ -1,13 +1,14 @@
+from django.db.models import F
 from django.shortcuts import get_object_or_404
 
-from rest_framework import status
+from rest_framework import filters, serializers, status
 from rest_framework.decorators import (
     action,
     api_view,
     authentication_classes,
     permission_classes,
 )
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
@@ -193,10 +194,31 @@ class ScannerQueryResultViewSet(ReadOnlyModelViewSet):
     """Read-only API to browse the matches (ScannerQueryResults) of a rule.
 
     Nested under ScannerQueryRuleViewSet, so the results are always scoped to
-    a single parent rule: ``/scanner/query-rules/{query_rule_pk}/results/``."""
+    a single parent rule: ``/scanner/query-rules/{query_rule_pk}/results/``.
+
+    Supports filtering by the query params in ``boolean_filters`` and
+    ``integer_filters``, and ordering via ``?sort=`` (see ``ordering_fields``).
+    """
 
     authentication_classes = [JWTKeyAuthentication]
     serializer_class = ScannerQueryResultSerializer
+    filter_backends = [filters.OrderingFilter]
+    # `addon_adu` and `version_created` are annotations added in get_queryset().
+    ordering_fields = ('id', 'addon_adu', 'version_created')
+    ordering = ('-id',)
+
+    # Public query param -> ORM lookup.
+    boolean_filters = {
+        'was_blocked': 'was_blocked',
+        'was_promoted': 'was_promoted',
+        'was_signed': 'version__file__is_signed',
+        'addon_disabled_by_user': 'version__addon__disabled_by_user',
+    }
+    integer_filters = {
+        'channel': 'version__channel',
+        'addon_status': 'version__addon__status',
+        'file_status': 'version__file__status',
+    }
 
     def get_permissions(self):
         return [GroupPermission(amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)]
@@ -209,8 +231,35 @@ class ScannerQueryResultViewSet(ReadOnlyModelViewSet):
         return self.rule_object
 
     def get_queryset(self):
-        return (
-            self.get_rule_object()
-            .results.select_related('version__addon')
-            .order_by('-pk')
+        qs = self.get_rule_object().results.select_related(
+            'version__addon', 'version__file'
         )
+        qs = qs.annotate(
+            addon_adu=F('version__addon__average_daily_users'),
+            version_created=F('version__created'),
+        )
+        return self.filter_by_params(qs)
+
+    def filter_by_params(self, qs):
+        params = self.request.query_params
+        for param, lookup in self.boolean_filters.items():
+            if param in params:
+                qs = qs.filter(**{lookup: self._parse_bool(param, params[param])})
+        for param, lookup in self.integer_filters.items():
+            if param in params:
+                qs = qs.filter(**{lookup: self._parse_int(param, params[param])})
+        return qs
+
+    @staticmethod
+    def _parse_bool(param, value):
+        try:
+            return serializers.BooleanField().to_internal_value(value)
+        except serializers.ValidationError as exc:
+            raise ParseError(f'Invalid boolean value for "{param}".') from exc
+
+    @staticmethod
+    def _parse_int(param, value):
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise ParseError(f'Invalid integer value for "{param}".') from exc


### PR DESCRIPTION
Fixes [#16332](https://github.com/mozilla/addons/issues/16332).

### Description

This patch adds a REST API for `ScannerQueryRule` and `ScannerQueryResult`, so scanner query rules can be created, run, aborted, and iterated on programmatically instead of only through the Django admin.

New endpoints (JWT API-key auth; reads gated by `ADMIN_SCANNERS_QUERY_VIEW`, writes/run/abort by `ADMIN_SCANNERS_QUERY_EDIT`):

- `GET/POST /api/v5/scanner/query-rules/`: list / create a query rule.
- `GET/PATCH/PUT/DELETE /api/v5/scanner/query-rules/{id}/`: read / edit / delete.
  - Editing is only allowed while the rule is `new`.
  - `name` and `scanner` are frozen after creation.
  - For `yara` rules the `name` is inferred from the definition (matching the admin) and required for `narc`.
- `POST /api/v5/scanner/query-rules/{id}/run/`: schedule a run (enqueues `run_scanner_query_rule`).
- `POST /api/v5/scanner/query-rules/{id}/abort/`: abort a run.
- `GET /api/v5/scanner/query-rules/{id}/results/`: the rule's matches (nested read-only viewset).
  - Supports filtering (`was_blocked`, `was_promoted`, `was_signed`, `addon_disabled_by_user`, `channel`, `addon_status`, `file_status`),
  - and ordering (`?sort=` one of `id`, `addon_adu`, `version_created`, prefix `-` for descending).
  - Each result exposes a minimal nested `version` (with its `addon` `guid`/`average_daily_users`).

### Context

Scanner query rules (ad-hoc YARA/NARC rules run across the whole add-on corpus) can currently only be authored and run via django admin. This exposes the same lifecycle over HTTP so that an iteration loop can be automated.

### Testing

1. Grant a user the `Admin:ScannersQueryView` and `Admin:ScannersQueryEdit` groups and get a JWT API key for them.
2. `POST /api/v5/scanner/query-rules/` with `{"scanner": "yara", "definition": "rule my_rule { condition: true }"}` --> expect 201. The response has `scanner: "yara"`, `state: "new"`, and `name` inferred as `"my_rule"` from the definition (for `narc`, `name` is required).
  a) Posting an uncompilable definition --> expect 400 with a `definition` error.
3. `POST /api/v5/scanner/query-rules/{id}/run/` --> expect 202. The rule `state` becomes `"scheduled"`, and a `run_scanner_query_rule` task is enqueued.
  a) Running a non-`new` rule --> expect 409.
4. Poll `GET /api/v5/scanner/query-rules/{id}/` and watch `state`/`completion_rate`/`completed`.
  a) Once complete, `GET .../{id}/results/` returns the matches; try filtering/sorting, e.g. `?was_blocked=true`, `?channel=listed`, `?sort=-addon_adu`.
5. `PATCH` a `new` rule --> expect 200.
  a) `PATCH` a non-`new` rule --> expect 400.
  b) Requests without a valid JWT key --> expect 401.
  c) Requests with a key lacking permissions --> expect 403.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add or update relevant [docs](../docs/) reflecting the changes made.
