### PR TITLE
Exclude theme review from anything policy-review-selection related

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -463,6 +463,10 @@ class TestReviewHelper(TestReviewHelperBase):
             == expected
         )
 
+    @override_switch('enable-policy-review-selection', active=True)
+    def test_actions_public_static_theme_with_policy_review_selection(self):
+        self.test_actions_public_static_theme()
+
     def test_actions_no_version(self):
         """Addons with no versions in that channel have no version set."""
         expected = []

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -533,7 +533,7 @@ class ReviewHelper:
         use_content_rejection = self.content_review and waffle.switch_is_active(
             'enable-content-rejection'
         )
-        policy_selection_enabled = waffle.switch_is_active(
+        policy_selection_enabled = not is_static_theme and waffle.switch_is_active(
             'enable-policy-review-selection'
         )
 
@@ -574,7 +574,6 @@ class ReviewHelper:
             'label': 'Positive Review',
             'available': (
                 policy_selection_enabled
-                and not is_static_theme
                 and not self.content_review
                 and is_appropriate_reviewer
             ),
@@ -594,7 +593,6 @@ class ReviewHelper:
             'label': 'Negative Review',
             'available': (
                 policy_selection_enabled
-                and not is_static_theme
                 and not self.content_review
                 and is_appropriate_reviewer
             ),
@@ -751,7 +749,7 @@ class ReviewHelper:
                 'This will approve the selected versions. '
                 'The comments will be sent to the developer.'
             ),
-            'available': (not policy_selection_enabled and can_approve_multiple),
+            'available': not policy_selection_enabled and can_approve_multiple,
             'enforcement_actions': (DECISION_ACTIONS.AMO_APPROVE,),
             'resolves_cinder_jobs': True,
         }


### PR DESCRIPTION
Fixes mozilla/addons#16321

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Makes approve and reject reviewer actions available to theme review again, by making a blanket exclusion of policy review selection actions for themes.

### Context

Previously we had a(n increasingly complicated) set of criteria for determining if a reviewer action should be available when `enable-policy-review-selection` was enabled, and was disabled.  Themes were supposed to be excluded from the changes, but one of the patches introduced a regression.

Theme review will eventually switch over to use policy-review-selection too, but not at launch (and some issues like https://github.com/mozilla/addons/issues/16261 need to be done too)

### Testing

- enable waffle switch 'enable-policy-review-selection`
- navigate to the review page for the theme
  - if you don't already have a theme, upload a theme (upload an xpi or use the theme wizard)
- see approve and reject actions are available for themes

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
