### PR TITLE
drop obsolete tested on fields in review form

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -516,8 +516,6 @@ class ReviewForm(forms.Form):
         label='Versions:',
     )  # queryset is set later in __init__.
 
-    operating_systems = forms.CharField(required=False, label='Operating systems:')
-    applications = forms.CharField(required=False, label='Applications:')
     delayed_rejection = forms.NullBooleanField(
         initial=False,
         required=False,
@@ -875,15 +873,6 @@ class ReviewForm(forms.Form):
         self.fields['cinder_policies'].widget.helper_actions = self.helper.actions
 
         self.fields['policy_values'].queryset = self.fields['cinder_policies'].queryset
-
-    @property
-    def unreviewed_files(self):
-        return (
-            (self.helper.version.file,)
-            if self.helper.version
-            and self.helper.version.file.status == amo.STATUS_AWAITING_REVIEW
-            else ()
-        )
 
 
 class MOTDForm(forms.Form):

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -258,33 +258,6 @@
           {{ form.cinder_jobs_to_resolve.errors }}
       </div>
 
-      <div class="review-actions-section review-actions-files data-toggle review-files"
-           data-value="{{ actions_full|join(' ') }}">
-        <label><strong>Files:</strong></label>
-        <ul>
-          {% for file in form.unreviewed_files %}
-          <li>
-            {{ file.pretty_filename }} &middot;
-            {{ file.get_review_status_display() }}
-          </li>
-          {% endfor %}
-        </ul>
-      </div>
-
-      <div class="review-actions-section review-actions-tested data-toggle review-tested"
-           data-value="{{ actions_full|join(' ') }}">
-        <strong>Tested on:</strong>
-        <label>
-          {{ form.operating_systems.label }}
-        </label>
-        {{ form.operating_systems }}
-        <label>
-          {{ form.applications.label }}
-        </label>
-        {{ form.applications }}
-        {{ form.operating_systems.errors }}
-        {{ form.applications.errors }}
-      </div>
       {% if form.delayed_rejection and form.delayed_rejection_date %}
         <div class="review-actions-section data-toggle review-delayed-rejection"
              data-value="{{ toggle_when_action('delayable') }}">

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -123,12 +123,7 @@ class TestReviewHelperBase(TestCase):
         self.helper.set_data(data)
 
     def get_data(self):
-        return {
-            'comments': 'foo',
-            'action': 'public',
-            'operating_systems': 'osx',
-            'applications': 'Firefox',
-        }
+        return {'comments': 'foo', 'action': 'public'}
 
     def get_helper(self, content_review=False, human_review=True):
         return ReviewHelper(

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2435,11 +2435,7 @@ class ReviewBase(QueueTest):
         return Addon.objects.get(pk=self.addon.pk)
 
     def get_dict(self, **kw):
-        data = {
-            'operating_systems': 'win',
-            'applications': 'some app',
-            'comments': 'some comment',
-        }
+        data = {'comments': 'some comment'}
         data.update(kw)
         return data
 
@@ -3450,12 +3446,7 @@ class TestReview(ReviewBase):
         check_entry(version_history)
 
     def test_files_in_item_history(self):
-        data = {
-            'action': 'public',
-            'operating_systems': 'win',
-            'applications': 'something',
-            'comments': 'something',
-        }
+        data = {'action': 'public', 'comments': 'something'}
         self.client.post(self.url, data)
 
         response = self.client.get(self.url)
@@ -4142,8 +4133,6 @@ class TestReview(ReviewBase):
 
         data = {
             'action': action,
-            'operating_systems': 'win',
-            'applications': 'some app',
             'comments': 'some comment',
             'cinder_policies': [policy.id],
             'versions': [version.pk],
@@ -5955,11 +5944,6 @@ class TestReview(ReviewBase):
             'reject_multiple_versions',
         ]
 
-        # We don't have approve/reject actions so these have an empty
-        # data-value.
-        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
-        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
-
     def test_test_data_value_attributes_admin(self):
         AutoApprovalSummary.objects.create(
             verdict=amo.AUTO_APPROVED, version=self.version
@@ -6075,11 +6059,6 @@ class TestReview(ReviewBase):
             'data-value'
         ].split(' ') == ['approve_multiple_versions', 'reject_multiple_versions']
 
-        # We don't have approve/reject actions so these have an empty
-        # data-value.
-        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
-        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
-
         assert doc('.data-toggle.review-delayed-rejection')[0].attrib[
             'data-value'
         ].split(' ') == [
@@ -6105,8 +6084,6 @@ class TestReview(ReviewBase):
         assert not doc('select#id_versions.data-toggle')[0]
         assert doc('.data-toggle.review-comments')[0].attrib['data-value'] == ''
         assert doc('.data-toggle.review-actions-policies')[0].attrib['data-value'] == ''
-        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
-        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
 
         # Viewer won't see delayed rejection inputs, need a reviewer.
         assert not doc('.data-toggle.review-delayed-rejection')
@@ -6142,14 +6119,6 @@ class TestReview(ReviewBase):
             'reply',
             'request_legal_review',
             'comment',
-        ]
-        assert doc('.data-toggle.review-files')[0].attrib['data-value'].split(' ') == [
-            'public',
-            'reject',
-        ]
-        assert doc('.data-toggle.review-tested')[0].attrib['data-value'].split(' ') == [
-            'public',
-            'reject',
         ]
         assert doc('.data-toggle.review-actions-policies')[0].attrib[
             'data-value'
@@ -6191,12 +6160,9 @@ class TestReview(ReviewBase):
             'request_legal_review',
             'comment',
         ]
-        # we don't show files, reasons, and tested with for any static theme actions
-        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
         assert doc('.data-toggle.review-actions-policies')[0].attrib[
             'data-value'
         ].split(' ') == ['reject', 'reject_multiple_versions']
-        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
 
     def test_post_review_ignore_disabled(self):
         # Though the latest version will be disabled, the add-on is public and

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -581,12 +581,6 @@ def review(request, addon, channel=None):
         .order_by('-created')
         .first()
     )
-    # The actions we shouldn't show a minimal form for.
-    # FIXME: the full/minimal distinction is obsolete - we don't use the extra fields
-    actions_full = []
-    for key, action in actions:
-        if not (is_static_theme or action.get('minimal')):
-            actions_full.append(key)
 
     addons_sharing_same_guid = (
         Addon.unfiltered.all()
@@ -694,7 +688,6 @@ def review(request, addon, channel=None):
             and request.user.is_staff
         ),
         actions=actions,
-        actions_full=actions_full,
         addon=addon,
         addons_sharing_same_guid=addons_sharing_same_guid,
         approvals_info=approvals_info,


### PR DESCRIPTION
Fixes mozilla/addons#16337

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Remove the tested on fields for the reviewer review form, that were no longer used. 

### Context

The values for these fields stopped being saved when we refactored the reviewer tools to use the ActionClasses, but they've remained as optional on the form.  But they stopped being _useful_ a long, long time before that when xul add-ons and binary components meant there could be differences between operating systems, and we supported a wide variety of applications.

### Testing

- Go to a review page in the reviewer tools for an add-on and do normal things.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
