### PR TITLE
fix bug with admin filters and ScannerRule fk referencing an callable iterable

### DIFF
--- a/src/olympia/abuse/tests/test_admin.py
+++ b/src/olympia/abuse/tests/test_admin.py
@@ -644,6 +644,51 @@ class TestCinderPolicyAdmin(TestCase):
         self.login(permission='CinderPolicies:View')
         self._make_list_request(read_only=True)
 
+    def test_list_with_filter(self):
+        self.login()
+        CinderPolicy.objects.create(
+            name='Published Policy',
+            uuid=uuid.uuid4(),
+            status_in_cinder=CinderPolicy.POLICY_STATUSES.PUBLISHED,
+            expose_in_reviewer_tools=POLICY_EXPOSURE.BOTH,
+        )
+        CinderPolicy.objects.create(
+            name='Archived Policy',
+            uuid=uuid.uuid4(),
+            status_in_cinder=CinderPolicy.POLICY_STATUSES.ARCHIVED,
+            expose_in_reviewer_tools=POLICY_EXPOSURE.NONE,
+        )
+        CinderPolicy.objects.create(
+            name='Draft Policy',
+            uuid=uuid.uuid4(),
+            status_in_cinder=CinderPolicy.POLICY_STATUSES.DRAFT,
+            expose_in_reviewer_tools=POLICY_EXPOSURE.EXTENSION,
+        )
+
+        # Filter by status_in_cinder=PUBLISHED
+        response = self.client.get(
+            self.list_url,
+            {'status_in_cinder__exact': CinderPolicy.POLICY_STATUSES.PUBLISHED},
+        )
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('#result_list tbody tr')) == 1
+        assert 'Published Policy' in doc('#result_list').text()
+        assert 'Archived Policy' not in doc('#result_list').text()
+        assert 'Draft Policy' not in doc('#result_list').text()
+
+        # Filter by expose_in_reviewer_tools=EXTENSION
+        response = self.client.get(
+            self.list_url,
+            {'expose_in_reviewer_tools__exact': POLICY_EXPOSURE.EXTENSION},
+        )
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('#result_list tbody tr')) == 1
+        assert 'Draft Policy' in doc('#result_list').text()
+        assert 'Published Policy' not in doc('#result_list').text()
+        assert 'Archived Policy' not in doc('#result_list').text()
+
     def _make_edit_request(self, expected_status_code):
         policy = CinderPolicy.objects.create(
             name='Bar', uuid=uuid.uuid4(), expose_in_reviewer_tools=POLICY_EXPOSURE.NONE

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -328,7 +328,7 @@ class ScannerRule(AbstractScannerRule):
             'Policy used to automatically derive an action from when the rule hit.'
         ),
         limit_choices_to={
-            'expose_in_reviewer_tools__in': POLICY_EXPOSURE.FOR_EXTENSIONS
+            'expose_in_reviewer_tools__in': POLICY_EXPOSURE.FOR_EXTENSIONS.values
         },
     )
     is_active = models.BooleanField(


### PR DESCRIPTION
Fixes mozilla/addons#16347

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

see issue - fixing a regression.

### Context

<!--
Often a pull request contains changes that are not fully self explanatory. Maybe this PR is a part of a series,
or maybe it is a partial change now with a more ambitious plan for the future. Add this additional context here.
If it is not relevant for your PR, remove this section.
-->

### Testing

http://olympia.test/admin/models/abuse/cinderpolicy/?status_in_cinder__exact=1 or another filter

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
