### PR TITLE
CRUD for PromotedGroup via django admin

### DIFF
--- a/src/olympia/promoted/admin.py
+++ b/src/olympia/promoted/admin.py
@@ -119,12 +119,10 @@ class PromotedGroupAdmin(AMOModelAdmin):
     ]
     list_filter = list_display
     search_fields = ('name',)
+    readonly_fields = ('badged',)
 
-    def has_add_permission(self, request, obj=None):
-        return False
+    # def has_change_permission(self, request, obj=None):
+    #     return False
 
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
+    # def has_delete_permission(self, request, obj=None):
+    #     return False

--- a/src/olympia/promoted/admin.py
+++ b/src/olympia/promoted/admin.py
@@ -120,9 +120,3 @@ class PromotedGroupAdmin(AMOModelAdmin):
     list_filter = list_display
     search_fields = ('name',)
     readonly_fields = ('badged',)
-
-    # def has_change_permission(self, request, obj=None):
-    #     return False
-
-    # def has_delete_permission(self, request, obj=None):
-    #     return False

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -51,12 +51,18 @@ class PromotedGroup(models.Model):
     )
     api_name = models.CharField(
         max_length=100,
-        help_text='Programmatic API name for the promotion group.',
+        help_text=(
+            'Programmatic API name for the promotion group - be careful with changes '
+            'as some api_names are referenced in constants. If the group is public, '
+            'changing this value will trigger a reindex of all add-ons in this group.'
+        ),
         unique=True,
     )
     search_ranking_bump = models.FloatField(
         help_text=(
-            'Boost value used to influence search ranking for add-ons in this group.'
+            'For public groups, boost value used to influence search ranking for '
+            'add-ons in this group. '
+            'Changing this value will trigger a reindex for those add-ons.'
         ),
         default=0.0,
     )
@@ -72,9 +78,13 @@ class PromotedGroup(models.Model):
     )
     badged = models.BooleanField(
         default=False,
-        help_text='Specifies if the add-on receives a badge upon promotion.',
+        help_text=(
+            'Specifies if the add-on receives a badge upon promotion. '
+            'Changes require a patch to update constants.'
+        ),
     )
     autograph_signing_states = models.JSONField(
+        blank=True,
         default=dict,
         help_text='Mapping of application shorthand to autograph signing states.',
     )
@@ -103,13 +113,46 @@ class PromotedGroup(models.Model):
     is_public = models.BooleanField(
         default=True,
         help_text=(
-            'Marks whether this promotion group is public (accessible via the API).'
+            'Marks whether this promotion group is public (accessible via the API). '
+            'Changing this value will trigger a reindex of all add-ons in this group.'
         ),
     )
     objects = PromotedGroupManager()
 
     def __str__(self):
         return self.name
+
+    def save(self, *args, **kwargs):
+        pre_save = None if not self.pk else PromotedGroup.objects.get(pk=self.pk)
+        super().save(*args, **kwargs)
+        if pre_save is not None and (
+            pre_save.is_public != self.is_public
+            or self.is_public
+            and (
+                pre_save.search_ranking_bump != self.search_ranking_bump
+                or pre_save.api_name != self.api_name
+            )
+        ):
+            from olympia.addons.tasks import index_addons
+
+            addon_ids = list(
+                self.promotedaddon_set.values_list('addon_id', flat=True).distinct()
+            )
+            if addon_ids:
+                index_addons.delay(addon_ids)
+
+    def delete(self, *args, **kwargs):
+        addon_ids = (
+            list(self.promotedaddon_set.values_list('addon_id', flat=True).distinct())
+            if self.is_public
+            else []
+        )
+        super().delete(*args, **kwargs)
+
+        if addon_ids:
+            from olympia.addons.tasks import index_addons
+
+            index_addons.delay(addon_ids)
 
 
 class PromotedAddon(ModelBase):

--- a/src/olympia/promoted/tests/test_admin.py
+++ b/src/olympia/promoted/tests/test_admin.py
@@ -1,3 +1,6 @@
+import json
+from unittest import mock
+
 from django.urls import reverse
 
 from olympia import amo
@@ -59,6 +62,85 @@ class TestDiscoveryPromotedGroupAdmin(TestCase):
         self.client.force_login(user)
         response = self.client.get(reverse(self.list_url_name), follow=True)
         assert response.status_code == 403
+
+    def _get_promotedgroup_form(self, group, **overrides):
+        """Return POST form data reflecting the given group's current state.
+
+        Pass a keyword argument with value None to explicitly remove that key
+        (e.g. ``is_public=None`` to leave the checkbox unchecked/False).
+        """
+        data = {
+            'name': group.name,
+            'api_name': group.api_name,
+            'search_ranking_bump': str(group.search_ranking_bump),
+            'autograph_signing_states': json.dumps(group.autograph_signing_states),
+        }
+        for field in (
+            'listed_pre_review',
+            'unlisted_pre_review',
+            'admin_review',
+            'can_primary_hero',
+            'immediate_approval',
+            'flag_for_human_review',
+            'can_be_compatible_with_all_fenix_versions',
+            'high_profile',
+            'high_profile_rating',
+            'is_public',
+        ):
+            if getattr(group, field):
+                data[field] = 'on'
+        for key, value in overrides.items():
+            if value is None:
+                data.pop(key, None)
+            else:
+                data[key] = value
+        return data
+
+    @mock.patch('olympia.addons.tasks.index_addons.delay')
+    def test_update_is_public_triggers_index_addons(self, index_addons_mock):
+        group = PromotedGroup.objects.create(
+            name='Test Group', api_name='test_toggle_public', is_public=True
+        )
+        addon = addon_factory(promoted_kwargs={'api_name': group.api_name})
+        user = user_factory(email='someone@mozilla.com')
+        self.grant_permission(user, '*:*')
+        self.client.force_login(user)
+        change_url = reverse(
+            'admin:discovery_discoverypromotedgroup_change', args=[group.pk]
+        )
+        index_addons_mock.reset_mock()
+
+        # Submit without 'is_public' to flip it to False
+        response = self.client.post(
+            change_url,
+            self._get_promotedgroup_form(group, is_public=None),
+            follow=True,
+        )
+        assert response.status_code == 200
+        group.refresh_from_db()
+        assert not group.is_public
+        assert index_addons_mock.call_count == 1
+        assert index_addons_mock.call_args[0] == ([addon.pk],)
+
+    @mock.patch('olympia.addons.tasks.index_addons.delay')
+    def test_delete_triggers_index_addons(self, index_addons_mock):
+        group = PromotedGroup.objects.create(
+            name='Test Delete Group', api_name='test_delete_group', is_public=True
+        )
+        addon = addon_factory(promoted_kwargs={'api_name': group.api_name})
+        user = user_factory(email='someone@mozilla.com')
+        self.grant_permission(user, '*:*')
+        self.client.force_login(user)
+        delete_url = reverse(
+            'admin:discovery_discoverypromotedgroup_delete', args=[group.pk]
+        )
+        index_addons_mock.reset_mock()
+
+        response = self.client.post(delete_url, {'post': 'yes'}, follow=True)
+        assert response.status_code == 200
+        assert not PromotedGroup.objects.filter(pk=group.pk).exists()
+        assert index_addons_mock.call_count == 1
+        assert index_addons_mock.call_args[0] == ([addon.pk],)
 
 
 class TestDiscoveryAddonAdmin(TestCase):

--- a/src/olympia/promoted/tests/test_models.py
+++ b/src/olympia/promoted/tests/test_models.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.db import IntegrityError, transaction
 
 from olympia.addons.models import Addon
@@ -100,6 +102,69 @@ class TestPromotedGroup(TestCase):
         # Ensure the __str__ method returns the name
         for pg in PromotedGroup.objects.all():
             self.assertEqual(str(pg), pg.name)
+
+    @mock.patch('olympia.addons.tasks.index_addons.delay')
+    def test_save_on_create_does_not_trigger_index_addons(self, index_addons_mock):
+        PromotedGroup.objects.create(name='Test Group', api_name='test_create_group')
+        assert index_addons_mock.call_count == 0
+
+    @mock.patch('olympia.addons.tasks.index_addons.delay')
+    def test_save_is_public_change_triggers_index_addons(self, index_addons_mock):
+        group = PromotedGroup.objects.create(
+            name='Test Group', api_name='test_group_public_change', is_public=True
+        )
+        addon = addon_factory(promoted_kwargs={'api_name': group.api_name})
+        index_addons_mock.reset_mock()
+
+        group.is_public = False
+        group.save()
+
+        assert index_addons_mock.call_count == 1
+        assert index_addons_mock.call_args[0] == ([addon.pk],)
+
+    @mock.patch('olympia.addons.tasks.index_addons.delay')
+    def _test_field_changes_triggers_when_public(self, field, index_addons_mock):
+        group = PromotedGroup.objects.create(
+            name='Test Group', api_name='test_group_bump', is_public=False
+        )
+        addon = addon_factory(promoted_kwargs={'api_name': group.api_name})
+        index_addons_mock.reset_mock()
+
+        setattr(group, field, 2.0)
+        group.save()
+
+        # should not trigger index_addons because the group is not public
+        assert index_addons_mock.call_count == 0
+
+        # Now make the group public and save again
+        group.is_public = True
+        group.save()
+        index_addons_mock.reset_mock()  # ignore this index
+
+        setattr(group, field, 3.0)
+        group.save()
+        assert index_addons_mock.call_count == 1
+        assert index_addons_mock.call_args[0] == ([addon.pk],)
+
+    def test_save_api_name_change_triggers_when_public(self):
+        self._test_field_changes_triggers_when_public('api_name')
+
+    def test_save_search_ranking_bump_change_triggers_when_public(self):
+        self._test_field_changes_triggers_when_public('search_ranking_bump')
+
+    @mock.patch('olympia.addons.tasks.index_addons.delay')
+    def test_save_unrelated_change_does_not_trigger_index_addons(
+        self, index_addons_mock
+    ):
+        group = PromotedGroup.objects.create(
+            name='Test Group', api_name='test_group_unrelated', is_public=True
+        )
+        index_addons_mock.reset_mock()
+
+        group.name = 'Test Group Renamed'
+        group.save()
+
+        assert index_addons_mock.call_count == 0
 
 
 class TestPromotedAddon(TestCase):


### PR DESCRIPTION
Fixes mozilla/addons#16342

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Enables django admin create, update, and delete for PromotedGroup instances so add-ons Operations (well, admins) can manage PromotedGroups themselves.  Triggers elasticsearch reindexes if changes are made to public groups.

### Context

Changing badged groups isn't possible unless/until we resolve https://github.com/mozilla/addons/issues/16341

I did consider adding further guard-rails for public groups - especially badged groups - because frontend is going exhibit changes immediately if you do something such as changing api_name, but left it at a warning in the field label instead. It's complicated - api_names such as spotlight have side-effects (e.g. warning being removed) that we can't account for in addons-server, and `notable` isn't even a public group and it's api_name is important.  For now, it's locked down to `*:*` anyway, but especially if it's opened up to users with narrower permissions we should reconsider more guard-rails.

### Testing

- edit a promoted group in http://olympia.test/admin/models/discovery/discoverypromotedgroup/
- create a new group and/or delete a group
- to test the reindexing is triggered you can:
  - select/create a promoted group
  - add an add-on to the group in http://olympia.test/admin/models/discovery/discoveryaddon/ 
  - either update  with is_public=True or update the api_name of the grou
  - see the promoted group is correctly exposed in `http://olympia.test/api/v5/addons/search/?q=<whatever the add-on is named>`

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
