### PR TITLE
Reduce number of database queries made by Scanner Query Rules

### DIFF
--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -327,15 +327,15 @@ def _run_narc(*, scanner_result, version, rules=None):
         }
     )
     addon = version.addon
-    attach_trans_dict(Addon, [addon], field_names=['name', 'summary'])
+    if not hasattr(addon, 'translations'):
+        attach_trans_dict(Addon, [addon], field_names=['name', 'summary'])
     name_values_from_db = dict(addon.translations[addon.name_id])
     summary_values_from_db = dict(addon.translations[addon.summary_id])
-    values_from_authors = list(
-        addon.authors.all()
-        .exclude(display_name=None)
-        .values_list('display_name', flat=True)
-    )
-
+    values_from_authors = [
+        author.display_name
+        for author in addon.authors.all()
+        if author.display_name is not None
+    ]
     # Because we're running on a Version, not a FileUpload, we should already
     # have a FileManifest, so we don't even need to parse the XPI to grab the
     # fields we want to look at - we can just build a dict with the data needed
@@ -723,20 +723,37 @@ def run_scanner_query_rule_on_versions_chunk(version_pks, query_rule_pk):
             rule.get_state_display(),
         )
         return
-    for version_pk in version_pks:
+    qs = (
+        Version.unfiltered.all()
+        .select_related('addon__addonguid', 'blockversion')
+        .prefetch_related('addon__promotedaddon')
+        .no_transforms()
+        .filter(pk__in=version_pks)
+        .order_by('pk')
+    )
+    if rule.scanner == NARC:
+        qs = qs.select_related('addon', 'file__file_manifest').prefetch_related(
+            # We don't need their roles or whether they are listed, so we can
+            # use a simple prefetch. Otherwise this would not work correctly,
+            # see Addon._attach_authors().
+            'addon__authors'
+        )
+        # Attaching translations is not lazy so do this last, it evaluates the
+        # queryset.
+        attach_trans_dict(
+            Addon, [version.addon for version in qs], field_names=['name', 'summary']
+        )
+    results = []
+    for version in qs:
         try:
-            version = (
-                Version.unfiltered.all()
-                .select_related('addon__addonguid')
-                .no_transforms()
-                .get(pk=version_pk)
-            )
-            _run_scanner_query_rule_on_version(version, rule)
+            if result := _run_scanner_query_rule_on_version(version, rule):
+                results.append(result)
         except Exception:
             log.exception(
                 'Error in run_scanner_query_rule_on_version task for Version %s.',
-                version_pk,
+                version.pk,
             )
+    ScannerQueryResult.objects.bulk_create(results)
 
 
 def _run_scanner_query_rule_on_version(version, rule):
@@ -755,9 +772,13 @@ def _run_scanner_query_rule_on_version(version, rule):
     # Unlike ScannerResult, we only want to save ScannerQueryResult if there is
     # a match, there would be too many things to save otherwise and we don't
     # really care about non-matches.
-    if scanner_result.results:
-        scanner_result.was_blocked = version.is_blocked
-        scanner_result.was_promoted = version.addon.is_promoted
-        scanner_result.save()
+    if not scanner_result.results:
+        return None
 
+    # Make sure to use our prefetch_related() here to avoid extra queries.
+    scanner_result.was_blocked = version.is_blocked
+    scanner_result.was_promoted = version.addon.promotedaddon.exists()
+    # We're going to create results in bulk in the parent, bypassing .save() so
+    # we need to add the matched_rule ourselves.
+    scanner_result.matched_rule = rule
     return scanner_result

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -7,6 +7,7 @@ from django.core.files import File as DjangoFile
 from django.test.utils import override_settings
 
 import requests
+import waffle
 from waffle.testutils import override_switch
 
 from olympia import amo
@@ -2263,6 +2264,55 @@ class TestRunYaraQueryRule(TestRunQueryRuleMixin, TestCase):
         self.rule.reload()
         assert self.rule.state == RUNNING  # Not touched by this task.
 
+    def test_run_on_chunk_num_queries(self):
+        # Extra addons shouldn't affect number of queries.
+        extra_addon1 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        extra_addon2 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        # Make the rule not match to avoid queries when saving results, we
+        # don't care about those at this time.
+        self.rule.update(
+            definition='rule always_false { condition: false }',
+            name='always_false',
+            state=RUNNING,
+        )
+        # Force waffle switch to be cached to not affect queries count.
+        waffle.switch_is_active('use-yara-x')
+        with self.assertNumQueries(3):
+            # - 1 for the rule
+            # - 1 for all promoted addon info (prefetched even if no match)
+            # - 1 for all versions + file
+            run_scanner_query_rule_on_versions_chunk(
+                [
+                    self.version.pk,
+                    extra_addon1.current_version.pk,
+                    extra_addon2.current_version.pk,
+                ],
+                self.rule.pk,
+            )
+        assert ScannerQueryResult.objects.count() == 0
+
+    def test_run_on_chunk_num_queries_matching(self):
+        # Extra addons shouldn't affect number of queries.
+        extra_addon1 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        extra_addon2 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        self.rule.update(state=RUNNING)
+        # Force waffle switch to be cached to not affect queries count.
+        waffle.switch_is_active('use-yara-x')
+        with self.assertNumQueries(4):
+            # - 1 for the rule
+            # - 1 for all versions + file
+            # - 1 for all promoted addon info
+            # - 1 for bulk-saving all results
+            run_scanner_query_rule_on_versions_chunk(
+                [
+                    self.version.pk,
+                    extra_addon1.current_version.pk,
+                    extra_addon2.current_version.pk,
+                ],
+                self.rule.pk,
+            )
+        assert ScannerQueryResult.objects.count() == 3
+
 
 @override_switch(name='use-yara-x', active=True)
 class TestRunYaraXQueryRule(TestRunYaraQueryRule):
@@ -2321,6 +2371,55 @@ class TestRunNarcQueryRule(TestRunQueryRuleMixin, TestCase):
         ]
         self.rule.reload()
         assert self.rule.state == RUNNING  # Not touched by this task.
+
+    def test_run_on_chunk_num_queries(self):
+        # Extra addons shouldn't affect number of queries.
+        extra_addon1 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        extra_addon2 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        # Make the rule not match to avoid queries when saving results, we
+        # don't care about those at this time.
+        self.rule.update(
+            definition='willnotmatchanything',
+            name='willnotmatchanything',
+            state=RUNNING,
+        )
+        with self.assertNumQueries(5):
+            # - 1 for the rule
+            # - 1 for all promoted addon info (prefetched even if no match)
+            # - 1 for all authors
+            # - 1 for all translations
+            # - 1 for all versions + file
+            run_scanner_query_rule_on_versions_chunk(
+                [
+                    self.version.pk,
+                    extra_addon1.current_version.pk,
+                    extra_addon2.current_version.pk,
+                ],
+                self.rule.pk,
+            )
+        assert ScannerQueryResult.objects.count() == 0
+
+    def test_run_on_chunk_num_queries_matching(self):
+        # Extra addons shouldn't affect number of queries.
+        extra_addon1 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        extra_addon2 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        self.rule.update(state=RUNNING)
+        with self.assertNumQueries(6):
+            # - 1 for the rule
+            # - 1 for all versions + file
+            # - 1 for all authors
+            # - 1 for all translations
+            # - 1 for all promoted addon info
+            # - 1 for bulk-saving all results
+            run_scanner_query_rule_on_versions_chunk(
+                [
+                    self.version.pk,
+                    extra_addon1.current_version.pk,
+                    extra_addon2.current_version.pk,
+                ],
+                self.rule.pk,
+            )
+        assert ScannerQueryResult.objects.count() == 3
 
 
 class TestCallWebhooks(UploadMixin, TestCase):

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -2266,8 +2266,15 @@ class TestRunYaraQueryRule(TestRunQueryRuleMixin, TestCase):
 
     def test_run_on_chunk_num_queries(self):
         # Extra addons shouldn't affect number of queries.
-        extra_addon1 = addon_factory(file_kw={'filename': 'webextension.xpi'})
-        extra_addon2 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        extra_addon1_version1 = addon_factory(
+            file_kw={'filename': 'webextension.xpi'}
+        ).current_version
+        extra_addon2_version1 = addon_factory(
+            file_kw={'filename': 'webextension.xpi'}
+        ).current_version
+        extra_addon2_version2 = version_factory(
+            addon=extra_addon2_version1.addon, file_kw={'filename': 'webextension.xpi'}
+        )
         # Make the rule not match to avoid queries when saving results, we
         # don't care about those at this time.
         self.rule.update(
@@ -2284,8 +2291,9 @@ class TestRunYaraQueryRule(TestRunQueryRuleMixin, TestCase):
             run_scanner_query_rule_on_versions_chunk(
                 [
                     self.version.pk,
-                    extra_addon1.current_version.pk,
-                    extra_addon2.current_version.pk,
+                    extra_addon1_version1.pk,
+                    extra_addon2_version1.pk,
+                    extra_addon2_version2.pk,
                 ],
                 self.rule.pk,
             )
@@ -2293,8 +2301,15 @@ class TestRunYaraQueryRule(TestRunQueryRuleMixin, TestCase):
 
     def test_run_on_chunk_num_queries_matching(self):
         # Extra addons shouldn't affect number of queries.
-        extra_addon1 = addon_factory(file_kw={'filename': 'webextension.xpi'})
-        extra_addon2 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        extra_addon1_version1 = addon_factory(
+            file_kw={'filename': 'webextension.xpi'}
+        ).current_version
+        extra_addon2_version1 = addon_factory(
+            file_kw={'filename': 'webextension.xpi'}
+        ).current_version
+        extra_addon2_version2 = version_factory(
+            addon=extra_addon2_version1.addon, file_kw={'filename': 'webextension.xpi'}
+        )
         self.rule.update(state=RUNNING)
         # Force waffle switch to be cached to not affect queries count.
         waffle.switch_is_active('use-yara-x')
@@ -2306,12 +2321,13 @@ class TestRunYaraQueryRule(TestRunQueryRuleMixin, TestCase):
             run_scanner_query_rule_on_versions_chunk(
                 [
                     self.version.pk,
-                    extra_addon1.current_version.pk,
-                    extra_addon2.current_version.pk,
+                    extra_addon1_version1.pk,
+                    extra_addon2_version1.pk,
+                    extra_addon2_version2.pk,
                 ],
                 self.rule.pk,
             )
-        assert ScannerQueryResult.objects.count() == 3
+        assert ScannerQueryResult.objects.count() == 4
 
 
 @override_switch(name='use-yara-x', active=True)
@@ -2374,8 +2390,15 @@ class TestRunNarcQueryRule(TestRunQueryRuleMixin, TestCase):
 
     def test_run_on_chunk_num_queries(self):
         # Extra addons shouldn't affect number of queries.
-        extra_addon1 = addon_factory(file_kw={'filename': 'webextension.xpi'})
-        extra_addon2 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        extra_addon1_version1 = addon_factory(
+            file_kw={'filename': 'webextension.xpi'}
+        ).current_version
+        extra_addon2_version1 = addon_factory(
+            file_kw={'filename': 'webextension.xpi'}
+        ).current_version
+        extra_addon2_version2 = version_factory(
+            addon=extra_addon2_version1.addon, file_kw={'filename': 'webextension.xpi'}
+        )
         # Make the rule not match to avoid queries when saving results, we
         # don't care about those at this time.
         self.rule.update(
@@ -2392,8 +2415,9 @@ class TestRunNarcQueryRule(TestRunQueryRuleMixin, TestCase):
             run_scanner_query_rule_on_versions_chunk(
                 [
                     self.version.pk,
-                    extra_addon1.current_version.pk,
-                    extra_addon2.current_version.pk,
+                    extra_addon1_version1.pk,
+                    extra_addon2_version1.pk,
+                    extra_addon2_version2.pk,
                 ],
                 self.rule.pk,
             )
@@ -2401,8 +2425,15 @@ class TestRunNarcQueryRule(TestRunQueryRuleMixin, TestCase):
 
     def test_run_on_chunk_num_queries_matching(self):
         # Extra addons shouldn't affect number of queries.
-        extra_addon1 = addon_factory(file_kw={'filename': 'webextension.xpi'})
-        extra_addon2 = addon_factory(file_kw={'filename': 'webextension.xpi'})
+        extra_addon1_version1 = addon_factory(
+            file_kw={'filename': 'webextension.xpi'}
+        ).current_version
+        extra_addon2_version1 = addon_factory(
+            file_kw={'filename': 'webextension.xpi'}
+        ).current_version
+        extra_addon2_version2 = version_factory(
+            addon=extra_addon2_version1.addon, file_kw={'filename': 'webextension.xpi'}
+        )
         self.rule.update(state=RUNNING)
         with self.assertNumQueries(6):
             # - 1 for the rule
@@ -2414,12 +2445,13 @@ class TestRunNarcQueryRule(TestRunQueryRuleMixin, TestCase):
             run_scanner_query_rule_on_versions_chunk(
                 [
                     self.version.pk,
-                    extra_addon1.current_version.pk,
-                    extra_addon2.current_version.pk,
+                    extra_addon1_version1.pk,
+                    extra_addon2_version1.pk,
+                    extra_addon2_version2.pk,
                 ],
                 self.rule.pk,
             )
-        assert ScannerQueryResult.objects.count() == 3
+        assert ScannerQueryResult.objects.count() == 4
 
 
 class TestCallWebhooks(UploadMixin, TestCase):


### PR DESCRIPTION
### Description

Optimize number of queries made by scanner query rules

### Context

Scanner query rules run against a bunch of versions in the database. As we have millions of versions in the database, a rule is divided into chunks that each process up to 250 versions.

Before this change, assuming a chunk of 250 versions, each chunk would execute:
- 251 queries for yara + 4 per match
- 1,001 queries for narc + 4 per match (!)

After this change, the same chunk of 250 versions would execute:
- 3 queries for yara + 1 for all matches
- 5 queries for narc + 1 for all matches

The main query for each chunk now has a bunch of joins so it's more costly, but given the number of queries it saves the tradeoff should be worth it.

Fixes mozilla/addons#16346

### Testing

We should have robust unit tests covering this. Scanner query rules can be created and triggered through the admin tools: http://olympia.test/en-US/admin/models/scanners/scannerqueryrule/