### PR TITLE
Send accurate reminder emails using ContentDecision instances

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1483,13 +1483,16 @@ class ContentDecision(ModelBase):
             return
 
         action_helper = self.get_action_helper()
-        log_entry = self.activities.exclude(
-            action=amo.LOG.REVIEWER_PRIVATE_COMMENT.id
-        ).last()
 
         if self.cinder_job:
             self.cinder_job.notify_reporters(action_helper)
 
+        if not notify_owners:
+            return
+
+        log_entry = self.activities.exclude(
+            action=amo.LOG.REVIEWER_PRIVATE_COMMENT.id
+        ).last()
         if self.addon_id:
             details = (log_entry and log_entry.details) or {}
             is_auto_approval = (
@@ -1526,10 +1529,9 @@ class ContentDecision(ModelBase):
         else:
             extra_context = {}
 
-        if notify_owners:
-            action_helper.notify_owners(
-                log_entry_id=getattr(log_entry, 'id', None), extra_context=extra_context
-            )
+        action_helper.notify_owners(
+            log_entry_id=getattr(log_entry, 'id', None), extra_context=extra_context
+        )
 
     def get_target_review_url(self):
         return reverse('reviewers.decision_review', kwargs={'decision_id': self.id})

--- a/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
+++ b/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
@@ -5,8 +5,7 @@ from django.core.management.base import BaseCommand
 import olympia.core.logger
 from olympia import amo
 from olympia.abuse.actions import ContentActionRejectVersionDelayed
-from olympia.abuse.models import CinderJob, ContentDecision
-from olympia.activity.models import ActivityLog
+from olympia.abuse.models import ContentDecision
 from olympia.addons.models import Addon, AddonReviewerFlags
 from olympia.constants.abuse import DECISION_ACTIONS
 
@@ -60,56 +59,55 @@ class Command(BaseCommand):
         )
 
     def notify_developers(self, *, addon, versions):
-        # Fetch the activity log to retrieve the comments to include in the
-        # email. There is no global one, so we just take the latest we can find
-        # for those versions with a delayed rejection action.
-        relevant_activity_log = (
-            ActivityLog.objects.for_versions(versions)
-            .filter(
-                action__in=(
-                    amo.LOG.REJECT_CONTENT_DELAYED.id,
-                    amo.LOG.REJECT_VERSION_DELAYED.id,
-                )
+        rejection_decisions = (
+            ContentDecision.objects.filter(
+                action_date__isnull=False,
+                overridden_by__isnull=True,
+                target_versions__in=versions,
+                action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON,
             )
-            .last()
+            .order_by('id')
+            .distinct()
         )
-        if (
-            not relevant_activity_log
-            or not relevant_activity_log.details
-            or not relevant_activity_log.details.get('comments')
-        ):
+
+        if not rejection_decisions.exists():
             log.info(
                 'Skipping notification about versions pending rejections for '
-                'add-on %s since there is no activity log or comments.',
+                'add-on %s since there are no decisions.',
                 addon.pk,
             )
             return
         log.info('Sending email for %s' % addon)
-        cinder_job = (
-            CinderJob.objects.filter(pending_rejections__version__in=versions)
-            .distinct()
-            .first()
-        )
-        # We just need the decision to send an accurate email
-        decision = (
-            final_decision
-            if cinder_job and (final_decision := cinder_job.final_decision)
-            # Fake a decision if there isn't a job
-            else ContentDecision(
-                addon=addon,
-                action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON,
+
+        for decision in rejection_decisions:
+            action_helper = ContentActionRejectVersionDelayed(decision)
+            relevant_activity_log = decision.activities.filter(
+                action__in=(
+                    amo.LOG.REJECT_CONTENT_DELAYED.id,
+                    amo.LOG.REJECT_VERSION_DELAYED.id,
+                )
+            ).last()
+            if not relevant_activity_log:
+                log.warning(
+                    'No relevant activity log found for decision %s, skipping '
+                    'notification for add-on %s',
+                    decision.pk,
+                    addon.pk,
+                )
+                continue
+            decision_versions = decision.target_versions.filter(
+                id__in=versions
+            ).values_list('version', flat=True)
+            action_helper.notify_owners(
+                log_entry_id=relevant_activity_log.id,
+                extra_context={
+                    'delayed_rejection_days': self.EXPIRING_PERIOD_DAYS,
+                    'version_list': ', '.join(decision_versions),
+                    'policy_texts': relevant_activity_log.details.get(
+                        'policy_texts', ()
+                    ),
+                },
             )
-        )
-        decision.reasoning = relevant_activity_log.details.get('comments', '')
-        action_helper = ContentActionRejectVersionDelayed(decision)
-        action_helper.notify_owners(
-            log_entry_id=relevant_activity_log.id,
-            extra_context={
-                'delayed_rejection_days': self.EXPIRING_PERIOD_DAYS,
-                'version_list': ', '.join(str(v.version) for v in versions),
-                'policy_texts': relevant_activity_log.details.get('policy_texts', ()),
-            },
-        )
 
         # Note that we did this so that we don't notify developers of this
         # add-on again until next rejection.

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1027,19 +1027,62 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
     def setUpTestData(cls):
         cls.user = user_factory(pk=settings.TASK_USER_ID)
 
+    def _setup_pending_rejection(
+        self,
+        *,
+        addon,
+        versions=None,
+        pending_rejection=None,
+        create_flags=True,
+        log_action=None,
+        followup_actions=(),
+        **decision_kwargs,
+    ):
+        """Set up an add-on with versions pending rejection: flag the versions,
+        create the matching delayed rejection activity logs and the
+        ``ContentDecision`` those activity logs belong to. Any actions passed in
+        ``followup_actions`` are attached to the decision as
+        ``ContentDecisionFollowupAction``s. Returns the decision."""
+        versions = list(addon.versions.all()) if versions is None else versions
+        pending_rejection = pending_rejection or datetime.now() + timedelta(hours=23)
+        log_action = log_action or amo.LOG.REJECT_VERSION_DELAYED
+
+        decision_kwargs.setdefault(
+            'action', DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON
+        )
+        decision_kwargs.setdefault('action_date', datetime.now())
+        comments = 'fôo'
+        decision = ContentDecision.objects.create(
+            addon=addon, reasoning=comments, **decision_kwargs
+        )
+        decision.target_versions.set(versions)
+        for followup_action in followup_actions:
+            ContentDecisionFollowupAction.objects.create(
+                decision=decision, action=followup_action
+            )
+        for version in versions:
+            if create_flags:
+                version_review_flags_factory(
+                    version=version, pending_rejection=pending_rejection
+                )
+            # Passing the decision connects the activity log to it, like the
+            # actual rejection would have done.
+            ActivityLog.objects.create(
+                log_action,
+                addon,
+                version,
+                decision,
+                details={'comments': comments},
+                user=self.user,
+            )
+        return decision
+
     def test_not_pending_rejection(self):
         author = user_factory()
         addon = addon_factory(users=[author])
         version_factory(addon=addon)
-        for version in addon.versions.all():
-            # Add some activity logs, but no pending_rejection flag.
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        # Set up the activity logs and decision, but no pending_rejection flag.
+        self._setup_pending_rejection(addon=addon, create_flags=False)
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 0
 
@@ -1047,17 +1090,9 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         author = user_factory()
         addon = addon_factory(users=[author])
         version_factory(addon=addon)
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(days=2)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(
+            addon=addon, pending_rejection=datetime.now() + timedelta(days=2)
+        )
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 0
 
@@ -1065,17 +1100,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         author = user_factory()
         addon = addon_factory(users=[author])
         version_factory(addon=addon)
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(addon=addon)
         # Disabled by user: we don't notify.
         addon.update(disabled_by_user=True)
         call_command('send_pending_rejection_last_warning_notifications')
@@ -1095,19 +1120,10 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         author = user_factory()
         addon = addon_factory(users=[author])
         version_factory(addon=addon)
+        self._setup_pending_rejection(addon=addon)
+        # Disable the files: we should be left with no versions to notify the
+        # developers about, since they have already been disabled.
         for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
-            # Disable file: we should be left with no versions to notify the
-            # developers about, since they have already been disabled.
             version.file.update(status=amo.STATUS_DISABLED)
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 0
@@ -1116,17 +1132,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         author = user_factory()
         addon = addon_factory(users=[author])
         version_factory(addon=addon, file_kw={'status': amo.STATUS_DISABLED})
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(addon=addon)
         # Add another version not pending rejection but unreviewed: we should
         # not notify developers in that case.
         version_factory(addon=addon, file_kw={'status': amo.STATUS_AWAITING_REVIEW})
@@ -1137,17 +1143,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         author = user_factory()
         addon = addon_factory(users=[author])
         version_factory(addon=addon, file_kw={'status': amo.STATUS_DISABLED})
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(addon=addon)
         # Add another version public and not pending rejection: we should
         # not notify developers in that case.
         version_factory(addon=addon)
@@ -1163,17 +1159,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             addon=addon, notified_about_expiring_delayed_rejections=True
         )
         version_factory(addon=addon)
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(addon=addon)
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 0
 
@@ -1183,17 +1169,10 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             users=[author], version_kw={'version': amo.DEFAULT_WEBEXT_MIN_VERSION}
         )
         version_factory(addon=addon, version='42.1')
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'Some cômments'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(
+            addon=addon,
+            followup_actions=[DECISION_ACTIONS.AMO_FU_DELAY_MID_SOFT_BLOCK_ADDON],
+        )
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 1
         assert addon.reviewerflags.notified_about_expiring_delayed_rejections
@@ -1202,49 +1181,32 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             message.subject == f'Mozilla Add-ons: {addon.name} [ref:Addon#{addon.id}]'
         )
         assert message.to == [author.email]
-        assert 'Some cômments' in message.body
+        assert 'fôo' in message.body
         for version in addon.versions.all():
             assert version.version in message.body
         assert 'right to appeal' not in message.body
         assert 'assessment performed on our own initiative' in message.body
         assert 'received from a third party' not in message.body
+        # The follow-up actions attached to the decision are listed in the email.
+        assert 'additional enforcement actions will be taken' in message.body
+        assert 'Add-on versions will be Restricted, after 14 days' in message.body
 
     def test_pending_rejection_close_to_deadline_with_cinder_job(self):
         author = user_factory()
         addon = addon_factory(
             users=[author], version_kw={'version': amo.DEFAULT_WEBEXT_MIN_VERSION}
         )
-        version = addon.current_version
         version_factory(addon=addon, version='42.1')
-        cinder_job = CinderJob.objects.create(
-            job_id='1',
-            decision=ContentDecision.objects.create(
-                cinder_id='13579',
-                action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON,
-                addon=addon,
-            ),
-        )
+        decision = self._setup_pending_rejection(addon=addon, cinder_id='13579')
+        cinder_job = CinderJob.objects.create(job_id='1', decision=decision)
         AbuseReport.objects.create(guid=addon.guid, cinder_job=cinder_job)
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'Some cômments'},
-                user=self.user,
-            )
-        # The job was resolved with the first rejection, but will still be picked up.
-        cinder_job.pending_rejections.add(version.reviewerflags)
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 1
         assert addon.reviewerflags.notified_about_expiring_delayed_rejections
         message = mail.outbox[0]
         assert message.subject == f'Mozilla Add-ons: {addon.name} [ref:13579]'
         assert message.to == [author.email]
-        assert 'Some cômments' in message.body
+        assert 'fôo' in message.body
         for version in addon.versions.all():
             assert version.version in message.body
         assert 'right to appeal' not in message.body
@@ -1260,17 +1222,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         disabled_version = version_factory(
             addon=addon, version='42.1', file_kw={'status': amo.STATUS_DISABLED}
         )
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(addon=addon)
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 1
         assert addon.reviewerflags.notified_about_expiring_delayed_rejections
@@ -1287,17 +1239,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         )
         version1 = addon.current_version
         version2 = version_factory(addon=addon, version='42.1')
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(addon=addon)
         more_recent_version = version_factory(
             addon=addon, file_kw={'status': amo.STATUS_DISABLED}, version='42.2'
         )
@@ -1318,17 +1260,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         )
         version1 = addon.current_version
         version2 = version_factory(addon=addon, version='42.1')
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(addon=addon)
         more_recent_version = version_factory(addon=addon, version='43.0')
         more_recent_version.delete()
         call_command('send_pending_rejection_last_warning_notifications')
@@ -1348,17 +1280,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         )
         version1 = addon.current_version
         version2 = version_factory(addon=addon, version='42.1')
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(addon=addon)
         more_recent_version = version_factory(addon=addon, version='43.0')
         version_review_flags_factory(
             version=more_recent_version,
@@ -1385,17 +1307,12 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         addon2 = addon_factory(users=[author2], version_kw={'version': '22.0'})
         version21 = addon2.current_version
         version22 = version_factory(addon=addon2, version='22.1')
-        for version in Version.objects.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_CONTENT_DELAYED,
-                version.addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(
+            addon=addon1, log_action=amo.LOG.REJECT_CONTENT_DELAYED
+        )
+        self._setup_pending_rejection(
+            addon=addon2, log_action=amo.LOG.REJECT_CONTENT_DELAYED
+        )
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 2
         assert addon1.reviewerflags.notified_about_expiring_delayed_rejections
@@ -1415,18 +1332,18 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         assert version21.version in message.body
         assert version22.version in message.body
 
-    def test_somehow_no_activity_log_skip(self):
+    def test_no_decision_skip(self):
         author = user_factory()
         addon = addon_factory(users=[author])
         version_factory(addon=addon)
+        # There is no matching decision for those versions, so we should not
+        # send the notification here.
         for version in addon.versions.all():
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            # The ActivityLog doesn't match a pending rejection, so we should
-            # not send the notification here.
             ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION,
+                amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
                 details={'comments': 'fôo'},
@@ -1435,58 +1352,67 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 0
 
-    def test_somehow_no_activity_log_details_skip(self):
+    def test_decision_not_actioned_skip(self):
         author = user_factory()
         addon = addon_factory(users=[author])
         version_factory(addon=addon)
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            # The ActivityLog doesn't have details, so we should
-            # not send the notification here.
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED, addon, version, user=self.user
-            )
+        # The decision hasn't been actioned yet (no action_date), so we should
+        # not send the notification here.
+        self._setup_pending_rejection(addon=addon, action_date=None)
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 0
 
-    def test_somehow_no_activity_log_comments_skip(self):
+    def test_decision_overridden_skip(self):
         author = user_factory()
         addon = addon_factory(users=[author])
         version_factory(addon=addon)
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            # The ActivityLog doesn't have comments, so we should
-            # not send the notification here.
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                user=self.user,
-                details={'foo': 'bar'},
-            )
+        # The decision has been overridden by a later one, so we should not
+        # send the notification here.
+        decision = self._setup_pending_rejection(addon=addon)
+        ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_APPROVE_VERSION,
+            action_date=datetime.now(),
+            override_of=decision,
+        )
         call_command('send_pending_rejection_last_warning_notifications')
         assert len(mail.outbox) == 0
+
+    def test_multiple_decisions_for_versions(self):
+        author = user_factory()
+        addon = addon_factory(
+            users=[author], version_kw={'version': amo.DEFAULT_WEBEXT_MIN_VERSION}
+        )
+        version_1 = addon.current_version
+        version_2 = version_factory(addon=addon, version='42.1')
+        # Two separate rejection decisions cover the versions pending rejection
+        # (e.g. a second rejection was issued for further policy violations). We
+        # send a reminder email for each of them.
+        self._setup_pending_rejection(
+            addon=addon, versions=[version_1], cinder_id='11111'
+        )
+        self._setup_pending_rejection(
+            addon=addon, versions=[version_2], cinder_id='22222'
+        )
+        call_command('send_pending_rejection_last_warning_notifications')
+        assert len(mail.outbox) == 2
+        assert addon.reviewerflags.notified_about_expiring_delayed_rejections
+        assert {message.subject for message in mail.outbox} == {
+            f'Mozilla Add-ons: {addon.name} [ref:11111]',
+            f'Mozilla Add-ons: {addon.name} [ref:22222]',
+        }
+        for message in mail.outbox:
+            assert message.to == [author.email]
+            assert 'fôo' in message.body
+        assert version_1.version in mail.outbox[0].body
+        assert version_2.version in mail.outbox[1].body
 
     def test_multiple_developers_are_notified(self):
         author1 = user_factory()
         author2 = user_factory()
         addon = addon_factory(users=[author1, author2])
         version_factory(addon=addon)
-        for version in addon.versions.all():
-            version_review_flags_factory(
-                version=version, pending_rejection=datetime.now() + timedelta(hours=23)
-            )
-            ActivityLog.objects.create(
-                amo.LOG.REJECT_VERSION_DELAYED,
-                addon,
-                version,
-                details={'comments': 'fôo'},
-                user=self.user,
-            )
+        self._setup_pending_rejection(addon=addon)
         more_recent_version = version_factory(addon=addon)
         version_review_flags_factory(
             version=more_recent_version,

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -1170,6 +1170,8 @@ class VersionReviewerFlags(ModelBase):
         UserProfile, null=True, on_delete=models.CASCADE
     )
     pending_content_rejection = models.BooleanField(null=True)
+    # Note, this is unused when 'enable-policy-review-selection' is enabled
+    # Remove this field when the switch is removed.
     pending_resolution_cinder_jobs = models.ManyToManyField(
         to='abuse.CinderJob', related_name='pending_rejections'
     )


### PR DESCRIPTION
Fixes mozilla/addons#16260

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Make delayed rejection reminder command always use the correct decision, so follow-up actions are mentioned in the email.

### Context

This differs to the changes made for auto_reject and auto_approve, where the changes were put behind the policy enforcement waffle switch - in this case the command was already calling the ActionClass code to send the email out, but previously would only use the correct decision when there was a CinderJob.

### Testing

- enable waffle switch `enable-policy-review-selection` (in django admin or [cmd line](https://mozilla.github.io/addons-server/topics/development/waffle.html))
- Enable at least one policies with enforcement action amo-reject-version-warning-addon - and preferably with a follow-up action - for the reviewer tools.  e.g. policy with uuid `0d2d9701-80c4-40ff-840c-dfe1d1cadd75`.  Use django admin or django shell to `CinderPolicy.get(uuid='0d2d9701-80c4-40ff-840c-dfe1d1cadd75').update(expose_in_reviewer_tools=1)`
- in reviewer tools, navigate to the review page for an extension, select `Negative Review` reviewer action, choose a policy (e.g. "Acceptable Use, specifically Minor exploitation") that has a "Add-on version delayed reject warning" enforcement action.
- choose one or more versions to reject and save the review
- see the email to the developer(s) in [fake email](https://mozilla.github.io/addons-server/topics/models/amo/FakeEmail.html) in django admin or django shell.  It should mention the policy that was violated; that the version will be rejected in X days; (and the follow-up actions from the policy)
- we need to update the delayed rejection date so we can trigger the reminder email immediately.  Easiest way is to update the VersionReviewerFlags instance(s) that hold the dates.  Use django admin, something like `VersionReviewerFlags.objects.filter(version__addon_id=<the pk of the addon you reviewed>, pending_rejection__isnull=False).update(pending_rejection=datetime.now())`
- run the command (`./manage.py send_pending_rejection_last_warning_notifications'`)
- the version should not be rejected yet
- see the reminder email in fake email.  This email should also mention the policy that was violated, and follow-up actions - i.e. it should contain the same information from the first email, but making saying it will happen in 1 day instead

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
