### PR TITLE
Hide Source Code Upload on Edit for Enterprise Versions

### DIFF
--- a/src/olympia/devhub/templates/devhub/versions/edit.html
+++ b/src/olympia/devhub/templates/devhub/versions/edit.html
@@ -115,16 +115,18 @@
           {% endwith %}
           </tr>
           <tr>
-          {% with field = version_form.source %}
-            <th>
-              <label for="{{ field.auto_id }}">{{ _("Source code") }}</label>
-              {{ tip(None, _("If your add-on contains minified, concatenated or otherwise machine-generated code, make the source available here for reviewers.")) }}
-            </th>
-            <td>
-              {{ field.errors }}
-              {{ field }}
-            </td>
-          {% endwith %}
+          {% if version.channel != amo.CHANNEL_ENTERPRISE %}
+            {% with field = version_form.source %}
+              <th>
+                <label for="{{ field.auto_id }}">{{ _("Source code") }}</label>
+                {{ tip(None, _("If your add-on contains minified, concatenated or otherwise machine-generated code, make the source available here for reviewers.")) }}
+              </th>
+              <td>
+                {{ field.errors }}
+                {{ field }}
+              </td>
+            {% endwith %}
+          {% endif %}
           </tr>
           {% endif %}
         </table>

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -115,6 +115,32 @@ class TestVersion(TestCase):
         doc = self.get_doc()
         assert '<strong>Invisible:</strong>' in doc.html()
 
+    def test_enterprise_source_hidden(self):
+        assert self.version.channel == amo.CHANNEL_LISTED
+        url = reverse('devhub.versions.edit', args=(self.addon.slug, self.version.pk))
+        response = self.client.get(url)
+        assert pq(response.content)('#id_source')
+
+        unlisted_version = version_factory(
+            addon=self.addon,
+            channel=amo.CHANNEL_UNLISTED,
+        )
+        url = reverse(
+            'devhub.versions.edit', args=(self.addon.slug, unlisted_version.pk)
+        )
+        response = self.client.get(url)
+        assert pq(response.content)('#id_source')
+
+        enterprise_version = version_factory(
+            addon=self.addon,
+            channel=amo.CHANNEL_ENTERPRISE,
+        )
+        url = reverse(
+            'devhub.versions.edit', args=(self.addon.slug, enterprise_version.pk)
+        )
+        response = self.client.get(url)
+        assert not pq(response.content)('#id_source')
+
     def test_upload_link_label_in_edit_nav(self):
         url = reverse('devhub.versions.edit', args=(self.addon.slug, self.version.pk))
         response = self.client.get(url)

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -415,9 +415,7 @@ class Version(OnChangeMixin, ModelBase):
             raise VersionCreateError('Only extensions can be enterprise add-ons.')
 
         if channel == amo.CHANNEL_ENTERPRISE and upload.source:
-            raise VersionCreateError(
-                'Enterprise extensions cannot have source uploads.'
-            )
+            raise VersionCreateError('Enterprise versions cannot have source uploads.')
 
         if addon.status == amo.STATUS_DISABLED:
             raise VersionCreateError(

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -414,6 +414,11 @@ class Version(OnChangeMixin, ModelBase):
         if channel == amo.CHANNEL_ENTERPRISE and addon.type != amo.ADDON_EXTENSION:
             raise VersionCreateError('Only extensions can be enterprise add-ons.')
 
+        if channel == amo.CHANNEL_ENTERPRISE and upload.source:
+            raise VersionCreateError(
+                'Enterprise extensions cannot have source uploads.'
+            )
+
         if addon.status == amo.STATUS_DISABLED:
             raise VersionCreateError(
                 'Addon is Mozilla Disabled; no new versions are allowed.'

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1942,9 +1942,10 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
                 parsed_data=self.dummy_parsed_data,
             )
 
+    @override_switch('enterprise-channel', active=True)
     def test_enterprise_channel_only_allowed_for_extensions(self):
         self.addon.update(type=amo.ADDON_STATICTHEME)
-        with self.assertRaises(VersionCreateError):
+        with self.assertRaises(VersionCreateError) as e:
             Version.from_upload(
                 self.upload,
                 self.addon,
@@ -1952,9 +1953,24 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
                 selected_apps=[self.selected_app],
                 parsed_data=self.dummy_parsed_data,
             )
+        assert str(e.exception) == 'Only extensions can be enterprise add-ons.'
+
+    @override_switch('enterprise-channel', active=True)
+    def test_enterprise_channel_disallow_source(self):
+        self.upload.source = 'src'
+
+        with self.assertRaises(VersionCreateError) as e:
+            Version.from_upload(
+                self.upload,
+                self.addon,
+                amo.CHANNEL_ENTERPRISE,
+                selected_apps=[self.selected_app],
+                parsed_data=self.dummy_parsed_data,
+            )
+        assert str(e.exception) == 'Enterprise extensions cannot have source uploads.'
 
     def test_enterprise_addon_disabled_waffle_switch(self):
-        with self.assertRaises(VersionCreateError):
+        with self.assertRaises(VersionCreateError) as e:
             Version.from_upload(
                 self.upload,
                 self.addon,
@@ -1962,6 +1978,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
                 selected_apps=[self.selected_app],
                 parsed_data=self.dummy_parsed_data,
             )
+        assert str(e.exception) == 'The enterprise channel is not enabled.'
 
     def test_addon_is_attached_to_upload_if_it_wasnt(self):
         assert self.upload.addon is None

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1967,7 +1967,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
                 selected_apps=[self.selected_app],
                 parsed_data=self.dummy_parsed_data,
             )
-        assert str(e.exception) == 'Enterprise extensions cannot have source uploads.'
+        assert str(e.exception) == 'Enterprise versions cannot have source uploads.'
 
     def test_enterprise_addon_disabled_waffle_switch(self):
         with self.assertRaises(VersionCreateError) as e:


### PR DESCRIPTION
Closes mozilla/addons#14852

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Hides the source upload on the version edit page for enterprise versions.

<img width="810" height="734" alt="image" src="https://github.com/user-attachments/assets/2473bd8b-c195-4452-aeec-660bf3feb236" />

### Testing

1. Enable the `enterprise-channel` waffle switch.
2. Create an enterprise extension or version (i.e has `browser_specific_settings: { gecko: { admin_install_only: true } } in its manifest`). 
3. The source code upload section is not visible for the enterprise version. It is still visible for others.

### Checklist
- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
