### PR TITLE
create activity and send email when overriding to same enforcement action

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1431,7 +1431,19 @@ class ContentDecision(ModelBase):
                     # decision was created so there is a record in the reviewer tools
                     # history, and we can send out an accurate email with policy text,
                     # etc.
-                    action_helper.log_action(amo.LOG.DECISION_CREATED)
+                    if not self.target_versions.exists() and (
+                        addon_version := getattr(action_helper, 'addon_version', None)
+                    ):
+                        # If there was no action, there is likely no target_versions
+                        # either (unless it was an override), so we provide a version to
+                        # associate it with, so it's visible in the review history.
+                        action_helper.log_action(
+                            amo.LOG.DECISION_CREATED,
+                            addon_version,
+                            extra_details={'versions': [addon_version.version]},
+                        )
+                    else:
+                        action_helper.log_action(amo.LOG.DECISION_CREATED)
                 # But only save it afterwards in case process_action failed
                 self.save(update_fields=('action_date',))
             else:

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1392,6 +1392,8 @@ class ContentDecision(ModelBase):
             log_entry = OverriddenActionClass.reverse_action(
                 reversed_decision=overridden, new_decision=self
             )
+        else:
+            log_entry = None
 
         # Reverse any follow-up actions (e.g. delayed blocks) of the overridden
         # decision too.
@@ -1421,6 +1423,13 @@ class ContentDecision(ModelBase):
                 # action first, then apply the new action below.
                 self.reverse_overridden_action()
                 log_entry = action_helper.process_action(release_hold=release_hold)
+                if not log_entry and not self.activities.exists():
+                    # If there was no action taken (e.g. the content was already
+                    # removed, so the action was a no-op) we still need to log that the
+                    # decision was created so there is a record in the reviewer tools
+                    # history, and we can send out an accurate email with policy text,
+                    # etc.
+                    action_helper.log_action(amo.LOG.DECISION_CREATED)
                 # But only save it afterwards in case process_action failed
                 self.save(update_fields=('action_date',))
             else:
@@ -1430,8 +1439,6 @@ class ContentDecision(ModelBase):
         if self.action_date:
             for followup in self.followup_actions.filter(action_date__isnull=True):
                 followup.execute_action()
-
-        log_entry = log_entry or self.activities.first()
 
         if self.cinder_job and self.addon_id:
             if self.action_date:

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1394,6 +1394,7 @@ class ContentDecision(ModelBase):
                 reversed_decision=overridden, new_decision=self
             )
         else:
+            self.target_versions.set(overridden.target_versions.all())
             log_entry = None
 
         # Reverse any follow-up actions (e.g. delayed blocks) of the overridden

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1393,6 +1393,8 @@ class ContentDecision(ModelBase):
             log_entry = OverriddenActionClass.reverse_action(
                 reversed_decision=overridden, new_decision=self
             )
+        else:
+            log_entry = None
 
         # Reverse any follow-up actions (e.g. delayed blocks) of the overridden
         # decision too.
@@ -1422,6 +1424,13 @@ class ContentDecision(ModelBase):
                 # action first, then apply the new action below.
                 self.reverse_overridden_action()
                 log_entry = action_helper.process_action(release_hold=release_hold)
+                if not log_entry and not self.activities.exists():
+                    # If there was no action taken (e.g. the content was already
+                    # removed, so the action was a no-op) we still need to log that the
+                    # decision was created so there is a record in the reviewer tools
+                    # history, and we can send out an accurate email with policy text,
+                    # etc.
+                    action_helper.log_action(amo.LOG.DECISION_CREATED)
                 # But only save it afterwards in case process_action failed
                 self.save(update_fields=('action_date',))
             else:
@@ -1431,8 +1440,6 @@ class ContentDecision(ModelBase):
         if self.action_date:
             for followup in self.followup_actions.filter(action_date__isnull=True):
                 followup.execute_action()
-
-        log_entry = log_entry or self.activities.first()
 
         if self.cinder_job and self.addon_id:
             if self.action_date:

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1393,6 +1393,7 @@ class ContentDecision(ModelBase):
                 reversed_decision=overridden, new_decision=self
             )
         else:
+            self.target_versions.set(overridden.target_versions.all())
             log_entry = None
 
         # Reverse any follow-up actions (e.g. delayed blocks) of the overridden

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -3772,6 +3772,45 @@ class TestContentDecision(TestCase):
             f'{older_version.version}, {newer_version.version}' in mail_item.body
         )
 
+    def test_execute_action_same_override_to_same_enforcement(self):
+        addon = addon_factory(users=[user_factory()], status=amo.STATUS_DISABLED)
+        addon.versions.get().file.update(
+            status=amo.STATUS_DISABLED,
+            original_status=amo.STATUS_APPROVED,
+            status_disabled_reason=File.STATUS_DISABLED_REASONS.ADDON_DISABLE,
+        )
+        overridden = ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            action_date=datetime.now(),
+            metadata={ContentDecision.POLICY_DYNAMIC_VALUES: {}},
+        )
+        overridden.policies.add(
+            CinderPolicy.objects.create(uuid='1234', name='Bad policy')
+        )
+        decision = ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            reasoning='some review text',
+            reviewer_user=self.reviewer_user,
+            override_of=overridden,
+            metadata={ContentDecision.POLICY_DYNAMIC_VALUES: {}},
+        )
+        decision.policies.add(
+            CinderPolicy.objects.create(uuid='12345', name='Other bad policy')
+        )
+
+        decision.execute_action()
+        assert addon.reload().status == amo.STATUS_DISABLED  # no change
+
+        decision.send_notifications()
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [addon.authors.get().email]
+        assert 'permanently disabled' in mail.outbox[0].body
+        assert 'Other bad policy' in mail.outbox[0].body
+
+        assert decision.activities.get().action == amo.LOG.DECISION_CREATED.id
+
     def _test_execute_action_reject_version_delayed_outcome(self, decision):
         decision.send_notifications()
         assert 'appeal' not in mail.outbox[0].body

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -3541,6 +3541,24 @@ class TestContentDecision(TestCase):
         )
         assert submission.from_followup == followup
 
+    def test_execute_action_disable_addon_already_disabled(self):
+        addon = addon_factory(users=[user_factory()], status=amo.STATUS_DISABLED)
+        decision = ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            reviewer_user=self.reviewer_user,
+        )
+        assert decision.action_date is None
+        assert decision.execute_action() is None
+        self.assertCloseToNow(decision.action_date)
+        assert decision.addon.reload().status == amo.STATUS_DISABLED
+        alog = ActivityLog.objects.filter(action=amo.LOG.DECISION_CREATED.id).get()
+        assert alog.contentdecisionlog_set.get().decision == decision
+        assert alog.versionlog_set.get().version == addon.versions.get()
+        decision.send_notifications()
+        assert len(mail.outbox) == 1
+        assert 'appeal' in mail.outbox[0].body
+
     def _test_execute_action_reject_version_outcome(self, decision):
         decision.send_notifications()
         assert 'appeal' in mail.outbox[0].body

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -3772,7 +3772,7 @@ class TestContentDecision(TestCase):
             f'{older_version.version}, {newer_version.version}' in mail_item.body
         )
 
-    def test_execute_action_same_override_to_same_enforcement(self):
+    def test_execute_action_override_to_same_enforcement(self):
         addon = addon_factory(users=[user_factory()], status=amo.STATUS_DISABLED)
         addon.versions.get().file.update(
             status=amo.STATUS_DISABLED,
@@ -3788,6 +3788,7 @@ class TestContentDecision(TestCase):
         overridden.policies.add(
             CinderPolicy.objects.create(uuid='1234', name='Bad policy')
         )
+        overridden.target_versions.set(addon.versions.all())
         decision = ContentDecision.objects.create(
             addon=addon,
             action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
@@ -3810,6 +3811,10 @@ class TestContentDecision(TestCase):
         assert 'Other bad policy' in mail.outbox[0].body
 
         assert decision.activities.get().action == amo.LOG.DECISION_CREATED.id
+
+        assert list(decision.target_versions.all()) == list(
+            overridden.target_versions.all()
+        )
 
     def _test_execute_action_reject_version_delayed_outcome(self, decision):
         decision.send_notifications()

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1329,6 +1329,15 @@ class SESSION_ANOMALY(_LOG):
     store_ip = True
 
 
+class DECISION_CREATED(_LOG):
+    id = 216
+    format = _('Decision on {addon} made with no new action taken.')
+    short = _('Decision made')
+    keep = True
+    review_queue = True
+    reviewer_review_action = True
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len({log.id for log in LOGS})

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -4090,6 +4090,70 @@ class TestReviewHelper(TestReviewHelperBase):
         self.check_subject(message)
         assert 'approved' in message.body
 
+    @override_switch('enable-policy-review-selection', active=True)
+    def test_review_with_policy_disable_override_to_disable(self):
+        self.grant_permission(self.user, 'Addons:Review')
+        self.file.update(
+            status=amo.STATUS_DISABLED,
+            original_status=amo.STATUS_AWAITING_REVIEW,
+            status_disabled_reason=File.STATUS_DISABLED_REASONS.NONE,
+        )
+        self.addon.update(status=amo.STATUS_DISABLED)
+        self.helper = self.get_helper()
+        mail.outbox = []
+        ActivityLog.objects.for_addons(self.addon).delete()
+        prior_decision = ContentDecision.objects.create(
+            addon=self.addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            action_date=datetime.now(),
+        )
+        prior_decision.target_versions.add(self.review_version)
+
+        new_policy = CinderPolicy.objects.create(
+            uuid='z',
+            enforcement_actions=[DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value],
+            name='New pólicy',
+            text='Pólicy téxt',
+        )
+        data = {
+            'cinder_policies': [new_policy],
+            'most_important_policy_actions': filter_enforcement_actions(
+                new_policy.split_enforcement_actions, Addon
+            ),
+            'override_decision': prior_decision,
+            'policy_values': {},
+        }
+        self.helper.set_data(data)
+        self.helper.handler.review_action = self.helper.actions['review_with_policy']
+        self.helper.handler.review_with_policy()
+
+        self.addon.reload()
+        assert self.addon.status == amo.STATUS_DISABLED
+        assert self.review_version.file.reload().status == amo.STATUS_DISABLED
+
+        new_decision = ContentDecision.objects.exclude(id=prior_decision.id).get(
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON
+        )
+        assert new_decision.override_of == prior_decision
+
+        logs = ActivityLog.objects
+        assert logs.count() == 1
+        activity_log = logs.first()
+        assert activity_log.action == amo.LOG.DECISION_CREATED.id
+        assert activity_log.arguments == [
+            self.addon,
+            new_decision,
+            new_policy,
+            self.review_version,
+        ]
+
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        self.check_subject(message)
+        assert 'no longer available for download' in message.body
+        assert 'New pólicy' in message.body
+        assert 'Pólicy téxt' in message.body
+
     def test_enable_addon(self):
         self.grant_permission(self.user, 'Reviews:Admin')
         self.setup_data(amo.STATUS_NULL, file_status=amo.STATUS_APPROVED)

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1280,7 +1280,7 @@ class ReviewBase:
             if update_queue_history:
                 self.update_queue_history(log_entry)
 
-        for decision in decisions:
+        for idx, decision in enumerate(decisions):
             # If there are multiple decisions, in theory only one should really
             # be executed completely and log an activity, the rest should be
             # no-op that we just need for record-keeping purposes. We will only
@@ -1294,7 +1294,7 @@ class ReviewBase:
                     self.log_attachment(log_entry)
                     if update_queue_history:
                         self.update_queue_history(log_entry)
-            elif log_entry:
+            elif log_entry and idx > 0:
                 # decision.execute_action() explicitly returned None but we
                 # already have a log_entry: that means this decision was
                 # already carried out, we are just resolving multiple jobs with

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1384,12 +1384,12 @@ class ReviewBase:
             decisions = [create_decision(override_decision=override_decision)]
 
         log_entry = None
-        for decision in decisions:
+        for idx, decision in enumerate(decisions):
             # If there are multiple decisions, in theory only one should really
             # be executed completely and log an activity, the rest should be
             # no-op that we just need for record-keeping purposes. We will only
             # notify the owners for that "complete" one.
-            notify_owners = False
+            notify_owners = idx == 0
             log_entry_for_decision = decision.execute_action()
             if log_entry_for_decision:
                 notify_owners = True


### PR DESCRIPTION
Fixes mozilla/addons#16354

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds a no-op ActivityLog when ContentAction.execute_action didn't do anything (so didn't return a log entry) so we can send an email out with the relevant policy texts, and have a record in the reviewer tools version log.  This happens when overriding a decision to the same enforcement action.

### Context

It's quite a subtle change, and because it's a no-op we don't want to return the activity from execute_action, it lead to a small change in the reviewer tools too.

### Testing

- enable `'enable-policy-review-selection'` waffle switch
- in reviewer tools, choose an add-on and review it negatively with some policies that disable the add-on
- back on the same review page, review it negatively again, but this time select the previous decision to override, and some other policies that also disable the add-on
- (no error)
- see there is an email for the override too, which should be the same disable email, but mention the new set of policies instead

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
