### PR TITLE
Add Enterprise Add-on API

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -497,6 +497,9 @@ This endpoint allows you to list all versions belonging to a specific add-on.
                           a user account listed as a developer of the add-on.
         all_with_deleted  Show all versions attached to this add-on, including
                           deleted ones. Requires admin permissions.
+        enterprise_only   Show all enterprise versions attached to this add-on.
+                          Requires either reviewer permissions or a user
+                          account listed as a developer of the add-on.
     ====================  =====================================================
 
 --------------
@@ -517,7 +520,7 @@ This endpoint allows you to fetch a single version belonging to a specific add-o
     :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
     :>json int id: The version id.
     :>json string approval_notes: Information for Mozilla reviewers, for when the add-on is reviewed.  These notes are only visible to Mozilla, and this field is only present if the user has reviewer permissions, or is listed as a developer of the add-on.
-    :>json string channel: The version channel, which determines its visibility on the site. Can be either ``unlisted`` or ``listed``.
+    :>json string channel: The version channel, which determines its visibility on the site. Can be either ``unlisted``, ``listed``, or ``enterprise``.
     :>json object compatibility:
         Object detailing which :ref:`applications <addon-detail-application>` the version is compatible with.
         The exact min/max version numbers in the object correspond to the :ref:`supported versions<applications-version-list>`.
@@ -854,7 +857,7 @@ This endpoint is for uploading an addon file, to then be submitted to create a n
     .. _upload-create-request:
 
     :form upload: The add-on file being uploaded.
-    :form channel: The channel this version should be uploaded to, which determines its visibility on the site. It can be either ``unlisted`` or ``listed``.
+    :form channel: The channel this version should be uploaded to, which determines its visibility on the site. It can be either ``unlisted``, ``listed``, or ``enterprise``.
     :reqheader Content-Type: multipart/form-data
 
 
@@ -901,7 +904,7 @@ This endpoint is for fetching a single previous upload by uuid.
     .. _upload-detail-object:
 
     :>json string uuid: The upload id.
-    :>json string channel: The version channel, which determines its visibility on the site. Can be either ``unlisted`` or ``listed``.
+    :>json string channel: The version channel, which determines its visibility on the site. Can be either ``unlisted``, ``listed``, or ``enterprise``.
     :>json boolean processed: If the version has been processed by the validator.
     :>json boolean submitted: If this upload has been submitted as a new add-on or version already. An upload can only be submitted once.
     :>json string url: URL to check the status of this upload.

--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -492,9 +492,10 @@ This endpoint allows you to list all versions belonging to a specific add-on.
     all_without_unlisted  Show all listed versions attached to this add-on.
                           Requires either reviewer permissions or a user
                           account listed as a developer of the add-on.
-       all_with_unlisted  Show all versions (including unlisted) attached to
-                          this add-on. Requires either reviewer permissions or
-                          a user account listed as a developer of the add-on.
+       all_with_unlisted  Show all versions (including unlisted and enterprise 
+                          versions) attached to this add-on. Requires either 
+                          reviewer permissions or a user account listed as a
+                          developer of the add-on.
         all_with_deleted  Show all versions attached to this add-on, including
                           deleted ones. Requires admin permissions.
         enterprise_only   Show all enterprise versions attached to this add-on.

--- a/docs/topics/api/scanners.rst
+++ b/docs/topics/api/scanners.rst
@@ -223,7 +223,7 @@ Rule results
     :query boolean was_signed: Only results whose file is signed.
     :query boolean addon_disabled_by_user: Only results whose add-on listing is
         invisible (``true``) or visible (``false``).
-    :query string channel: Version channel, ``unlisted`` or ``listed``.
+    :query string channel: Version channel. Can be either ``unlisted``, ``listed``, or ``enterprise``.
     :query string addon_status: Add-on status (e.g. ``public``, ``disabled``).
     :query string file_status: File status (e.g. ``public``, ``disabled``).
     :query string sort: Ordering field. One of ``id``, ``addon_adu``
@@ -237,7 +237,7 @@ Rule results
     :>json object results[].version: Minimal version representation (may be ``null``).
     :>json int results[].version.id: The version id.
     :>json string results[].version.version: The version number.
-    :>json string results[].version.channel: The version channel (``listed`` or ``unlisted``).
+    :>json string results[].version.channel: The version channel (``listed``, ``unlisted``, or ``enterprise``).
     :>json string results[].version.created: When the version was created.
     :>json object results[].version.addon: The add-on (``id``, ``guid``, ``average_daily_users``).
     :>json object results[].matches: The matched files and metadata, keyed by rule name.

--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -120,6 +120,30 @@ class ReviewNotesViewSetDetailMixin(LogMixin):
         response = self.client.get(self.url)
         assert response.status_code == 200
 
+    def test_get_enterprise_simple_reviewer(self):
+        self.change_channel_for_addon(self.addon, amo.CHANNEL_ENTERPRISE)
+        self._login_reviewer()
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
+    def test_get_enterprise_specific_reviewer(self):
+        self.change_channel_for_addon(self.addon, amo.CHANNEL_ENTERPRISE)
+        self._login_reviewer(permission=amo.permissions.ADDONS_REVIEW_UNLISTED)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+    def test_get_enterprise_unlisted_viewer(self):
+        self.change_channel_for_addon(self.addon, amo.CHANNEL_ENTERPRISE)
+        self._login_reviewer(permission=amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+    def test_get_enterprise_author(self):
+        self.change_channel_for_addon(self.addon, amo.CHANNEL_ENTERPRISE)
+        self._login_developer()
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
     def test_get_deleted(self):
         self.addon.delete()
         self._login_developer()

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1908,7 +1908,10 @@ class VersionRollbackSerializer(DeveloperVersionSerializer):
                 gettext('Rollback is only available for version %s in this channel.')
                 % first.version
             )
-        elif existing.channel == amo.CHANNEL_UNLISTED and existing not in available:
+        elif (
+            existing.channel in (amo.CHANNEL_UNLISTED, amo.CHANNEL_ENTERPRISE)
+            and existing not in available
+        ):
             raise exceptions.ValidationError(
                 gettext(
                     'Only approved versions can be rolled back, except the most recent '

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -66,6 +66,7 @@ from olympia.versions.models import (
     ApplicationsVersions,
     AppVersion,
     License,
+    VersionCreateError,
     VersionPreview,
     VersionProvenance,
     VersionReviewerFlags,
@@ -386,6 +387,32 @@ class AddonAndVersionViewSetDetailMixin:
         user = UserProfile.objects.create(username='author')
         AddonUser.objects.create(user=user, addon=self.addon)
         self.make_addon_unlisted(self.addon)
+        self.client.login_api(user)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+    def test_get_enterprise_no_rights(self):
+        user = UserProfile.objects.create(username='user')
+        self.change_channel_for_addon(self.addon, amo.CHANNEL_ENTERPRISE)
+        self.client.login_api(user)
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+        data = json.loads(force_str(response.content))
+        assert data['detail'] == ('You do not have permission to perform this action.')
+
+    def test_get_enterprise_addons_api_view_unlisted(self):
+        user = UserProfile.objects.create(username='user')
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
+        self.change_channel_for_addon(self.addon, amo.CHANNEL_ENTERPRISE)
+        self.client.login_api(user)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+    def test_get_enterprise_author(self):
+        user = UserProfile.objects.create(username='author')
+        AddonUser.objects.create(user=user, addon=self.addon)
+        self.change_channel_for_addon(self.addon, amo.CHANNEL_ENTERPRISE)
         self.client.login_api(user)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -3127,6 +3154,43 @@ class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 403
 
+    def test_enterprise_version_no_unlisted_permission(self):
+        user = UserProfile.objects.create(username='user')
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
+    def test_enterprise_version_addons_api_view_unlisted(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        self._test_url()
+
+    def test_enterprise_version_not_author(self):
+        user = UserProfile.objects.create(username='user')
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
+    def test_enterprise_version_author(self):
+        user = UserProfile.objects.create(username='author')
+        AddonUser.objects.create(user=user, addon=self.addon)
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        self._test_url()
+
+    def test_enterprise_version_admin(self):
+        user = UserProfile.objects.create(username='admin')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        self._test_url()
+
     def test_developer_version_serializer_used_for_authors(self):
         self.version.update(source='src.zip')
         # not logged in
@@ -3688,6 +3752,46 @@ class TestVersionViewSetCreate(UploadMixin, VersionViewSetCreateUpdateMixin, Tes
         assert provenance.version == version
         assert provenance.source == amo.UPLOAD_SOURCE_ADDON_API
         assert provenance.client_info == 'web-ext/12.34'
+
+    @override_switch('enterprise-channel', active=True)
+    def test_basic_enterprise(self):
+        self.upload.update(channel=amo.CHANNEL_ENTERPRISE)
+        response = self.client.post(
+            self.url,
+            data=self.minimal_data,
+            HTTP_USER_AGENT='web-ext/12.34',
+        )
+        assert response.status_code == 201, response.content
+        data = response.data
+        assert data['license'] is None
+        assert data['compatibility'] == {
+            'firefox': {'max': '*', 'min': amo.DEFAULT_WEBEXT_MIN_VERSION},
+        }
+        self.addon.reload()
+        assert self.addon.versions.count() == 2
+        version = self.addon.find_latest_version(channel=None)
+        request = APIRequestFactory().get('/')
+        request.version = 'v5'
+        request.user = self.user
+        assert data == DeveloperVersionSerializer(
+            context={'request': request}
+        ).to_representation(version)
+        assert version.channel == amo.CHANNEL_ENTERPRISE
+        self.statsd_incr_mock.assert_any_call('addons.submission.version.enterprise')
+        self.statsd_incr_mock.assert_any_call('addons.submission.webext_version.12_34')
+        provenance = VersionProvenance.objects.get()
+        assert provenance.version == version
+        assert provenance.source == amo.UPLOAD_SOURCE_ADDON_API
+        assert provenance.client_info == 'web-ext/12.34'
+
+    def test_enterprise_switch_off(self):
+        self.upload.update(channel=amo.CHANNEL_ENTERPRISE)
+        with self.assertRaises(VersionCreateError):
+            self.client.post(
+                self.url,
+                data=self.minimal_data,
+            )
+        assert self.addon.reload().versions.count() == 1
 
     @patch('olympia.addons.views.log')
     def test_does_not_log_without_source(self, log_mock):
@@ -5047,12 +5151,12 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
             guid=generate_addon_guid(), name='My Addôn', slug='my-addon'
         )
         self.old_version = self.addon.current_version
-        self.old_version.update(created=self.days_ago(2))
+        self.old_version.update(created=self.days_ago(3))
 
         # Don't use addon.current_version, changing its state as we do in
         # the tests might render the add-on itself inaccessible.
         self.version = version_factory(addon=self.addon, version='1.0.1')
-        self.version.update(created=self.days_ago(1))
+        self.version.update(created=self.days_ago(2))
 
         # This version is unlisted and should be hidden by default, only
         # shown when requesting to see unlisted stuff explicitly, with the
@@ -5061,6 +5165,16 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
             addon=self.addon,
             version=amo.DEFAULT_WEBEXT_MIN_VERSION,
             channel=amo.CHANNEL_UNLISTED,
+        )
+        self.unlisted_version.update(created=self.days_ago(1))
+
+        # This version is enterprise and should be hidden by default, only
+        # shown when requesting to see enterprise explicitly, with the
+        # right permissions.
+        self.enterprise_version = version_factory(
+            addon=self.addon,
+            version='5.0',
+            channel=amo.CHANNEL_ENTERPRISE,
         )
 
         self._set_tested_url(self.addon.pk)
@@ -5087,14 +5201,17 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         assert response.status_code == 200
         result = json.loads(force_str(response.content))
         assert result['results']
-        assert len(result['results']) == 3
+        assert len(result['results']) == 4
         result_version = result['results'][0]
+        assert result_version['id'] == self.enterprise_version.pk
+        assert result_version['version'] == self.enterprise_version.version
+        result_version = result['results'][1]
         assert result_version['id'] == self.unlisted_version.pk
         assert result_version['version'] == self.unlisted_version.version
-        result_version = result['results'][1]
+        result_version = result['results'][2]
         assert result_version['id'] == self.version.pk
         assert result_version['version'] == self.version.version
-        result_version = result['results'][2]
+        result_version = result['results'][3]
         assert result_version['id'] == self.old_version.pk
         assert result_version['version'] == self.old_version.version
 
@@ -5107,6 +5224,17 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         result_version = result['results'][0]
         assert result_version['id'] == self.old_version.pk
         assert result_version['version'] == self.old_version.version
+
+    def _test_url_only_contains_enterprise_version(self, **kwargs):
+        response = self.client.get(self.url, data=kwargs)
+        assert response.status_code == 200
+        result = json.loads(force_str(response.content))
+        assert result['results']
+        assert len(result['results']) == 1
+        result_version = result['results'][0]
+        assert result_version['id'] == self.enterprise_version.pk
+        assert result_version['version'] == self.enterprise_version.version
+        assert result_version['channel'] == 'enterprise'
 
     def _set_tested_url(self, param):
         self.url = reverse_ns('addon-version-list', kwargs={'addon_pk': param})
@@ -5270,8 +5398,9 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
         self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
         self.client.login_api(user)
-        # delete the unlisted version so only the listed versions remain.
+        # delete the unlisted versions so only the listed versions remain.
         self.unlisted_version.delete()
+        self.enterprise_version.delete()
 
         # confirm that we have access to view unlisted versions.
         response = self.client.get(self.url, data={'filter': 'all_with_unlisted'})
@@ -5286,6 +5415,71 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         # And that without_unlisted doesn't fail when there are no unlisted
         response = self.client.get(self.url, data={'filter': 'all_without_unlisted'})
         assert response.status_code == 200
+
+    def test_with_enterprise_addons_api_view_unlisted(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
+        self.client.login_api(user)
+        self._test_url_only_contains_enterprise_version(filter='enterprise_only')
+
+    def test_enterprise_only_when_no_enterprise_versions(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
+        self.client.login_api(user)
+        # delete the unlisted version so only the listed versions remain.
+        self.enterprise_version.delete()
+
+        # confirm that we have access to view unlisted versions.
+        response = self.client.get(self.url, data={'filter': 'enterprise_only'})
+        assert response.status_code == 200
+        result = json.loads(force_str(response.content))
+        assert len(result['results']) == 0
+
+    def test_enterprise_only_logout(self):
+        response = self.client.get(self.url, data={'filter': 'enterprise_only'})
+        assert response.status_code == 401
+
+    def test_enterprise_only_not_author(self):
+        user = UserProfile.objects.create(username='user')
+        self.client.login_api(user)
+        response = self.client.get(self.url, data={'filter': 'enterprise_only'})
+        assert response.status_code == 403
+
+    def test_enterprise_only_author(self):
+        user = UserProfile.objects.create(username='author')
+        AddonUser.objects.create(user=user, addon=self.addon)
+        user.update(read_dev_agreement=None)
+        self.client.login_api(user)
+        self._test_url_only_contains_enterprise_version(filter='enterprise_only')
+
+    def test_enterprise_only_with_superpowers(self):
+        user = UserProfile.objects.create(username='user')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
+        self.client.login_api(user)
+        self._test_url_only_contains_enterprise_version(filter='enterprise_only')
+
+    def test_enterprise_only_not_available_in_old_api_versions(self):
+        current_api_version = settings.REST_FRAMEWORK['DEFAULT_VERSION']
+        assert (
+            'enterprise-channel-shim' not in settings.DRF_API_GATES[current_api_version]
+        )
+        user = UserProfile.objects.create(username='admin')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
+        self.client.login_api(user)
+
+        for api_version in ('v3', 'v4'):
+            assert 'enterprise-channel-shim' in settings.DRF_API_GATES[api_version]
+            url = reverse_ns(
+                'addon-version-list',
+                api_version=api_version,
+                kwargs={'addon_pk': self.addon.pk},
+            )
+            response = self.client.get(url, data={'filter': 'enterprise_only'})
+            assert response.status_code == 400
+            data = json.loads(force_str(response.content))
+            assert data == ['Invalid "filter" parameter specified.']
 
     def test_deleted_version_anonymous(self):
         self.version.delete()
@@ -5323,9 +5517,10 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
         self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
         self.client.login_api(user)
-        # delete the listed versions so only the unlisted version remains.
+        # delete the other versions so only the unlisted version remains.
         self.version.delete()
         self.old_version.delete()
+        self.enterprise_version.delete()
 
         # confirm that we have access to view unlisted versions.
         response = self.client.get(self.url, data={'filter': 'all_with_unlisted'})

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -5463,14 +5463,14 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
     def test_enterprise_only_not_available_in_old_api_versions(self):
         current_api_version = settings.REST_FRAMEWORK['DEFAULT_VERSION']
         assert (
-            'enterprise-channel-shim' not in settings.DRF_API_GATES[current_api_version]
+            'no-enterprise-channel' not in settings.DRF_API_GATES[current_api_version]
         )
         user = UserProfile.objects.create(username='admin')
         self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.login_api(user)
 
         for api_version in ('v3', 'v4'):
-            assert 'enterprise-channel-shim' in settings.DRF_API_GATES[api_version]
+            assert 'no-enterprise-channel' in settings.DRF_API_GATES[api_version]
             url = reverse_ns(
                 'addon-version-list',
                 api_version=api_version,
@@ -5480,6 +5480,37 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
             assert response.status_code == 400
             data = json.loads(force_str(response.content))
             assert data == ['Invalid "filter" parameter specified.']
+
+    def test_enterprise_versions_filtered_in_old_api_versions(self):
+        user = UserProfile.objects.create(username='user')
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
+        self.client.login_api(user)
+
+        # confirm that we have access to view unlisted versions.
+        response = self.client.get(self.url, data={'filter': 'all_with_unlisted'})
+        assert response.status_code == 200
+        result = json.loads(force_str(response.content))
+        assert result['results']
+        assert len(result['results']) == 4
+        assert 'enterprise' in [result['results'][x]['channel'] for x in range(4)]
+
+        # Only listed & unlisted in v3/v4.
+        for api_version in ('v3', 'v4'):
+            assert 'no-enterprise-channel' in settings.DRF_API_GATES[api_version]
+            url = reverse_ns(
+                'addon-version-list',
+                api_version=api_version,
+                kwargs={'addon_pk': self.addon.pk},
+            )
+            response = self.client.get(url, data={'filter': 'all_with_unlisted'})
+            assert response.status_code == 200
+            result = json.loads(force_str(response.content))
+            assert result['results']
+            assert len(result['results']) == 3
+            assert 'enterprise' not in [
+                result['results'][x]['channel'] for x in range(3)
+            ]
 
     def test_deleted_version_anonymous(self):
         self.version.delete()

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -3165,6 +3165,54 @@ class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 403
 
+    def test_enterprise_version_reviewer(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'Addons:Review')
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
+    def test_enterprise_version_enterprise_reviewer(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'Addons:ReviewUnlisted')
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        self._test_url()
+
+    def test_enterprise_version_enterprise_viewer(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'ReviewerTools:ViewUnlisted')
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        self._test_url()
+
+    def test_enterprise_version_author(self):
+        user = UserProfile.objects.create(username='author')
+        AddonUser.objects.create(user=user, addon=self.addon)
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        self._test_url()
+
+    def test_enterprise_version_admin(self):
+        user = UserProfile.objects.create(username='admin')
+        self.grant_permission(user, '*:*')
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        self._test_url()
+
+    def test_enterprise_version_anonymous(self):
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        response = self.client.get(self.url)
+        assert response.status_code == 401
+
+    def test_enterprise_version_user_but_not_author(self):
+        user = UserProfile.objects.create(username='simpleuser')
+        self.client.login_api(user)
+        self.version.update(channel=amo.CHANNEL_ENTERPRISE)
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
     def test_developer_version_serializer_used_for_authors(self):
         self.version.update(source='src.zip')
         # not logged in
@@ -5085,12 +5133,12 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
             guid=generate_addon_guid(), name='My Addôn', slug='my-addon'
         )
         self.old_version = self.addon.current_version
-        self.old_version.update(created=self.days_ago(2))
+        self.old_version.update(created=self.days_ago(3))
 
         # Don't use addon.current_version, changing its state as we do in
         # the tests might render the add-on itself inaccessible.
         self.version = version_factory(addon=self.addon, version='1.0.1')
-        self.version.update(created=self.days_ago(1))
+        self.version.update(created=self.days_ago(2))
 
         # This version is unlisted and should be hidden by default, only
         # shown when requesting to see unlisted stuff explicitly, with the
@@ -5099,6 +5147,16 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
             addon=self.addon,
             version=amo.DEFAULT_WEBEXT_MIN_VERSION,
             channel=amo.CHANNEL_UNLISTED,
+        )
+        self.unlisted_version.update(created=self.days_ago(1))
+
+        # This version is enterprise and should be hidden by default, only
+        # shown when requesting to see enterprise explicitly, with the
+        # right permissions.
+        self.enterprise_version = version_factory(
+            addon=self.addon,
+            version='5.0',
+            channel=amo.CHANNEL_ENTERPRISE,
         )
 
         self._set_tested_url(self.addon.pk)
@@ -5125,14 +5183,17 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         assert response.status_code == 200
         result = json.loads(force_str(response.content))
         assert result['results']
-        assert len(result['results']) == 3
+        assert len(result['results']) == 4
         result_version = result['results'][0]
+        assert result_version['id'] == self.enterprise_version.pk
+        assert result_version['version'] == self.enterprise_version.version
+        result_version = result['results'][1]
         assert result_version['id'] == self.unlisted_version.pk
         assert result_version['version'] == self.unlisted_version.version
-        result_version = result['results'][1]
+        result_version = result['results'][2]
         assert result_version['id'] == self.version.pk
         assert result_version['version'] == self.version.version
-        result_version = result['results'][2]
+        result_version = result['results'][3]
         assert result_version['id'] == self.old_version.pk
         assert result_version['version'] == self.old_version.version
 
@@ -5145,6 +5206,16 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         result_version = result['results'][0]
         assert result_version['id'] == self.old_version.pk
         assert result_version['version'] == self.old_version.version
+
+    def _test_url_only_contains_enterprise_version(self, **kwargs):
+        response = self.client.get(self.url, data=kwargs)
+        assert response.status_code == 200
+        result = json.loads(force_str(response.content))
+        assert result['results']
+        assert len(result['results']) == 1
+        result_version = result['results'][0]
+        assert result_version['id'] == self.enterprise_version.pk
+        assert result_version['version'] == self.enterprise_version.version
 
     def _set_tested_url(self, param):
         self.url = reverse_ns('addon-version-list', kwargs={'addon_pk': param})
@@ -5313,8 +5384,9 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         self.grant_permission(user, 'Addons:Review')
         self.grant_permission(user, 'Addons:ReviewUnlisted')
         self.client.login_api(user)
-        # delete the unlisted version so only the listed versions remain.
+        # delete the unlisted versions so only the listed versions remain.
         self.unlisted_version.delete()
+        self.enterprise_version.delete()
 
         # confirm that we have access to view unlisted versions.
         response = self.client.get(self.url, data={'filter': 'all_with_unlisted'})
@@ -5334,8 +5406,9 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         user = UserProfile.objects.create(username='reviewer')
         self.grant_permission(user, 'ReviewerTools:ViewUnlisted')
         self.client.login_api(user)
-        # delete the unlisted version so only the listed versions remain.
+        # delete the unlisted versions so only the listed versions remain.
         self.unlisted_version.delete()
+        self.enterprise_version.delete()
 
         # confirm that we have access to view unlisted versions.
         response = self.client.get(self.url, data={'filter': 'all_with_unlisted'})
@@ -5350,6 +5423,51 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         # And that without_unlisted doesn't fail when there are no unlisted
         response = self.client.get(self.url, data={'filter': 'all_without_unlisted'})
         assert response.status_code == 200
+
+    def test_enterprise_only_admin(self):
+        user = UserProfile.objects.create(username='admin')
+        self.grant_permission(user, '*:*')
+        self.client.login_api(user)
+        self._test_url_only_contains_enterprise_version(filter='enterprise_only')
+
+    def test_with_enterprise_unlisted_viewer(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'ReviewerTools:ViewUnlisted')
+        self.client.login_api(user)
+        self._test_url_only_contains_enterprise_version(filter='enterprise_only')
+
+    def test_with_enterprise_unlisted_author(self):
+        user = UserProfile.objects.create(username='author')
+        AddonUser.objects.create(user=user, addon=self.addon)
+        self.client.login_api(user)
+        self._test_url_only_contains_enterprise_version(filter='enterprise_only')
+
+    def test_enterprise_only_when_no_enterprise_versions(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'Addons:Review')
+        self.grant_permission(user, 'Addons:ReviewUnlisted')
+        self.client.login_api(user)
+        # delete the unlisted version so only the listed versions remain.
+        self.enterprise_version.delete()
+
+        # confirm that we have access to view unlisted versions.
+        response = self.client.get(self.url, data={'filter': 'enterprise_only'})
+        assert response.status_code == 200
+        result = json.loads(force_str(response.content))
+        assert len(result['results']) == 0
+
+    def test_enterprise_only_when_no_enterprise_versions_viewer(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'ReviewerTools:ViewUnlisted')
+        self.client.login_api(user)
+        # delete the unlisted version so only the listed versions remain.
+        self.enterprise_version.delete()
+
+        # confirm that we have access to view unlisted versions.
+        response = self.client.get(self.url, data={'filter': 'enterprise_only'})
+        assert response.status_code == 200
+        result = json.loads(force_str(response.content))
+        assert len(result['results']) == 0
 
     def test_deleted_version_anonymous(self):
         self.version.delete()
@@ -5387,9 +5505,10 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         self.grant_permission(user, 'Addons:Review')
         self.grant_permission(user, 'Addons:ReviewUnlisted')
         self.client.login_api(user)
-        # delete the listed versions so only the unlisted version remains.
+        # delete the other versions so only the unlisted version remains.
         self.version.delete()
         self.old_version.delete()
+        self.enterprise_version.delete()
 
         # confirm that we have access to view unlisted versions.
         response = self.client.get(self.url, data={'filter': 'all_with_unlisted'})
@@ -5411,9 +5530,10 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         user = UserProfile.objects.create(username='reviewer')
         self.grant_permission(user, 'ReviewerTools:ViewUnlisted')
         self.client.login_api(user)
-        # delete the listed versions so only the unlisted version remains.
+        # delete the other versions so only the unlisted version remains.
         self.version.delete()
         self.old_version.delete()
+        self.enterprise_version.delete()
 
         # confirm that we have access to view unlisted versions.
         response = self.client.get(self.url, data={'filter': 'all_with_unlisted'})

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -625,7 +625,7 @@ class AddonVersionViewSet(
             'all_without_unlisted',
         ]
 
-        if not is_gate_active(self.request, 'enterprise-channel-shim'):
+        if not is_gate_active(self.request, 'no-enterprise-channel'):
             valid_filters.append('enterprise_only')
 
         if requested is not None:
@@ -659,6 +659,12 @@ class AddonVersionViewSet(
             queryset = addon.versions.filter(
                 file__status=amo.STATUS_APPROVED, channel=amo.CHANNEL_LISTED
             )
+
+        if is_gate_active(self.request, 'no-enterprise-channel'):
+            queryset = queryset.filter(
+                channel__in=[amo.CHANNEL_LISTED, amo.CHANNEL_UNLISTED]
+            )
+
         queryset = queryset.select_related('file___webext_permissions')
         if (
             self.action == 'list'

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -519,7 +519,10 @@ class AddonVersionViewSet(
                     & GroupPermission(amo.permissions.ADDONS_API_VIEW)
                 )
                 | (
-                    AllowForVersionChannel(amo.CHANNEL_UNLISTED)
+                    (
+                        AllowForVersionChannel(amo.CHANNEL_UNLISTED)
+                        | AllowForVersionChannel(amo.CHANNEL_ENTERPRISE)
+                    )
                     & GroupPermission(amo.permissions.ADDONS_API_VIEW)
                     & GroupPermission(amo.permissions.ADDONS_API_VIEW_UNLISTED)
                 )
@@ -578,7 +581,7 @@ class AddonVersionViewSet(
             permission_classes = [
                 GroupPermission(amo.permissions.ADDONS_API_VIEW_DELETED)
             ]
-        elif requested == 'all_with_unlisted':
+        elif requested in ('all_with_unlisted', 'enterprise_only'):
             # To see unlisted versions, you need to be add-on author or have
             # Addons:ApiView and Addons:ApiViewUnlisted.
             permission_classes = [
@@ -616,11 +619,15 @@ class AddonVersionViewSet(
     def get_queryset(self):
         """Return the right base queryset depending on the situation."""
         requested = self.request.GET.get('filter')
-        valid_filters = (
+        valid_filters = [
             'all_with_deleted',
             'all_with_unlisted',
             'all_without_unlisted',
-        )
+        ]
+
+        if not is_gate_active(self.request, 'enterprise-channel-shim'):
+            valid_filters.append('enterprise_only')
+
         if requested is not None:
             if self.action != 'list':
                 raise serializers.ValidationError(
@@ -646,6 +653,8 @@ class AddonVersionViewSet(
             queryset = addon.versions.all()
         elif requested == 'all_without_unlisted':
             queryset = addon.versions.filter(channel=amo.CHANNEL_LISTED)
+        elif requested == 'enterprise_only':
+            queryset = addon.versions.filter(channel=amo.CHANNEL_ENTERPRISE)
         else:
             queryset = addon.versions.filter(
                 file__status=amo.STATUS_APPROVED, channel=amo.CHANNEL_LISTED

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -563,7 +563,7 @@ class AddonVersionViewSet(
             self.permission_classes = [
                 GroupPermission(amo.permissions.ADDONS_VIEW_DELETED)
             ]
-        elif requested == 'all_with_unlisted':
+        elif requested in ('all_with_unlisted', 'enterprise_only'):
             # To see unlisted versions, you need to be add-on author or
             # unlisted reviewer.
             self.permission_classes = [
@@ -602,7 +602,7 @@ class AddonVersionViewSet(
         ).has_object_permission(request, self, obj):
             raise http.Http404
 
-        if obj.channel == amo.CHANNEL_UNLISTED:
+        if obj.channel in (amo.CHANNEL_UNLISTED, amo.CHANNEL_ENTERPRISE):
             # If the instance is unlisted, only allow unlisted reviewers and
             # authors..
             self.permission_classes = [
@@ -625,11 +625,15 @@ class AddonVersionViewSet(
     def get_queryset(self):
         """Return the right base queryset depending on the situation."""
         requested = self.request.GET.get('filter')
-        valid_filters = (
+        valid_filters = [
             'all_with_deleted',
             'all_with_unlisted',
             'all_without_unlisted',
-        )
+        ]
+
+        if not is_gate_active(self.request, 'enterprise-channel-shim'):
+            valid_filters.append('enterprise_only')
+
         if requested is not None:
             if self.action != 'list':
                 raise serializers.ValidationError(
@@ -655,6 +659,8 @@ class AddonVersionViewSet(
             queryset = addon.versions.all()
         elif requested == 'all_without_unlisted':
             queryset = addon.versions.filter(channel=amo.CHANNEL_LISTED)
+        elif requested == 'enterprise_only':
+            queryset = addon.versions.filter(channel=amo.CHANNEL_ENTERPRISE)
         else:
             queryset = addon.versions.filter(
                 file__status=amo.STATUS_APPROVED, channel=amo.CHANNEL_LISTED

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -593,13 +593,12 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
         return request
 
     def make_addon_unlisted(self, addon):
-        self.change_channel_for_addon(addon, False)
+        self.change_channel_for_addon(addon, amo.CHANNEL_UNLISTED)
 
     def make_addon_listed(self, addon):
-        self.change_channel_for_addon(addon, True)
+        self.change_channel_for_addon(addon, amo.CHANNEL_LISTED)
 
-    def change_channel_for_addon(self, addon, listed):
-        channel = amo.CHANNEL_LISTED if listed else amo.CHANNEL_UNLISTED
+    def change_channel_for_addon(self, addon, channel):
         for version in addon.versions(manager='unfiltered_for_relations').all():
             version.update(channel=channel)
 

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -197,9 +197,11 @@ class AllowUnlistedViewerOrReviewer(AllowListedViewerOrReviewer):
         can_access_because_unlisted_reviewer = acl.is_unlisted_addons_reviewer(
             request.user
         ) and (not self.disallow_unsafe or request.method in SAFE_METHODS)
-        has_unlisted_or_no_listed = obj.has_unlisted_versions(
-            include_deleted=True
-        ) or not obj.has_listed_versions(include_deleted=True)
+        has_unlisted_or_no_listed = (
+            obj.has_unlisted_versions(include_deleted=True)
+            or obj.has_enterprise_versions(include_deleted=True)
+            or not obj.has_listed_versions(include_deleted=True)
+        )
 
         return has_unlisted_or_no_listed and (
             can_access_because_unlisted_viewer or can_access_because_unlisted_reviewer

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -227,9 +227,11 @@ class AllowUnlistedViewerOrReviewer(AllowListedViewerOrReviewer):
         can_access_because_unlisted_reviewer = acl.is_unlisted_addons_reviewer(
             request.user
         ) and (not self.disallow_unsafe or request.method in SAFE_METHODS)
-        has_unlisted_or_no_listed = obj.has_unlisted_versions(
-            include_deleted=True
-        ) or not obj.has_listed_versions(include_deleted=True)
+        has_unlisted_or_no_listed = (
+            obj.has_unlisted_versions(include_deleted=True)
+            or obj.has_enterprise_versions(include_deleted=True)
+            or not obj.has_listed_versions(include_deleted=True)
+        )
 
         return has_unlisted_or_no_listed and (
             can_access_because_unlisted_viewer or can_access_because_unlisted_reviewer

--- a/src/olympia/api/tests/test_permissions.py
+++ b/src/olympia/api/tests/test_permissions.py
@@ -601,11 +601,40 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
         self.request.method = 'GET'
         assert self.permission.has_object_permission(self.request, myview, obj)
 
+    def test_enterprise_reviewer(self):
+        self.request.user = user_factory()
+        self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
+        obj = Mock(spec=[])
+        obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: True
+
+        # Enterprise is restricted in similar manner to unlisted.
+        assert self.permission.has_permission(self.request, myview)
+        assert self.permission.has_object_permission(self.request, myview, obj)
+
+    def test_enterprise_viewer(self):
+        self.request.user = user_factory()
+        self.grant_permission(self.request.user, 'ReviewerTools:ViewUnlisted')
+        obj = Mock(spec=[])
+        obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: True
+
+        # Enterprise is restricted in similar manner to unlisted.
+        assert self.permission.has_permission(self.request, myview)
+
+        # self.request is a POST, viewers should not have access to that.
+        assert not self.permission.has_object_permission(self.request, myview, obj)
+
+        # GET requests should be allowed.
+        self.request.method = 'GET'
+        assert self.permission.has_object_permission(self.request, myview, obj)
+
     def test_object_with_listed_versions_but_no_unlisted_versions(self):
         self.request.user = user_factory()
         self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: True
 
         assert self.permission.has_permission(self.request, myview)
@@ -616,6 +645,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
         self.grant_permission(self.request.user, 'ReviewerTools:ViewUnlisted')
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: True
 
         assert self.permission.has_permission(self.request, myview)
@@ -626,6 +656,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
         self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: False
 
         assert self.permission.has_permission(self.request, myview)
@@ -636,6 +667,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
         self.grant_permission(self.request.user, 'ReviewerTools:ViewUnlisted')
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: False
 
         assert self.permission.has_permission(self.request, myview)
@@ -675,11 +707,24 @@ class TestAllowUnlistedViewerOrReviewerReadOnly(TestAllowUnlistedViewerOrReviewe
         self.request.method = 'GET'
         assert self.permission.has_object_permission(self.request, myview, obj)
 
+    def test_enterprise_reviewer(self):
+        self.request.user = user_factory()
+        self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
+        obj = Mock(spec=[])
+        obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: True
+
+        assert self.permission.has_permission(self.request, myview)
+        assert not self.permission.has_object_permission(self.request, myview, obj)
+        self.request.method = 'GET'
+        assert self.permission.has_object_permission(self.request, myview, obj)
+
     def test_object_with_no_unlisted_versions_and_no_listed_versions(self):
         self.request.user = user_factory()
         self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: False
         assert self.permission.has_permission(self.request, myview)
         assert not self.permission.has_object_permission(self.request, myview, obj)

--- a/src/olympia/api/tests/test_permissions.py
+++ b/src/olympia/api/tests/test_permissions.py
@@ -546,11 +546,42 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
         self.request.method = 'GET'
         assert self.permission.has_object_permission(self.request, myview, obj)
 
+    def test_enterprise_reviewer(self):
+        self.request.user = user_factory()
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
+        obj = Mock(spec=[])
+        obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: True
+
+        # Enterprise is restricted in similar manner to unlisted.
+        assert self.permission.has_permission(self.request, myview)
+        assert self.permission.has_object_permission(self.request, myview, obj)
+
+    def test_enterprise_viewer(self):
+        self.request.user = user_factory()
+        self.grant_permission(
+            self.request.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
+        obj = Mock(spec=[])
+        obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: True
+
+        # Enterprise is restricted in similar manner to unlisted.
+        assert self.permission.has_permission(self.request, myview)
+
+        # self.request is a POST, viewers should not have access to that.
+        assert not self.permission.has_object_permission(self.request, myview, obj)
+
+        # GET requests should be allowed.
+        self.request.method = 'GET'
+        assert self.permission.has_object_permission(self.request, myview, obj)
+
     def test_object_with_listed_versions_but_no_unlisted_versions(self):
         self.request.user = user_factory()
         self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: True
 
         assert self.permission.has_permission(self.request, myview)
@@ -563,6 +594,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
         )
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: True
 
         assert self.permission.has_permission(self.request, myview)
@@ -573,6 +605,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
         self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: False
 
         assert self.permission.has_permission(self.request, myview)
@@ -585,6 +618,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
         )
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
+        obj.has_enterprise_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: False
 
         assert self.permission.has_permission(self.request, myview)

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -520,12 +520,12 @@ class TestUploadURLs(TestCase):
             assert resp.status_code == 302
         self.file_upload = FileUpload.objects.get()
 
-    def upload_addon(self, status=amo.STATUS_APPROVED, listed=True):
+    def upload_addon(self, channel, status=amo.STATUS_APPROVED):
         """Update the test add-on with the given flags and send an upload
         request for it."""
-        self.change_channel_for_addon(self.addon, listed=listed)
+        self.change_channel_for_addon(self.addon, channel=channel)
         self.addon.update(status=status)
-        channel_text = 'listed' if listed else 'unlisted'
+        channel_text = amo.CHANNEL_CHOICES_API[channel]
         return self.upload(
             'devhub.upload_for_version', channel=channel_text, addon_id=self.addon.slug
         )
@@ -552,8 +552,8 @@ class TestUploadURLs(TestCase):
         """Test that the add-on update upload URLs result in file uploads
         with the correct flags."""
         for status in amo.VALID_ADDON_STATUSES:
-            self.upload_addon(listed=True, status=status)
+            self.upload_addon(channel=amo.CHANNEL_LISTED, status=status)
             self.expect_validation(channel=amo.CHANNEL_LISTED)
 
-        self.upload_addon(listed=False, status=amo.STATUS_APPROVED)
+        self.upload_addon(channel=amo.CHANNEL_UNLISTED, status=amo.STATUS_APPROVED)
         self.expect_validation(channel=amo.CHANNEL_UNLISTED)

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -172,6 +172,9 @@ class TestFileUploadViewSet(TestCase):
     def test_create_unlisted(self):
         self._test_create(amo.CHANNEL_UNLISTED, 'unlisted')
 
+    def test_create_enterprise(self):
+        self._test_create(amo.CHANNEL_ENTERPRISE, 'enterprise')
+
     def test_list(self):
         response = self.client.get(
             self.list_url,

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1321,7 +1321,7 @@ DRF_API_GATES = {
         'categories-application',
         'minimal-profile-has-all-fields-shim',
         'promoted-groups-shim',
-        'enterprise-channel-shim',
+        'no-enterprise-channel',
     ),
     'v4': (
         'l10n_flat_input_output',
@@ -1341,7 +1341,7 @@ DRF_API_GATES = {
         'block-versions-list-shim',
         'promoted-groups-shim',
         'minimal-profile-has-all-fields-shim',
-        'enterprise-channel-shim',
+        'no-enterprise-channel',
     ),
     'v5': (
         'addons-search-_score-field',

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1321,6 +1321,7 @@ DRF_API_GATES = {
         'categories-application',
         'minimal-profile-has-all-fields-shim',
         'promoted-groups-shim',
+        'enterprise-channel-shim',
     ),
     'v4': (
         'l10n_flat_input_output',
@@ -1340,6 +1341,7 @@ DRF_API_GATES = {
         'block-versions-list-shim',
         'promoted-groups-shim',
         'minimal-profile-has-all-fields-shim',
+        'enterprise-channel-shim',
     ),
     'v5': (
         'addons-search-_score-field',

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -611,18 +611,19 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         assert 'processed' in response.data
         assert addon.versions.latest().channel == amo.CHANNEL_LISTED
 
-    def test_enterprise_channel_ignored_for_existing_addons_listed(self):
-        addon = Addon.objects.get(guid=self.guid)
+    def test_enterprise_channel_errors_for_existing_addons_listed(self):
         response = self.request('PUT', self.url(self.guid, '3.0'), channel='enterprise')
-        assert response.status_code == 202, response.data
-        assert addon.versions.latest().channel == amo.CHANNEL_LISTED
+        assert response.status_code == 400
+        error_msg = 'Only API v5+ supports enterprise channels.'
+        assert error_msg in response.data['error']
 
-    def test_enterprise_channel_ignored_for_existing_addons_unlisted(self):
+    def test_enterprise_channel_errors_for_existing_addons_unlisted(self):
         addon = Addon.objects.get(guid=self.guid)
         addon.versions.latest().update(channel=amo.CHANNEL_UNLISTED)
         response = self.request('PUT', self.url(self.guid, '3.0'), channel='enterprise')
-        assert response.status_code == 202, response.data
-        assert addon.versions.latest().channel == amo.CHANNEL_UNLISTED
+        assert response.status_code == 400
+        error_msg = 'Only API v5+ supports enterprise channels.'
+        assert error_msg in response.data['error']
 
     def test_enterprise_channel_ignored_for_new_addon(self):
         response = self.request(

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -611,6 +611,27 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         assert 'processed' in response.data
         assert addon.versions.latest().channel == amo.CHANNEL_LISTED
 
+    def test_enterprise_channel_ignored_for_existing_addons_listed(self):
+        addon = Addon.objects.get(guid=self.guid)
+        response = self.request('PUT', self.url(self.guid, '3.0'), channel='enterprise')
+        assert response.status_code == 202, response.data
+        assert addon.versions.latest().channel == amo.CHANNEL_LISTED
+
+    def test_enterprise_channel_ignored_for_existing_addons_unlisted(self):
+        addon = Addon.objects.get(guid=self.guid)
+        addon.versions.latest().update(channel=amo.CHANNEL_UNLISTED)
+        response = self.request('PUT', self.url(self.guid, '3.0'), channel='enterprise')
+        assert response.status_code == 202, response.data
+        assert addon.versions.latest().channel == amo.CHANNEL_UNLISTED
+
+    def test_enterprise_channel_ignored_for_new_addon(self):
+        response = self.request(
+            'PUT', guid='@create-version', version='1.0', channel='enterprise'
+        )
+        assert response.status_code == 201, response.data
+        addon = Addon.objects.get(guid='@create-version')
+        assert addon.versions.latest().channel == amo.CHANNEL_UNLISTED
+
     def test_listed_channel_fails_for_incomplete_addon(self):
         addon = Addon.objects.get(guid=self.guid)
         assert addon.status == amo.STATUS_APPROVED

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -204,7 +204,9 @@ class VersionView(APIView):
             created = False
             channel_param = request.POST.get('channel')
             channel = amo.CHANNEL_CHOICES_LOOKUP.get(channel_param)
-            if not channel:
+            if (
+                not channel or channel == amo.CHANNEL_ENTERPRISE  # api/v5+ only
+            ):
                 last_version = addon.find_latest_version(None, exclude=())
                 if last_version:
                     channel = last_version.channel

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -199,7 +199,9 @@ class VersionView(APIView):
             created = False
             channel_param = request.POST.get('channel')
             channel = amo.CHANNEL_CHOICES_LOOKUP.get(channel_param)
-            if not channel:
+            if (
+                not channel or channel == amo.CHANNEL_ENTERPRISE  # api/v5+ only
+            ):
                 last_version = addon.find_latest_version(None, exclude=())
                 if last_version:
                     channel = last_version.channel

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -204,9 +204,12 @@ class VersionView(APIView):
             created = False
             channel_param = request.POST.get('channel')
             channel = amo.CHANNEL_CHOICES_LOOKUP.get(channel_param)
-            if (
-                not channel or channel == amo.CHANNEL_ENTERPRISE  # api/v5+ only
-            ):
+
+            if channel == amo.CHANNEL_ENTERPRISE:
+                msg = gettext('Only API v5+ supports enterprise channels.')
+                raise forms.ValidationError(msg, status.HTTP_400_BAD_REQUEST)
+
+            if not channel:
                 last_version = addon.find_latest_version(None, exclude=())
                 if last_version:
                     channel = last_version.channel

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -286,6 +286,12 @@ class TestDownloadsUnlistedVersions(TestDownloadsBase):
         assert self.client.get(self.latest_url).status_code == 404
 
 
+class TestDownloadsEnterpriseVersions(TestDownloadsUnlistedVersions):
+    def setUp(self):
+        super().setUp()
+        self.change_channel_for_addon(self.addon, amo.CHANNEL_ENTERPRISE)
+
+
 class TestDownloadsUnlistedAddonDeleted(TestDownloadsUnlistedVersions):
     # Everything should work the same for unlisted when the addon is deleted
     # except developers can no longer access.
@@ -619,6 +625,28 @@ class TestUnlistedDisabledAndDeletedFileDownloadsSessionAPIAuth(
 class TestUnlistedDisabledAndDeletedFileDownloadsJWTAPIAuth(
     APILoginMixin, TestUnlistedDisabledAndDeletedFileDownloads
 ):
+    client_class = APITestClientJWT
+
+
+class TestEnterpriseFileDownloads(
+    DownloadsNonDisabledMixin, NonPublicFileDownloadsMixin, TestDownloadsBase
+):
+    def setUp(self):
+        super().setUp()
+        self.change_channel_for_addon(self.addon, amo.CHANNEL_ENTERPRISE)
+        self.grant_permission(
+            UserProfile.objects.get(email='reviewer@mozilla.com'),
+            amo.permissions.ADDONS_REVIEW_UNLISTED,
+        )
+
+
+class TestEnterpriseFileDownloadsSessionAPIAuth(
+    APILoginMixin, TestEnterpriseFileDownloads
+):
+    client_class = APITestClientSessionID
+
+
+class TestEnterpriseFileDownloadsJWTAPIAuth(APILoginMixin, TestEnterpriseFileDownloads):
     client_class = APITestClientJWT
 
 

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -69,10 +69,10 @@ def download_file(request, file_id, download_type=None, **kwargs):
     """
     Download the file identified by `file_id` parameter.
 
-    If the file is disabled or belongs to an unlisted version, requires an
-    add-on developer, an appropriate reviewer for the channel or a user with a
-    special permission. If the file is deleted or belongs to a deleted version
-    or add-on, reviewers can still access but developers can't.
+    If the file is disabled or belongs to an unlisted or enterprise version,
+    requires an add-on developer, an appropriate reviewer for the channel or a
+    user with a special permission. If the file is deleted or belongs to a
+    deleted version or add-on, reviewers can still access but developers can't.
     """
 
     def is_appropriate_reviewer(addon, channel):
@@ -106,10 +106,10 @@ def download_file(request, file_id, download_type=None, **kwargs):
     elif (
         addon.is_disabled
         or file_.status == amo.STATUS_DISABLED
-        or channel == amo.CHANNEL_UNLISTED
+        or channel in (amo.CHANNEL_UNLISTED, amo.CHANNEL_ENTERPRISE)
     ):
         # Only the appropriate reviewer or developers of the add-on can see
-        # disabled or unlisted things.
+        # disabled, unlisted or enterprise things.
         require_permission = True
         has_permission = is_appropriate_reviewer(
             addon, channel


### PR DESCRIPTION
Fixes mozilla/addons#14851

### Description

Adds API support for enterprise channel work.

### Testing

- V3 and V4 APIs do not support enterprise uploads.
- Does not show enterprise by default anywhere (following unlisted behaviour)
- Only authors & those with unlisted permissions can access the APIs.

## 1. Upload

`/api/v5/addons/upload/`
-  [POST](https://mozilla.github.io/addons-server/topics/api/addons.html#upload-create) can take and create an enterprise upload. 
- [GET](https://mozilla.github.io/addons-server/topics/api/addons.html#upload-list) should include any previously uploaded enterprise uploads.

`/api/v5/addons/upload/<string:uuid>/`
- [GET](https://mozilla.github.io/addons-server/topics/api/addons.html#upload-detail) shows details about an enterprise upload. Should show the `ADMIN_INSTALL_ONLY_REQUIRED` error when the setting is missing.
<details><summary>Screenshots</summary>
<img width="827" height="680" alt="image" src="https://github.com/user-attachments/assets/c33db5bb-41c7-486a-9bce-3d3026a496ca" />
<img width="747" height="578" alt="image" src="https://github.com/user-attachments/assets/5e612542-3f7a-4ca5-99ef-3f27c7bc215b" />
</details>

## 2. Add-on

`/api/v5/addons/addon/`
- [POST](https://mozilla.github.io/addons-server/topics/api/addons.html#create) can take an enterprise upload and create a new add-on.

## 3. Version

`/api/v5/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/`
- [POST](https://mozilla.github.io/addons-server/topics/api/addons.html#version-create) Allows submitting an enterprise upload as a version to an existing add-on.
- [GET](https://mozilla.github.io/addons-server/topics/api/addons.html#versions-list) does not show enterprise versions by default. Can filter to show via `enterprise_only`.

`/api/v5/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/(int:id|string:version_number)/`
- [GET](https://mozilla.github.io/addons-server/topics/api/addons.html#version-detail) can retrieve an enterprise version.

### Checklist


- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
