### PR TITLE
Add --force-reviewer and --before args to auto_resolve_reports command

### DIFF
--- a/src/olympia/abuse/management/commands/auto_resolve_reports.py
+++ b/src/olympia/abuse/management/commands/auto_resolve_reports.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from django.core.management.base import BaseCommand
 
 import olympia.core.logger
@@ -8,13 +10,37 @@ from olympia.abuse.tasks import auto_resolve_job
 class Command(BaseCommand):
     log = olympia.core.logger.getLogger('z.abuse')
 
-    def handle(self, *args, **options):
-        job_ids = (
-            CinderJob.objects.filter(
-                decisions__isnull=True
-            ).resolvable_in_reviewer_tools()
-        ).values_list('id', flat=True)
-        self.stdout.write(f'{len(job_ids)} unresolved CinderJobs in reviewer tools')
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--force-reviewer',
+            action='store_true',
+            default=False,
+            help=(
+                'Force auto-resolve of all unresolved CinderJobs handled by reviewers, '
+                'skipping should_auto_resolve check',
+            ),
+        )
+        parser.add_argument(
+            '--before',
+            type=date.fromisoformat,
+            default=None,
+            help=(
+                'Only auto-resolve CinderJobs with reports created before this date '
+                '(YYYY-MM-DD)'
+            ),
+        )
 
-        for job_id in job_ids:
-            auto_resolve_job.delay(job_pk=job_id)
+    def handle(self, *args, **options):
+        force = options.get('force_reviewer')
+        before = options.get('before')
+        jobs = (
+            CinderJob.objects.filter(decisions__isnull=True)
+            .resolvable_in_reviewer_tools()
+            .exclude(appealed_decisions__isnull=False)
+        )
+        if before:
+            jobs = jobs.exclude(abusereport__created__gte=before)
+        self.stdout.write(f'{jobs.count()} unresolved CinderJobs in reviewer tools')
+
+        for job_id in jobs.values_list('id', flat=True):
+            auto_resolve_job.delay(job_pk=job_id, force=force)

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -219,7 +219,7 @@ class CinderJob(ModelBase):
         )
         return not self.is_appeal and (is_disabled or is_human_reviewed)
 
-    def handle_already_moderated(self, abuse_report, entity_helper):
+    def handle_already_moderated(self, abuse_report, entity_helper, metadata=None):
         decision = ContentDecision.objects.create(
             addon=(self.target_addon if self.target_addon_id else abuse_report.addon),
             rating=getattr(abuse_report, 'rating', None),
@@ -230,6 +230,7 @@ class CinderJob(ModelBase):
             reviewer_user_id=settings.TASK_USER_ID,
             cinder_job=self,
             override_of=self.final_decision,
+            metadata=metadata or {},
         )
         decision.policies.set(
             CinderPolicy.objects.filter(

--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -302,10 +302,9 @@ def handle_forward_to_legal_action(*, decision_pk):
 
 @task
 @use_primary_db
-def auto_resolve_job(*, job_pk):
+def auto_resolve_job(*, job_pk, force=False):
     job = CinderJob.objects.get(pk=job_pk)
-    if job.should_auto_resolve():
-        # if it should be auto resolved, fire a task to resolve it
+    if force or job.should_auto_resolve():
         log.info(
             'Found job#%s to auto resolve for addon#%s.',
             job.id,
@@ -314,7 +313,11 @@ def auto_resolve_job(*, job_pk):
         entity_helper = CinderJob.get_entity_helper(
             job.target, resolved_in_reviewer_tools=True
         )
-        job.handle_already_moderated(job.abusereport_set.first(), entity_helper)
+        job.handle_already_moderated(
+            job.abusereport_set.first(),
+            entity_helper,
+            metadata={'automation_source': 'auto_resolve_reports command'},
+        )
         job.clear_needs_human_review_flags()
 
 

--- a/src/olympia/abuse/tests/test_commands.py
+++ b/src/olympia/abuse/tests/test_commands.py
@@ -1,7 +1,8 @@
 import uuid
-from datetime import datetime
+from datetime import date, datetime, timedelta
 
 from django.conf import settings
+from django.core import mail
 from django.core.management import call_command
 
 import pytest
@@ -106,8 +107,16 @@ class TestAutoResolveReports(TestCase):
         assert CinderJob.objects.unresolved().get() == job_not_reviewed
         assert job1.reload().final_decision
         assert job1.final_decision.action == DECISION_ACTIONS.AMO_CLOSED_NO_ACTION
+        assert (
+            job1.final_decision.metadata['automation_source']
+            == 'auto_resolve_reports command'
+        )
         assert job2.reload().final_decision
         assert job2.final_decision.action == DECISION_ACTIONS.AMO_CLOSED_NO_ACTION
+        assert (
+            job2.final_decision.metadata['automation_source']
+            == 'auto_resolve_reports command'
+        )
         # NHRs should be cleared.
         assert not NeedsHumanReview.objects.filter(
             version__addon=addon1, is_active=True
@@ -115,6 +124,173 @@ class TestAutoResolveReports(TestCase):
         assert not NeedsHumanReview.objects.filter(
             version__addon=addon2, is_active=True
         ).exists()
+
+    def test_auto_resolve_force_reviewer(self):
+        addon1 = addon_factory()
+        job1 = CinderJob.objects.create(
+            job_id='1', resolvable_in_reviewer_tools=True, target_addon=addon1
+        )
+        AbuseReport.objects.create(
+            guid=addon1.guid, cinder_job=job1, reporter_email='some1@user'
+        )
+        unreviewed = version_factory(
+            addon=addon1, file_kw={'status': amo.STATUS_AWAITING_REVIEW}
+        )
+        job_not_reviewer_tools = CinderJob.objects.create(
+            job_id='nope', resolvable_in_reviewer_tools=False, target_addon=addon1
+        )
+        AbuseReport.objects.create(
+            guid=addon1.guid,
+            addon_version=unreviewed.version,
+            cinder_job=job_not_reviewer_tools,
+            reporter_email='somenot@user',
+        )
+        addon2 = addon_factory()
+        job2 = CinderJob.objects.create(
+            job_id='2', resolvable_in_reviewer_tools=True, target_addon=addon2
+        )
+        AbuseReport.objects.create(
+            guid=addon2.guid,
+            addon_version=addon2.current_version.version,
+            cinder_job=job2,
+            reporter=user_factory(email='some2@user'),
+        )
+        job_appeal = CinderJob.objects.create(
+            job_id='appeal', resolvable_in_reviewer_tools=True, target_addon=addon2
+        )
+        CinderJob.objects.create(
+            job_id='appealled',
+            decision=ContentDecision.objects.create(
+                addon=addon2,
+                action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+                appeal_job=job_appeal,
+            ),
+        )
+        assert CinderJob.objects.unresolved().count() == 4
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}v1/jobs/{job1.job_id}/decision',
+            json={'uuid': uuid.uuid4().hex},
+            status=201,
+        )
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}v1/jobs/{job2.job_id}/decision',
+            json={'uuid': uuid.uuid4().hex},
+            status=201,
+        )
+        NeedsHumanReview.objects.create(
+            reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION,
+            version=unreviewed,
+        )
+        NeedsHumanReview.objects.create(
+            reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION,
+            version=addon2.current_version,
+        )
+        call_command('auto_resolve_reports', '--force-reviewer')
+
+        assert CinderJob.objects.unresolved().count() == 2
+        assert set(CinderJob.objects.unresolved().all()) == {
+            job_not_reviewer_tools,
+            job_appeal,
+        }
+        assert job1.reload().final_decision
+        assert job1.final_decision.action == DECISION_ACTIONS.AMO_CLOSED_NO_ACTION
+        assert (
+            job1.final_decision.metadata['automation_source']
+            == 'auto_resolve_reports command'
+        )
+        assert job2.reload().final_decision
+        assert job2.final_decision.action == DECISION_ACTIONS.AMO_CLOSED_NO_ACTION
+        assert (
+            job2.final_decision.metadata['automation_source']
+            == 'auto_resolve_reports command'
+        )
+        # NHRs should be cleared.
+        assert not NeedsHumanReview.objects.filter(
+            version__addon=addon1, is_active=True
+        ).exists()
+        assert not NeedsHumanReview.objects.filter(
+            version__addon=addon2, is_active=True
+        ).exists()
+        assert len(mail.outbox) == 2
+        assert {tuple(email.recipients()) for email in mail.outbox} == {
+            ('some1@user',),
+            ('some2@user',),
+        }
+
+    def test_auto_resolve_before_date(self):
+        today = date.today()
+        addon = addon_factory(version_kw={'human_review_date': datetime.now()})
+        job_old = CinderJob.objects.create(
+            job_id='1',
+            resolvable_in_reviewer_tools=True,
+            target_addon=addon,
+        )
+        AbuseReport.objects.create(
+            guid=job_old.target_addon.guid,
+            cinder_job=job_old,
+            created=today - timedelta(days=5),
+            reporter_email='some1@user',
+        )
+        job_new = CinderJob.objects.create(
+            job_id='nope',
+            resolvable_in_reviewer_tools=True,
+            target_addon=addon,
+        )
+        AbuseReport.objects.create(
+            guid=job_new.target_addon.guid,
+            cinder_job=job_new,
+            created=today - timedelta(days=1),
+        )
+        job_mixed = CinderJob.objects.create(
+            job_id='2',
+            resolvable_in_reviewer_tools=True,
+            target_addon=addon_factory(
+                version_kw={'human_review_date': datetime.now()}
+            ),
+        )
+        AbuseReport.objects.create(
+            guid=job_mixed.target_addon.guid,
+            addon_version=job_mixed.target_addon.current_version.version,
+            cinder_job=job_mixed,
+            created=(
+                datetime.combine(today, datetime.min.time())
+                - timedelta(days=3, seconds=5)
+            ),
+        )
+        AbuseReport.objects.create(
+            guid=job_mixed.target_addon.guid,
+            addon_version=job_mixed.target_addon.current_version.version,
+            cinder_job=job_mixed,
+            created=(datetime.combine(today, datetime.min.time()) - timedelta(days=2)),
+        )
+        assert CinderJob.objects.unresolved().count() == 3
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}v1/jobs/{job_old.job_id}/decision',
+            json={'uuid': uuid.uuid4().hex},
+            status=201,
+        )
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}v1/jobs/{job_mixed.job_id}/decision',
+            json={'uuid': uuid.uuid4().hex},
+            status=201,
+        )
+        before_date = today - timedelta(days=3)  # set a date in the past
+        call_command('auto_resolve_reports', before=str(before_date))
+
+        assert CinderJob.objects.unresolved().count() == 2
+        assert set(CinderJob.objects.unresolved().all()) == {job_new, job_mixed}
+        assert job_old.reload().final_decision
+        assert job_old.final_decision.action == DECISION_ACTIONS.AMO_CLOSED_NO_ACTION
+        assert (
+            job_old.final_decision.metadata['automation_source']
+            == 'auto_resolve_reports command'
+        )
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].recipients() == ['some1@user']
 
     def test_auto_resolve_forwarded_job(self):
         addon1 = addon_factory(version_kw={'human_review_date': datetime.now()})
@@ -199,6 +375,10 @@ class TestAutoResolveReports(TestCase):
         assert job_forwarded.reload().final_decision
         assert (
             job_forwarded.final_decision.action == DECISION_ACTIONS.AMO_CLOSED_NO_ACTION
+        )
+        assert (
+            job_forwarded.final_decision.metadata['automation_source']
+            == 'auto_resolve_reports command'
         )
         # NHR should be cleared.
         assert not NeedsHumanReview.objects.filter(


### PR DESCRIPTION
Fixes mozilla/addons#16364

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Expands on the existing auto_resolve_reports command to allow us to close jobs that don't pass the should_auto_resolve check and/or limit the jobs to only those that have abuse reports created before a certain date.

### Context

If this command was going to be used more widely, I'd add an `after` parameter, plus break down `force-reviewer` into `force` and `reviewer-handled=True/False`.  But according to the ticket this is a one-time fix (one could argue even _this_ much is unnecessary).

### Testing

- enable all the Cinder related waffles + have your Cinder API key set in settings
- report an add-on [1] for abuse for abuse for one of the "Report the add-on because it's illegal or incompliant" reasons
  - either do this logged in, or specify an email address  
  - in a django shell identify the AbuseReport instance (the newest) and `.update(created=<some past date>)`; 
  - then update the associated `.cinder_job.update(resolvable_in_reviewer_tools=True)` to make it resolvable in reviewer tools
- report a different add-on [2], but report it twice
  - this time, only update the created date of one of the abuse reports to a past date
  - update the associated cinder_job like before (both abuse reports should be fk'd to the same CinderJob instance - cinder bundles abuse reports by add-on)
- (optional) create some more abuse reports/jobs that shouldn't be auto resolved:
  - an abuse report for another add-on that doesn't have it's date updated, so is new
  - abuse reports where the CinderJob isn't updated to `resolvable_in_reviewer_tools=True`
  - an appeal job (make a decision on an add-on in the reviewer tools; appeal the decision)
- run `./manage.py auto_resolve_reports --before=2025-07-01 --force-reviewer` - adjusted to be after whatever `<past date>` you used above.
- see the CinderJob for add-on [1] is resolved with a decision 
  - check the ContentDecision in django shell - the `metadata` should contain an indication it was created via auto_resolve_reports.
- see the CinderJob for add-on [2] is not resolved (plus any of the optional cases)
- see there is an email to you, as the reporter, in django admin fakemail for your report on add-on [1]

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
