### PR TITLE
convert all permission string literals in tests to permission constant

### DIFF
--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -376,7 +376,7 @@ class NegativeContentActionMixin:
         assert len(mail.outbox) == 0
 
         user = user_factory()
-        self.grant_permission(user, ':'.join(ADDONS_HIGH_IMPACT_APPROVE))
+        self.grant_permission(user, ADDONS_HIGH_IMPACT_APPROVE)
         self.ActionClass(self.decision).notify_2nd_level_approvers()
         assert len(mail.outbox) == 1
         assert mail.outbox[0].subject == (
@@ -631,7 +631,7 @@ class TestContentActionBanUser(
         self.user.update(email='foo@baa')
         assert action_helper.should_hold_action() is False
         del self.user.groups_list
-        self.grant_permission(self.user, 'this:thing')
+        self.grant_permission(self.user, amo.permissions.NONE)
         assert action_helper.should_hold_action() is True
 
         self.user.groups_list = []

--- a/src/olympia/abuse/tests/test_admin.py
+++ b/src/olympia/abuse/tests/test_admin.py
@@ -35,7 +35,9 @@ class TestAbuseReportAdmin(TestCase):
         cls.addon2 = addon_factory(guid='@guid2', name='Owt')
         cls.addon3 = addon_factory(guid='@guid3', name='Eerht')
         cls.user = user_factory(email='someone@mozilla.com')
-        grant_permission(cls.user, 'AbuseReports:Edit', 'Abuse Report Triage')
+        grant_permission(
+            cls.user, amo.permissions.ABUSEREPORTS_EDIT, name='Abuse Report Triage'
+        )
         # Create a few abuse reports.
         cls.report1 = AbuseReport.objects.create(
             addon_name='The One',
@@ -581,10 +583,10 @@ class TestCinderPolicyAdmin(TestCase):
         self.list_url = reverse('admin:abuse_cinderpolicy_changelist')
         self.sync_cinder_policies_url = reverse('admin:abuse_sync_cinder_policies')
 
-    def login(self, permission='*:*'):
+    def login(self, permission=amo.permissions.SUPERPOWERS):
         self.user = user_factory(email='someone@mozilla.com')
         if permission:
-            grant_permission(self.user, permission, 'Group')
+            grant_permission(self.user, permission, name='Group')
         self.client.force_login(self.user)
 
     def _make_list_request(self, *, read_only=False):
@@ -641,7 +643,7 @@ class TestCinderPolicyAdmin(TestCase):
         self._make_list_request()
 
     def test_list_with_view_permission(self):
-        self.login(permission='CinderPolicies:View')
+        self.login(permission=amo.permissions.CINDER_POLICIES_VIEW)
         self._make_list_request(read_only=True)
 
     def test_list_with_filter(self):
@@ -711,7 +713,7 @@ class TestCinderPolicyAdmin(TestCase):
         assert policy.reload().expose_in_reviewer_tools == POLICY_EXPOSURE.NONE
 
     def test_edit_policies_cannot_with_view_permission(self):
-        self.login(permission='CinderPolicies:View')
+        self.login(permission=amo.permissions.CINDER_POLICIES_VIEW)
         policy = self._make_edit_request(403)
         assert policy.reload().expose_in_reviewer_tools == POLICY_EXPOSURE.NONE
 
@@ -738,5 +740,5 @@ class TestCinderPolicyAdmin(TestCase):
         self._make_sync_policies_request()
 
     def test_sync_policies_with_view_permission(self):
-        self.login(permission='CinderPolicies:View')
+        self.login(permission=amo.permissions.CINDER_POLICIES_VIEW)
         self._make_sync_policies_request()

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -3376,7 +3376,7 @@ class TestContentDecision(TestCase):
         assert 'appeal' in mail.outbox[0].body
 
     def test_execute_action_ban_user_held(self):
-        self.grant_permission(user_factory(), ':'.join(ADDONS_HIGH_IMPACT_APPROVE))
+        self.grant_permission(user_factory(), ADDONS_HIGH_IMPACT_APPROVE)
         user = user_factory(email='superstarops@mozilla.com')
         decision = ContentDecision.objects.create(
             user=user,
@@ -3421,7 +3421,7 @@ class TestContentDecision(TestCase):
         assert 'appeal' in mail.outbox[0].body
 
     def test_execute_action_disable_addon_held(self):
-        self.grant_permission(user_factory(), ':'.join(ADDONS_HIGH_IMPACT_APPROVE))
+        self.grant_permission(user_factory(), ADDONS_HIGH_IMPACT_APPROVE)
         addon = addon_factory(users=[user_factory()])
         self.make_addon_promoted(
             addon, api_name='high_profile', high_profile=True, approve_version=True
@@ -3552,7 +3552,7 @@ class TestContentDecision(TestCase):
         assert VersionReviewerFlags.objects.filter(version=version).exists()
 
     def test_execute_action_reject_version_held(self):
-        self.grant_permission(user_factory(), ':'.join(ADDONS_HIGH_IMPACT_APPROVE))
+        self.grant_permission(user_factory(), ADDONS_HIGH_IMPACT_APPROVE)
         addon = addon_factory(users=[user_factory()], file_kw={'is_signed': True})
         version = addon.current_version
         self.make_addon_promoted(
@@ -3818,7 +3818,7 @@ class TestContentDecision(TestCase):
         assert addon.current_version.reviewerflags.pending_rejection == in_fourteen_days
 
     def test_execute_action_reject_version_delayed_held(self):
-        self.grant_permission(user_factory(), ':'.join(ADDONS_HIGH_IMPACT_APPROVE))
+        self.grant_permission(user_factory(), ADDONS_HIGH_IMPACT_APPROVE)
         addon = addon_factory(users=[user_factory()], file_kw={'is_signed': True})
         version = addon.current_version
         self.make_addon_promoted(
@@ -4042,7 +4042,7 @@ class TestContentDecision(TestCase):
         assert 'appeal' in mail.outbox[0].body
 
     def test_execute_action_delete_collection_held(self):
-        self.grant_permission(user_factory(), ':'.join(ADDONS_HIGH_IMPACT_APPROVE))
+        self.grant_permission(user_factory(), ADDONS_HIGH_IMPACT_APPROVE)
         collection = collection_factory(author=self.task_user)
         decision = ContentDecision.objects.create(
             collection=collection,
@@ -4087,7 +4087,7 @@ class TestContentDecision(TestCase):
         assert 'appeal' in mail.outbox[0].body
 
     def test_execute_action_delete_rating_held(self):
-        self.grant_permission(user_factory(), ':'.join(ADDONS_HIGH_IMPACT_APPROVE))
+        self.grant_permission(user_factory(), ADDONS_HIGH_IMPACT_APPROVE)
         user = user_factory()
         addon = addon_factory(users=[user])
         rating = Rating.objects.create(

--- a/src/olympia/access/tests.py
+++ b/src/olympia/access/tests.py
@@ -199,7 +199,7 @@ class TestCheckReviewer(TestCase):
         assert not is_reviewer(self.user, self.statictheme)
 
     def test_perm_addons(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         assert is_listed_addons_reviewer(self.user)
         assert not is_unlisted_addons_reviewer(self.user)
         assert not is_unlisted_addons_viewer_or_reviewer(self.user)
@@ -207,7 +207,7 @@ class TestCheckReviewer(TestCase):
         assert is_user_any_kind_of_reviewer(self.user)
 
     def test_perm_unlisted_addons(self):
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         assert not is_listed_addons_reviewer(self.user)
         assert is_unlisted_addons_reviewer(self.user)
         assert is_unlisted_addons_viewer_or_reviewer(self.user)
@@ -215,7 +215,7 @@ class TestCheckReviewer(TestCase):
         assert is_user_any_kind_of_reviewer(self.user)
 
     def test_perm_static_themes(self):
-        self.grant_permission(self.user, 'Addons:ThemeReview')
+        self.grant_permission(self.user, amo.permissions.STATIC_THEMES_REVIEW)
         assert not is_listed_addons_reviewer(self.user)
         assert not is_unlisted_addons_reviewer(self.user)
         assert not is_unlisted_addons_viewer_or_reviewer(self.user)
@@ -224,14 +224,14 @@ class TestCheckReviewer(TestCase):
 
     def test_is_reviewer_for_addon_reviewer(self):
         """An addon reviewer is not necessarily a theme reviewer."""
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         assert is_reviewer(self.user, self.addon)
         assert not is_reviewer(self.user, self.statictheme)
         assert is_user_any_kind_of_reviewer(self.user)
         assert is_reviewer(self.user, self.addon, allow_content_reviewers=False)
 
     def test_is_reviewer_for_static_theme_reviewer(self):
-        self.grant_permission(self.user, 'Addons:ThemeReview')
+        self.grant_permission(self.user, amo.permissions.STATIC_THEMES_REVIEW)
         assert not is_reviewer(self.user, self.addon)
         assert not is_reviewer(self.user, self.addon, allow_content_reviewers=False)
         assert is_reviewer(self.user, self.statictheme)
@@ -240,7 +240,7 @@ class TestCheckReviewer(TestCase):
         assert is_user_any_kind_of_reviewer(self.user)
 
     def test_perm_content_review(self):
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         assert is_user_any_kind_of_reviewer(self.user)
 
         assert not is_unlisted_addons_reviewer(self.user)
@@ -256,7 +256,7 @@ class TestCheckReviewer(TestCase):
         assert not is_reviewer(self.user, self.addon, allow_content_reviewers=False)
 
     def test_perm_reviewertools_view(self):
-        self.grant_permission(self.user, 'ReviewerTools:View')
+        self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_VIEW)
         assert is_user_any_kind_of_reviewer(self.user, allow_viewers=True)
         assert not is_user_any_kind_of_reviewer(self.user)
         assert not is_unlisted_addons_reviewer(self.user)
@@ -269,7 +269,7 @@ class TestCheckReviewer(TestCase):
     def test_perm_reviewertools_unlisted_view(self):
         self.make_addon_unlisted(self.addon)
         self.make_addon_unlisted(self.statictheme)
-        self.grant_permission(self.user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         assert is_user_any_kind_of_reviewer(self.user, allow_viewers=True)
         assert not is_user_any_kind_of_reviewer(self.user)
         assert is_unlisted_addons_viewer_or_reviewer(self.user)

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -632,7 +632,7 @@ class TestWithUser(TestCase):
 
     def test_special_user_should_redirect_for_two_factor_auth(self):
         # User isn't a developer but is part of a group.
-        self.grant_permission(self.user, 'Some:Thing')
+        self.grant_permission(self.user, amo.permissions.NONE)
         self._test_should_redirect_for_two_factor_auth()
 
     def test_theme_developer_should_not_redirect_for_two_factor_auth(self):
@@ -1284,7 +1284,7 @@ class TestAccountViewSet(TestCase):
 
         # Even as admin deleted users are not visible through the API.
         user = user_factory()
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.login_api(user)
         response = self.client.get(self.url)
         assert response.status_code == 404
@@ -1336,7 +1336,7 @@ class TestAccountViewSet(TestCase):
         assert response.data['url'] == absolutify(self.user.get_url_path())
 
     def test_admin_view(self):
-        self.grant_permission(self.user, 'Users:Edit')
+        self.grant_permission(self.user, amo.permissions.USERS_EDIT)
         self.client.login_api(self.user)
         self.random_user = user_factory(biography='something!')
         random_user_profile_url = reverse_ns(
@@ -1366,7 +1366,7 @@ class TestAccountViewSet(TestCase):
 
     def test_admin_view_slug(self):
         # Check it works the same with an account slug rather than pk.
-        self.grant_permission(self.user, 'Users:Edit')
+        self.grant_permission(self.user, amo.permissions.USERS_EDIT)
         self.client.login_api(self.user)
         self.random_user = user_factory()
         random_user_profile_url = reverse_ns(
@@ -1379,7 +1379,7 @@ class TestAccountViewSet(TestCase):
         assert response.data['url'] == absolutify(self.random_user.get_url_path())
 
     def test_lookup_view(self):
-        self.grant_permission(self.user, 'Users:Lookup')
+        self.grant_permission(self.user, amo.permissions.USERS_LOOKUP)
         self.client.login_api(self.user)
         random_user = user_factory(biography='something!')
         random_user_profile_url = reverse_ns(
@@ -1413,7 +1413,7 @@ class TestAccountLookup(APIKeyAuthTestMixin, TestCase):
     def setUp(self):
         self.target_user = user_factory(email='developer@example.com')
         self.create_api_user()
-        self.grant_permission(self.user, 'Users:Lookup')
+        self.grant_permission(self.user, amo.permissions.USERS_LOOKUP)
         self.url = reverse_ns('account-lookup')
         super().setUp()
 
@@ -1477,7 +1477,7 @@ class TestAccountRetrieveWithJWT(APIKeyAuthTestMixin, TestCase):
         super().setUp()
 
     def test_retrieve_with_lookup_permission_returns_email(self):
-        self.grant_permission(self.user, 'Users:Lookup')
+        self.grant_permission(self.user, amo.permissions.USERS_LOOKUP)
         response = self.get(self.url)
         assert response.status_code == 200
         assert response.data['name'] == self.target_user.name
@@ -1534,7 +1534,7 @@ class TestAccountViewSetUpdate(TestCase):
         assert response.status_code == 403
 
     def test_admin_patch(self):
-        self.grant_permission(self.user, 'Users:Edit')
+        self.grant_permission(self.user, amo.permissions.USERS_EDIT)
         self.client.login_api(self.user)
         random_user = user_factory()
         url = reverse_ns('account-detail', kwargs={'pk': random_user.pk})
@@ -1839,7 +1839,7 @@ class TestAccountViewSetDelete(TestCase):
         assert response.status_code == 403
 
     def test_admin_delete(self):
-        self.grant_permission(self.user, 'Users:Edit')
+        self.grant_permission(self.user, amo.permissions.USERS_EDIT)
         self.client.login_api(self.user)
 
         random_user = user_factory()
@@ -2261,7 +2261,7 @@ class TestAccountNotificationViewSetList(TestCase):
 
     def test_admin_view(self):
         self.user = user_factory()  # different user now
-        self.grant_permission(self.user, 'Users:Edit')
+        self.grant_permission(self.user, amo.permissions.USERS_EDIT)
         self.client.login_api(self.user)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -2355,7 +2355,7 @@ class TestAccountNotificationViewSetUpdate(TestCase):
     def test_admin_update(self):
         original_user = self.user
         self.user = user_factory()  # different user now
-        self.grant_permission(self.user, 'Users:Edit')
+        self.grant_permission(self.user, amo.permissions.USERS_EDIT)
         self.client.login_api(self.user)
 
         response = self.client.post(self.url, data={'reply': False})

--- a/src/olympia/activity/tests/test_admin.py
+++ b/src/olympia/activity/tests/test_admin.py
@@ -34,7 +34,7 @@ class TestActivityLogAdmin(TestCase):
         )
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'ActivityLog:View')
+        self.grant_permission(user, amo.permissions.ACTIVITYLOG_VIEW)
         self.client.force_login(user)
 
         with self.assertNumQueries(11):
@@ -61,7 +61,7 @@ class TestActivityLogAdmin(TestCase):
         )
         activity.log_create(amo.LOG.USER_DISABLE, addon1, user=author)
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'ActivityLog:View')
+        self.grant_permission(user, amo.permissions.ACTIVITYLOG_VIEW)
         self.client.force_login(user)
         response = self.client.get(
             self.list_url, {'action': [amo.LOG.CREATE_ADDON.id, amo.LOG.ADD_VERSION.id]}
@@ -77,7 +77,7 @@ class TestActivityLogAdmin(TestCase):
 
     def test_search_for_single_ip(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'ActivityLog:View')
+        self.grant_permission(user, amo.permissions.ACTIVITYLOG_VIEW)
         self.client.force_login(user)
         user2 = user_factory()
         user3 = user_factory()
@@ -121,7 +121,7 @@ class TestActivityLogAdmin(TestCase):
 
     def test_search_for_ja4(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'ActivityLog:View')
+        self.grant_permission(user, amo.permissions.ACTIVITYLOG_VIEW)
         self.client.force_login(user)
         user2 = user_factory()
         user3 = user_factory()
@@ -162,7 +162,7 @@ class TestActivityLogAdmin(TestCase):
         activity.log_create(
             amo.LOG.ADD_VERSION, addon.current_version, addon, user=user
         )
-        self.grant_permission(user, 'ActivityLog:View')
+        self.grant_permission(user, amo.permissions.ACTIVITYLOG_VIEW)
         self.client.force_login(user)
         response = self.client.get(self.list_url)
         assert response.status_code == 200
@@ -187,7 +187,7 @@ class TestReviewActionReasonLogAdmin(TestCase):
 
     def test_can_see_module_in_admin_with_super_access(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         response = self.client.get(self.admin_home_url, follow=True)
         assert response.status_code == 200
@@ -210,7 +210,7 @@ class TestReviewActionReasonLogAdmin(TestCase):
             name='inactive reason', is_active=False, canned_response='.'
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         activity_log = ActivityLog.objects.create(
             action=amo.LOG.APPROVE_VERSION.id, user=user

--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -107,7 +107,7 @@ class TestEmailBouncing(TestCase):
         addon = addon_factory()
         version = addon.find_latest_version(channel=amo.CHANNEL_LISTED)
         user = user_factory()
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         ActivityLogToken.objects.create(
             user=user, version=version, uuid='5a0b8a83d501412589cc5d562334b46b'
         )
@@ -250,7 +250,7 @@ class TestAddEmailToActivityLog(TestCase):
         assert self.version.reload().due_date == expected_due_date
 
     def test_reviewer_comment(self):
-        self.grant_permission(self.profile, 'Addons:Review')
+        self.grant_permission(self.profile, amo.permissions.ADDONS_REVIEW)
         note = add_email_to_activity_log(self.parser)
         assert note.log == amo.LOG.REVIEWER_REPLY_VERSION
         self.token.refresh_from_db()
@@ -296,7 +296,9 @@ class TestLogAndNotify(TestCase):
         self.developer = user_factory()
         self.developer2 = user_factory()
         self.reviewer = user_factory()
-        self.grant_permission(self.reviewer, 'Addons:Review', 'Addon Reviewers')
+        self.grant_permission(
+            self.reviewer, amo.permissions.ADDONS_REVIEW, name='Addon Reviewers'
+        )
 
         self.addon = addon_factory()
         self.version = self.addon.find_latest_version(channel=amo.CHANNEL_LISTED)
@@ -455,7 +457,9 @@ class TestLogAndNotify(TestCase):
 
     @mock.patch('olympia.activity.utils.send_mail')
     def test_staff_cc_group_get_mail(self, send_mail_mock):
-        self.grant_permission(self.reviewer, 'None:None', ACTIVITY_MAIL_GROUP)
+        self.grant_permission(
+            self.reviewer, amo.permissions.NONE, name=ACTIVITY_MAIL_GROUP
+        )
         action = amo.LOG.DEVELOPER_REPLY_VERSION
         comments = 'Thïs is á reply'
         log_and_notify(action, comments, self.developer, self.version)
@@ -533,7 +537,11 @@ class TestLogAndNotify(TestCase):
     @mock.patch('olympia.activity.utils.send_mail')
     def test_review_url_unlisted(self, send_mail_mock):
         self.version.update(channel=amo.CHANNEL_UNLISTED)
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted', 'Addon Reviewers')
+        self.grant_permission(
+            self.reviewer,
+            amo.permissions.ADDONS_REVIEW_UNLISTED,
+            name='Addon Reviewers',
+        )
 
         # One from the reviewer.
         self._create(amo.LOG.REVIEWER_PRIVATE_COMMENT, self.reviewer)

--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -55,12 +55,14 @@ class ReviewNotesViewSetDetailMixin(LogMixin):
         AddonUser.objects.create(user=user, addon=self.addon)
         self.client.login_api(user)
 
-    def _login_reviewer(self, permission='Addons:Review'):
+    def _login_reviewer(self, permission=amo.permissions.ADDONS_REVIEW):
         user = UserProfile.objects.create(username='reviewer')
         self.grant_permission(user, permission)
         self.client.login_api(user)
 
-    def _login_unlisted_reviewer(self, permission='Addons:ReviewUnlisted'):
+    def _login_unlisted_reviewer(
+        self, permission=amo.permissions.ADDONS_REVIEW_UNLISTED
+    ):
         user = UserProfile.objects.create(username='reviewer-unlisted')
         self.grant_permission(user, permission)
         self.client.login_api(user)
@@ -102,13 +104,13 @@ class ReviewNotesViewSetDetailMixin(LogMixin):
 
     def test_get_not_listed_specific_reviewer(self):
         self.make_addon_unlisted(self.addon)
-        self._login_reviewer(permission='Addons:ReviewUnlisted')
+        self._login_reviewer(permission=amo.permissions.ADDONS_REVIEW_UNLISTED)
         response = self.client.get(self.url)
         assert response.status_code == 200
 
     def test_get_not_listed_unlisted_viewer(self):
         self.make_addon_unlisted(self.addon)
-        self._login_reviewer(permission='ReviewerTools:ViewUnlisted')
+        self._login_reviewer(permission=amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
 
@@ -132,7 +134,7 @@ class ReviewNotesViewSetDetailMixin(LogMixin):
 
     def test_get_deleted_admin(self):
         self.addon.delete()
-        self._login_reviewer(permission='*:*')
+        self._login_reviewer(permission=amo.permissions.SUPERPOWERS)
         response = self.client.get(self.url)
         assert response.status_code == 200
 
@@ -168,7 +170,7 @@ class ReviewNotesViewSetDetailMixin(LogMixin):
         assert response.status_code == 404
 
     def test_get_version_not_found(self):
-        self._login_reviewer(permission='*:*')
+        self._login_reviewer(permission=amo.permissions.SUPERPOWERS)
         self._set_tested_url(version_pk=self.version.pk + 27)
         response = self.client.get(self.url)
         assert response.status_code == 404
@@ -219,7 +221,7 @@ class ReviewNotesViewSetDetailMixin(LogMixin):
 
     def test_user_not_anonymized_for_view_only_reviewer(self):
         user = UserProfile.objects.create(username='view-only-reviewer')
-        self.grant_permission(user, 'ReviewerTools:View')
+        self.grant_permission(user, amo.permissions.REVIEWER_TOOLS_VIEW)
         self.client.login_api(user)
         response = self.client.get(self.url)
         result = json.loads(response.content)
@@ -273,7 +275,7 @@ class TestReviewNotesViewSetDetail(ReviewNotesViewSetDetailMixin, TestCase):
         )
 
     def test_get_note_not_found(self):
-        self._login_reviewer(permission='*:*')
+        self._login_reviewer(permission=amo.permissions.SUPERPOWERS)
         self._set_tested_url(self.note.pk + 42)
         response = self.client.get(self.url)
         assert response.status_code == 404
@@ -529,15 +531,15 @@ class TestReviewNotesViewSetCreate(TestCase):
         assert not self.version.due_date
 
     def test_reviewer_reply_listed(self):
-        self._test_reviewer_reply('Addons:Review')
+        self._test_reviewer_reply(amo.permissions.ADDONS_REVIEW)
 
     def test_reviewer_reply_unlisted(self):
         self.make_addon_unlisted(self.addon)
-        self._test_reviewer_reply('Addons:ReviewUnlisted')
+        self._test_reviewer_reply(amo.permissions.ADDONS_REVIEW_UNLISTED)
 
     def test_reply_to_deleted_addon_is_404(self):
         self.user = user_factory()
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.addon.delete()
         self.client.login_api(self.user)
         response = self._post_reply()
@@ -554,7 +556,7 @@ class TestReviewNotesViewSetCreate(TestCase):
         assert self.addon.status
 
         self.user = user_factory()
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         response = self._post_reply()
         assert response.status_code == 404
@@ -566,7 +568,7 @@ class TestReviewNotesViewSetCreate(TestCase):
         new_version = version_factory(addon=self.addon)
         assert new_version == self.addon.find_latest_version(channel=amo.CHANNEL_LISTED)
         self.user = user_factory()
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
 
         # First check we can reply to new version
@@ -589,12 +591,12 @@ class TestReviewNotesViewSetCreate(TestCase):
 
     def test_reviewer_can_reply_to_disabled_version_listed(self):
         self.version.file.update(status=amo.STATUS_DISABLED)
-        self._test_reviewer_reply('Addons:Review')
+        self._test_reviewer_reply(amo.permissions.ADDONS_REVIEW)
 
     def test_reviewer_can_reply_to_disabled_version_unlisted(self):
         self.make_addon_unlisted(self.addon)
         self.version.file.update(status=amo.STATUS_DISABLED)
-        self._test_reviewer_reply('Addons:ReviewUnlisted')
+        self._test_reviewer_reply(amo.permissions.ADDONS_REVIEW_UNLISTED)
 
 
 @override_settings(ALLOWED_CLIENTS_EMAIL_API=['10.10.10.10'])
@@ -620,7 +622,7 @@ class TestEmailApi(TestCase):
 
     def test_basic(self):
         user = user_factory()
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         addon = addon_factory()
         version = addon.find_latest_version(channel=amo.CHANNEL_LISTED)
         req = self.get_request(sample_message_content)
@@ -741,7 +743,9 @@ class TestDownloadAttachment(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.url, follow=True)
         self.assertEqual(response.status_code, 404)
-        self.grant_permission(self.user, 'Addons:Review', 'Addon Reviewers')
+        self.grant_permission(
+            self.user, amo.permissions.ADDONS_REVIEW, name='Addon Reviewers'
+        )
         response = self.client.get(self.url, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertIn('.txt', response['Content-Disposition'])
@@ -751,7 +755,9 @@ class TestDownloadAttachment(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.url, follow=True)
         self.assertEqual(response.status_code, 404)
-        self.grant_permission(self.user, 'Addons:Review', 'Addon Reviewers')
+        self.grant_permission(
+            self.user, amo.permissions.ADDONS_REVIEW, name='Addon Reviewers'
+        )
         response = self.client.get(self.url, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertIn('.txt', response['Content-Disposition'])

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -109,7 +109,7 @@ class TestAddonAdmin(TestCase):
 
     def test_can_see_addon_module_in_admin_with_addons_edit(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.admin_home_url, follow=True)
         assert response.status_code == 200
@@ -129,7 +129,7 @@ class TestAddonAdmin(TestCase):
     def test_can_list_with_addons_edit_permission(self):
         addon = addon_factory()
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -139,7 +139,7 @@ class TestAddonAdmin(TestCase):
         addon = addon_factory()
         version_factory(addon=addon, channel=amo.CHANNEL_LISTED)
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert b'Review (listed)' in response.content
@@ -149,7 +149,7 @@ class TestAddonAdmin(TestCase):
         version_kw = {'channel': amo.CHANNEL_UNLISTED}
         addon_factory(guid='@foo', version_kw=version_kw)
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert b'Review (listed)' not in response.content
@@ -160,7 +160,7 @@ class TestAddonAdmin(TestCase):
         version_factory(addon=addon, channel=amo.CHANNEL_LISTED)
         version_factory(addon=addon, channel=amo.CHANNEL_UNLISTED)
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert b'Review (listed)' in response.content
@@ -171,7 +171,7 @@ class TestAddonAdmin(TestCase):
         addon_factory(guid='@bar')
         addon_factory(guid='@xyz')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
 
         with self.assertNumQueries(8):
@@ -199,7 +199,7 @@ class TestAddonAdmin(TestCase):
         )
         addon_factory(guid='@bar')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -226,7 +226,7 @@ class TestAddonAdmin(TestCase):
         addon_factory(guid='@foo')
         addon_factory(guid='@bar')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
 
         with self.assertNumQueries(8):
@@ -244,7 +244,7 @@ class TestAddonAdmin(TestCase):
 
     def test_search_tooltip(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url)
         doc = pq(response.content)
@@ -263,7 +263,7 @@ class TestAddonAdmin(TestCase):
 
     def test_search_by_ip(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
 
         addon = addon_factory(guid='@foo')
@@ -314,7 +314,7 @@ class TestAddonAdmin(TestCase):
         addon = addon_factory(guid='@foo')
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -347,7 +347,7 @@ class TestAddonAdmin(TestCase):
         assert addon.slug is None
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -380,7 +380,7 @@ class TestAddonAdmin(TestCase):
         version_factory(addon=addon, channel=amo.CHANNEL_LISTED)
         detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url, follow=True)
         assert b'Reviewer Tools (listed)' in response.content
@@ -391,7 +391,7 @@ class TestAddonAdmin(TestCase):
         addon = addon_factory(guid='@foo', version_kw=version_kw)
         detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url, follow=True)
         assert b'Reviewer Tools (listed)' not in response.content
@@ -403,7 +403,7 @@ class TestAddonAdmin(TestCase):
         version_factory(addon=addon, version='0.2', channel=amo.CHANNEL_UNLISTED)
         detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url, follow=True)
         content = response.content.decode('utf-8')
@@ -463,7 +463,7 @@ class TestAddonAdmin(TestCase):
         detail_url_by_slug = reverse('admin:addons_addon_change', args=(addon.slug,))
         detail_url_final = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url_by_slug, follow=False)
         self.assert3xx(response, detail_url_final, 301)
@@ -473,7 +473,7 @@ class TestAddonAdmin(TestCase):
         detail_url_by_guid = reverse('admin:addons_addon_change', args=(addon.guid,))
         detail_url_final = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url_by_guid, follow=True)
         self.assert3xx(response, detail_url_final, 301)
@@ -483,7 +483,7 @@ class TestAddonAdmin(TestCase):
         addon.delete()
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -533,8 +533,8 @@ class TestAddonAdmin(TestCase):
         addonuser = addon.addonuser_set.get()
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -564,8 +564,8 @@ class TestAddonAdmin(TestCase):
         assert addon.reviewerflags.needs_admin_theme_review
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         response = self.client.get(self.detail_url)
         assert response.status_code == 200
@@ -590,7 +590,7 @@ class TestAddonAdmin(TestCase):
         assert addon.reviewerflags.needs_admin_theme_review
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url)
         assert response.status_code == 200
@@ -611,7 +611,7 @@ class TestAddonAdmin(TestCase):
         addonuser = addon.addonuser_set.get()
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -638,8 +638,8 @@ class TestAddonAdmin(TestCase):
         addonuser = addon.addonuser_set.get()
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -694,8 +694,8 @@ class TestAddonAdmin(TestCase):
         file = addon.current_version.file
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         post_data = self._get_full_post_data(addon, addon.addonuser_set.get())
         file.version.delete()
 
@@ -719,8 +719,8 @@ class TestAddonAdmin(TestCase):
         addon = addon_factory(guid='@foo', users=[user_factory()])
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
 
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
@@ -739,8 +739,8 @@ class TestAddonAdmin(TestCase):
         addon = addon_factory(guid='@foo', users=[user_factory()])
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         with self.assertNumQueries(20 if self.is_django42 else 18):
             # It's very high because most of AddonAdmin is unoptimized but we
@@ -766,8 +766,8 @@ class TestAddonAdmin(TestCase):
         [version_factory(addon=addon, version=str(i)) for i in range(0, 30)]
         self.detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -819,7 +819,7 @@ class TestReplacementAddonList(TestCase):
 
     def test_can_see_replacementaddon_module_in_admin_with_addons_edit(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         url = reverse('admin:index')
         response = self.client.get(url)
@@ -832,7 +832,7 @@ class TestReplacementAddonList(TestCase):
 
     def test_can_see_replacementaddon_module_in_admin_with_admin(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         url = reverse('admin:index')
         response = self.client.get(url)
@@ -846,7 +846,7 @@ class TestReplacementAddonList(TestCase):
     def test_can_list_with_addons_edit_permission(self):
         ReplacementAddon.objects.create(guid='@bar', path='/addon/bar-replacement/')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -860,7 +860,7 @@ class TestReplacementAddonList(TestCase):
             'admin:addons_replacementaddon_change', args=(replacement.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -878,7 +878,7 @@ class TestReplacementAddonList(TestCase):
             'admin:addons_replacementaddon_delete', args=(replacement.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.delete_url, follow=True)
         assert response.status_code == 403
@@ -894,7 +894,7 @@ class TestReplacementAddonList(TestCase):
             'admin:addons_replacementaddon_change', args=(replacement.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -915,7 +915,7 @@ class TestReplacementAddonList(TestCase):
             'admin:addons_replacementaddon_delete', args=(replacement.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         response = self.client.get(self.delete_url, follow=True)
         assert response.status_code == 200
@@ -925,7 +925,7 @@ class TestReplacementAddonList(TestCase):
 
     def test_can_list_with_admin_permission(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         # '@foofoo&foo' isn't a valid guid, because &, but testing urlencoding.
         ReplacementAddon.objects.create(guid='@foofoo&foo', path='/addon/bar/')
@@ -951,7 +951,7 @@ class TestAddonRegionalRestrictionsAdmin(TestCase):
     def setUp(self):
         self.list_url = reverse('admin:addons_addonregionalrestrictions_changelist')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:RegionalRestrictionsEdit')
+        self.grant_permission(user, amo.permissions.ADMIN_REGIONALRESTRICTIONS)
         self.client.force_login(user)
 
     def test_can_see_module_in_admin(self):
@@ -1060,7 +1060,7 @@ class TestAddonRegionalRestrictionsAdmin(TestCase):
 class TestAddonBrowserMappingAdmin(TestCase):
     def setUp(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Curation')
+        self.grant_permission(user, amo.permissions.ADMIN_CURATION)
         self.client.force_login(user)
         self.list_url = reverse('admin:addons_addonbrowsermapping_changelist')
         self.add_url = reverse('admin:addons_addonbrowsermapping_add')

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -375,10 +375,8 @@ class AddonAndVersionViewSetDetailMixin:
 
     def test_get_unlisted_addons_api_view_unlisted(self):
         user = UserProfile.objects.create(username='user')
-        self.grant_permission(
-            user,
-            (amo.permissions.ADDONS_API_VIEW, amo.permissions.ADDONS_API_VIEW_UNLISTED),
-        )
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
         self.make_addon_unlisted(self.addon)
         self.client.login_api(user)
         response = self.client.get(self.url)
@@ -418,10 +416,8 @@ class AddonAndVersionViewSetDetailMixin:
 
     def test_get_deleted_addons_api_view(self):
         user = UserProfile.objects.create(username='user')
-        self.grant_permission(
-            user,
-            (amo.permissions.ADDONS_API_VIEW, amo.permissions.ADDONS_API_VIEW_DELETED),
-        )
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_DELETED)
         self.addon.delete()
         self.client.login_api(user)
         response = self.client.get(self.url)
@@ -621,10 +617,8 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
 
     def test_show_latest_unlisted_version_addons_api_view_unlisted(self):
         user = UserProfile.objects.create(username='author')
-        self.grant_permission(
-            user,
-            (amo.permissions.ADDONS_API_VIEW, amo.permissions.ADDONS_API_VIEW_UNLISTED),
-        )
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
         self.client.login_api(user)
 
         unlisted_version = version_factory(
@@ -809,7 +803,7 @@ class AddonViewSetCreateUpdateMixin(RequestMixin):
             'name': ['Add-on names cannot contain the Mozilla or Firefox trademarks.']
         }
 
-        self.grant_permission(self.user, 'Trademark:Bypass')
+        self.grant_permission(self.user, amo.permissions.TRADEMARK_BYPASS)
         response = self.request(name=name)
         assert response.status_code == self.SUCCESS_STATUS_CODE, response.content
         assert response.data['name'] == name
@@ -3058,10 +3052,8 @@ class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
 
     def test_deleted_version_reviewer(self):
         user = UserProfile.objects.create(username='user')
-        self.grant_permission(
-            user,
-            (amo.permissions.ADDONS_API_VIEW, amo.permissions.ADDONS_API_VIEW_DELETED),
-        )
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_DELETED)
         self.client.login_api(user)
         self.version.delete()
         self._test_url()
@@ -3103,10 +3095,8 @@ class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
 
     def test_unlisted_version_addons_api_view_unlisted(self):
         user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(
-            user,
-            (amo.permissions.ADDONS_API_VIEW, amo.permissions.ADDONS_API_VIEW_UNLISTED),
-        )
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
         self.client.login_api(user)
         self.version.update(channel=amo.CHANNEL_UNLISTED)
         self._test_url()
@@ -4925,7 +4915,7 @@ class TestVersionViewSetRollback(TestCase):
         }
 
     def test_new_version_string_must_be_unique(self):
-        self.grant_permission(self.user, 'API:BypassThrottling')
+        self.grant_permission(self.user, amo.permissions.API_BYPASS_THROTTLING)
         self.first_version.delete()  # deleted shouldn't matter
         # the version number should be unique across channels
         unlisted_version = version_factory(
@@ -5008,7 +4998,7 @@ class TestVersionViewSetRollback(TestCase):
     def test_rollback_partial_permission_reviewer(self):
         # Reviewer can read but cannot rollback.
         user = user_factory(id=settings.TASK_USER_ID)
-        self.grant_permission(user, 'Addons:ContentReview')
+        self.grant_permission(user, amo.permissions.ADDONS_CONTENT_REVIEW)
         self.client.login_api(user)
 
         response = self.client.post(self.url)
@@ -5223,10 +5213,8 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
 
     def test_deleted_version_addons_api_view(self):
         user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(
-            user,
-            (amo.permissions.ADDONS_API_VIEW, amo.permissions.ADDONS_API_VIEW_DELETED),
-        )
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_DELETED)
         self.client.login_api(user)
         self.version.delete()
         self._test_url_only_contains_old_version()
@@ -5264,10 +5252,8 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
 
     def test_with_unlisted_addons_api_view_unlisted(self):
         user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(
-            user,
-            (amo.permissions.ADDONS_API_VIEW, amo.permissions.ADDONS_API_VIEW_UNLISTED),
-        )
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
         self.client.login_api(user)
 
         self._test_url_contains_all(filter='all_with_unlisted')
@@ -5281,10 +5267,8 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
 
     def test_all_with_unlisted_when_no_unlisted_versions(self):
         user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(
-            user,
-            (amo.permissions.ADDONS_API_VIEW, amo.permissions.ADDONS_API_VIEW_UNLISTED),
-        )
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
         self.client.login_api(user)
         # delete the unlisted version so only the listed versions remain.
         self.unlisted_version.delete()
@@ -5336,10 +5320,8 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
 
     def test_all_without_unlisted_when_no_listed_versions(self):
         user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(
-            user,
-            (amo.permissions.ADDONS_API_VIEW, amo.permissions.ADDONS_API_VIEW_UNLISTED),
-        )
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW)
+        self.grant_permission(user, amo.permissions.ADDONS_API_VIEW_UNLISTED)
         self.client.login_api(user)
         # delete the listed versions so only the unlisted version remains.
         self.version.delete()
@@ -5560,7 +5542,7 @@ class TestAddonViewSetEulaPolicy(TestCase):
         assert not self.addon.privacy_policy
 
     def test_update_reviewer_not_author(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         response = self.client.patch(
             self.url,
@@ -8410,7 +8392,7 @@ class TestAddonPendingAuthorViewSet(TestCase):
         )
         # but the author can send, even if they have elevated permissions themselves
         self.client.login_api(self.user)
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         response = self.client.post(self.list_url, data={'user_id': user.id})
         assert response.status_code == 201
 

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -438,18 +438,11 @@ def activate_locale(locale=None, app=None):
     translation.activate(old_locale)
 
 
-def grant_permission(user_obj, rules, name):
-    def flatten_to_string(str_or_permission):
-        if isinstance(str_or_permission, str):
-            return str_or_permission
-        elif isinstance(str_or_permission, amo.permissions.AclPermission):
-            return ':'.join(str_or_permission)
-        elif isinstance(str_or_permission, (tuple, list)):
-            return ','.join(flatten_to_string(item) for item in str_or_permission)
-        else:
-            return ''
+def grant_permission(user_obj, permission, name):
+    if not isinstance(permission, amo.permissions.AclPermission):
+        raise ValueError('Invalid rules provided to grant_permission')
 
-    group = Group.objects.create(name=name, rules=flatten_to_string(rules))
+    group = Group.objects.create(name=name, rules=str(permission))
     GroupUser.objects.create(group=group, user=user_obj)
 
 
@@ -584,9 +577,9 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
     def create_flag(self, *args, **kwargs):
         return create_flag(*args, **kwargs)
 
-    def grant_permission(self, user_obj, rules, name='Test Group'):
-        """Creates group with rule, and adds user to group."""
-        grant_permission(user_obj, rules, name)
+    def grant_permission(self, user_obj, permission, name='Test Group'):
+        """Creates group with rules, and adds user to group."""
+        grant_permission(user_obj, permission, name)
 
     def days_ago(self, days):
         return days_ago(days)

--- a/src/olympia/amo/tests/test_csp_headers.py
+++ b/src/olympia/amo/tests/test_csp_headers.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 
+from olympia import amo
 from olympia.amo.tests import TestCase, user_factory
 from olympia.lib import settings_base as base_settings
 
@@ -16,7 +17,7 @@ class TestCSPHeaders(TestCase):
     @override_settings(SITE_URL='http://internal-admin-testserver')
     def test_admin_csp(self):
         user = user_factory(email='me@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         url = reverse('admin:index')
         response = self.client.get(url, follow=True)
@@ -32,7 +33,7 @@ class TestCSPHeaders(TestCase):
 
     def test_admin_csp_different_locale(self):
         user = user_factory(email='me@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         with self.activate('fr'):
             url = reverse('admin:index')

--- a/src/olympia/api/tests/test_permissions.py
+++ b/src/olympia/api/tests/test_permissions.py
@@ -60,7 +60,7 @@ class TestGroupPermissionOnView(WithDynamicEndpoints):
         self.endpoint(ProtectedView)
         self.url = reverse('test-dynamic-endpoint')
         self.user = user_factory(email='regular@mozilla.com')
-        self.grant_permission(self.user, 'None:None')
+        self.grant_permission(self.user, amo.permissions.NONE)
         self.client.login_api(self.user)
 
     def test_user_must_be_in_required_group(self):
@@ -285,7 +285,7 @@ class TestAllowListedViewerOrReviewer(TestCase):
 
     def test_admin(self):
         user = user_factory()
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
 
         for method in self.safe_methods + self.unsafe_methods:
             request = getattr(self.request_factory, method)('/')
@@ -298,7 +298,7 @@ class TestAllowListedViewerOrReviewer(TestCase):
 
     def test_reviewer_tools_access_read_only(self):
         user = user_factory()
-        self.grant_permission(user, 'ReviewerTools:View')
+        self.grant_permission(user, amo.permissions.REVIEWER_TOOLS_VIEW)
         obj = Mock(spec=[])
         obj.type = amo.ADDON_EXTENSION
         obj.has_listed_versions = lambda include_deleted=False: True
@@ -320,7 +320,7 @@ class TestAllowListedViewerOrReviewer(TestCase):
     def test_reviewer_tools_unlisted_access_read_only(self):
         self.permission = AllowUnlistedViewerOrReviewer()
         user = user_factory()
-        self.grant_permission(user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         obj = Mock(spec=[])
         obj.type = amo.ADDON_EXTENSION
         obj.has_unlisted_versions = lambda include_deleted=False: True
@@ -341,7 +341,7 @@ class TestAllowListedViewerOrReviewer(TestCase):
 
     def test_addon_reviewer(self):
         user = user_factory()
-        self.grant_permission(user, 'Addons:Review')
+        self.grant_permission(user, amo.permissions.ADDONS_REVIEW)
         obj = Mock(spec=[])
         obj.type = amo.ADDON_EXTENSION
         obj.has_listed_versions = lambda include_deleted=False: True
@@ -364,7 +364,7 @@ class TestAllowListedViewerOrReviewer(TestCase):
 
     def test_theme_reviewer(self):
         user = user_factory()
-        self.grant_permission(user, 'Addons:ThemeReview')
+        self.grant_permission(user, amo.permissions.STATIC_THEMES_REVIEW)
         obj = Mock(spec=[])
         obj.type = amo.ADDON_STATICTHEME
         obj.has_listed_versions = lambda include_deleted=False: True
@@ -387,7 +387,7 @@ class TestAllowListedViewerOrReviewer(TestCase):
 
     def test_no_listed_version_reviewer(self):
         user = user_factory()
-        self.grant_permission(user, 'Addons:Review')
+        self.grant_permission(user, amo.permissions.ADDONS_REVIEW)
         obj = Mock(spec=[])
         obj.type = amo.ADDON_EXTENSION
         obj.has_listed_versions = lambda include_deleted=False: False
@@ -439,7 +439,7 @@ class TestAllowAnyKindOfReviewer(TestCase):
 
     def test_admin(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, '*:*')
+        self.grant_permission(self.request.user, amo.permissions.SUPERPOWERS)
         obj = Mock(spec=[])
 
         assert self.permission.has_permission(self.request, myview)
@@ -447,7 +447,7 @@ class TestAllowAnyKindOfReviewer(TestCase):
 
     def test_regular_reviewer(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         obj = Mock(spec=[])
 
         assert self.permission.has_permission(self.request, myview)
@@ -455,7 +455,7 @@ class TestAllowAnyKindOfReviewer(TestCase):
 
     def test_unlisted_reviewer(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: True
 
@@ -464,7 +464,9 @@ class TestAllowAnyKindOfReviewer(TestCase):
 
     def test_unlisted_viewer(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            self.request.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: True
 
@@ -502,7 +504,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
 
     def test_admin(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, '*:*')
+        self.grant_permission(self.request.user, amo.permissions.SUPERPOWERS)
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: True
 
@@ -511,7 +513,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
 
     def test_regular_reviewer(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: True
 
@@ -520,7 +522,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
 
     def test_unlisted_reviewer(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: True
 
@@ -529,7 +531,9 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
 
     def test_unlisted_viewer(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            self.request.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: True
 
@@ -544,7 +548,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
 
     def test_object_with_listed_versions_but_no_unlisted_versions(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: True
@@ -554,7 +558,9 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
 
     def test_object_with_listed_versions_but_no_unlisted_versions_viewer(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            self.request.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: True
@@ -564,7 +570,7 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
 
     def test_object_with_no_unlisted_versions_and_no_listed_versions(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: False
@@ -574,7 +580,9 @@ class TestAllowUnlistedViewerOrReviewer(TestCase):
 
     def test_object_with_no_unlisted_versions_and_no_listed_versions_viewer(self):
         self.request.user = user_factory()
-        self.grant_permission(self.request.user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            self.request.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         obj = Mock(spec=[])
         obj.has_unlisted_versions = lambda include_deleted=False: False
         obj.has_listed_versions = lambda include_deleted=False: False

--- a/src/olympia/api/tests/test_throttling.py
+++ b/src/olympia/api/tests/test_throttling.py
@@ -120,7 +120,7 @@ class TestGranularUserRateThrottle(TestCase):
         assert allow_request_mock.call_count == 1
 
         # User with the right permission: bypass throttling.
-        self.grant_permission(request.user, 'API:BypassThrottling')
+        self.grant_permission(request.user, amo.permissions.API_BYPASS_THROTTLING)
         allow_request_mock.reset_mock()
         assert self.throttle.allow_request(request, view) is True
         assert allow_request_mock.call_count == 0

--- a/src/olympia/applications/tests.py
+++ b/src/olympia/applications/tests.py
@@ -87,7 +87,7 @@ class TestAppVersionsAPIPut(APIKeyAuthTestMixin, TestCase):
             'appversions', kwargs={'application': 'firefox', 'version': '42.0'}
         )
         self.create_api_user()
-        self.grant_permission(self.user, 'AppVersions:Create')
+        self.grant_permission(self.user, amo.permissions.APPVERSIONS_CREATE)
         AppVersion.objects.all().delete()
 
     def test_not_authenticated(self):

--- a/src/olympia/bandwagon/tests/test_admin.py
+++ b/src/olympia/bandwagon/tests/test_admin.py
@@ -16,7 +16,7 @@ class TestCollectionAdmin(TestCase):
 
     def test_can_see_bandwagon_module_in_admin_with_collections_edit(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Collections:Edit')
+        self.grant_permission(user, amo.permissions.COLLECTIONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.admin_home_url, follow=True)
         assert response.status_code == 200
@@ -26,7 +26,7 @@ class TestCollectionAdmin(TestCase):
 
     def test_can_see_bandwagon_module_in_admin_with_admin_curation(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Curation')
+        self.grant_permission(user, amo.permissions.ADMIN_CURATION)
         self.client.force_login(user)
         response = self.client.get(self.admin_home_url, follow=True)
         assert response.status_code == 200
@@ -47,7 +47,7 @@ class TestCollectionAdmin(TestCase):
     def test_can_list_with_collections_edit_permission(self):
         collection = Collection.objects.create(slug='floob')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Collections:Edit')
+        self.grant_permission(user, amo.permissions.COLLECTIONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -56,7 +56,7 @@ class TestCollectionAdmin(TestCase):
     def test_can_list_with_admin_curation_permission(self):
         collection = Collection.objects.create(slug='floob')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Curation')
+        self.grant_permission(user, amo.permissions.ADMIN_CURATION)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -81,7 +81,7 @@ class TestCollectionAdmin(TestCase):
             'admin:bandwagon_collection_change', args=(collection.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Collections:Edit')
+        self.grant_permission(user, amo.permissions.COLLECTIONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -163,7 +163,7 @@ class TestCollectionAdmin(TestCase):
             'admin:bandwagon_collection_change', args=(collection.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Curation')
+        self.grant_permission(user, amo.permissions.ADMIN_CURATION)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 403
@@ -299,7 +299,7 @@ class TestCollectionAdmin(TestCase):
             'admin:bandwagon_collection_delete', args=(collection.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Collections:Edit')
+        self.grant_permission(user, amo.permissions.COLLECTIONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.delete_url, follow=True)
         assert response.status_code == 403
@@ -313,7 +313,7 @@ class TestCollectionAdmin(TestCase):
             'admin:bandwagon_collection_delete', args=(collection.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Curation')
+        self.grant_permission(user, amo.permissions.ADMIN_CURATION)
         self.client.force_login(user)
         response = self.client.get(self.delete_url, follow=True)
         assert response.status_code == 403
@@ -336,7 +336,7 @@ class TestCollectionAdmin(TestCase):
             'admin:bandwagon_collection_delete', args=(collection.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         response = self.client.post(self.delete_url, data={'post': 'yes'}, follow=True)
         assert response.status_code == 200
@@ -364,8 +364,8 @@ class TestCollectionAdmin(TestCase):
             'admin:bandwagon_collection_change', args=(collection.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Advanced')
-        self.grant_permission(user, 'Collections:Edit')
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
+        self.grant_permission(user, amo.permissions.COLLECTIONS_EDIT)
         self.client.force_login(user)
         post_data = {
             # Django wants the whole form to be submitted, unfortunately.

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -61,17 +61,17 @@ class TestCollectionViewSetList(TestCase):
         other_url = reverse_ns('collection-list', kwargs={'user_pk': random_user.pk})
         collection_factory(author=random_user)
 
-        self.grant_permission(self.user, 'Collections:Edit')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_EDIT)
         self.client.login_api(self.user)
         response = self.client.get(other_url)
         assert response.status_code == 403
 
-        self.grant_permission(self.user, 'Collections:Contribute')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_CONTRIBUTE)
         self.client.login_api(self.user)
         response = self.client.get(other_url)
         assert response.status_code == 403
 
-        self.grant_permission(self.user, 'Admin:Curation')
+        self.grant_permission(self.user, amo.permissions.ADMIN_CURATION)
         response = self.client.get(other_url)
         assert response.status_code == 403
 
@@ -173,17 +173,17 @@ class TestCollectionViewSetDetail(TestCase):
         random_user = user_factory()
         collection = collection_factory(author=random_user, listed=False)
 
-        self.grant_permission(self.user, 'Collections:Edit')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_EDIT)
         self.client.login_api(self.user)
         response = self.client.get(self._get_url(random_user, collection))
         assert response.status_code == 403
 
-        self.grant_permission(self.user, 'Collections:Contribute')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_CONTRIBUTE)
         self.client.login_api(self.user)
         response = self.client.get(self._get_url(random_user, collection))
         assert response.status_code == 403
 
-        self.grant_permission(self.user, 'Admin:Curation')
+        self.grant_permission(self.user, amo.permissions.ADMIN_CURATION)
         response = self.client.get(self._get_url(random_user, collection))
         assert response.status_code == 403
 
@@ -203,7 +203,7 @@ class TestCollectionViewSetDetail(TestCase):
             response = self.client.get(self.url)
             assert response.status_code == 403
 
-            self.grant_permission(random_user, 'Collections:Contribute')
+            self.grant_permission(random_user, amo.permissions.COLLECTIONS_CONTRIBUTE)
             # Now they can access it.
             response = self.client.get(self.url)
             assert response.status_code == 200
@@ -474,7 +474,7 @@ class CollectionViewSetDataMixin:
         assert json.loads(response.content) == {'name': ['This name cannot be used.']}
 
         # But you can if you have the correct permission
-        self.grant_permission(self.user, 'Collections:Edit')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_EDIT)
         self.client.login_api(self.user)
         response = self.send(data=data)
         assert response.status_code in (200, 201)
@@ -487,7 +487,7 @@ class CollectionViewSetDataMixin:
         assert response.status_code == 400
         assert json.loads(response.content) == {'name': ['This name cannot be used.']}
         # even with permission
-        self.grant_permission(self.user, 'Collections:Edit')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_EDIT)
         self.client.login_api(self.user)
         response = self.send(data=data)
         assert response.status_code == 400
@@ -512,7 +512,7 @@ class CollectionViewSetDataMixin:
         }
 
         # But you can if you have the correct permission
-        self.grant_permission(self.user, 'Collections:Edit')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_EDIT)
         self.client.login_api(self.user)
         response = self.send(data=data)
         assert response.status_code in (200, 201)
@@ -527,7 +527,7 @@ class CollectionViewSetDataMixin:
             'slug': ['This custom URL cannot be used.']
         }
         # even with permission
-        self.grant_permission(self.user, 'Collections:Edit')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_EDIT)
         self.client.login_api(self.user)
         response = self.send(data=data)
         assert response.status_code == 400
@@ -636,18 +636,18 @@ class TestCollectionViewSetCreate(CollectionViewSetDataMixin, TestCase):
         assert response.status_code == 403
 
     def test_admin_create_fails(self):
-        self.grant_permission(self.user, 'Collections:Edit')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_EDIT)
         self.client.login_api(self.user)
         random_user = user_factory()
         url = self.get_url(random_user)
         response = self.send(url=url)
         assert response.status_code == 403
 
-        self.grant_permission(self.user, 'Collections:Contribute')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_CONTRIBUTE)
         response = self.send(url=url)
         assert response.status_code == 403
 
-        self.grant_permission(self.user, 'Admin:Curation')
+        self.grant_permission(self.user, amo.permissions.ADMIN_CURATION)
         response = self.send(url=url)
         assert response.status_code == 403
 
@@ -697,7 +697,7 @@ class TestCollectionViewSetPatch(CollectionViewSetDataMixin, TestCase):
         assert response.status_code == 403
 
     def test_admin_patch(self):
-        self.grant_permission(self.user, 'Collections:Edit')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_EDIT)
         self.client.login_api(self.user)
         random_user = user_factory()
         self.collection.update(author=random_user)
@@ -706,11 +706,11 @@ class TestCollectionViewSetPatch(CollectionViewSetDataMixin, TestCase):
         response = self.send(url=url)
         assert response.status_code == 403
 
-        self.grant_permission(self.user, 'Collections:Contribute')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_CONTRIBUTE)
         response = self.send(url=url)
         assert response.status_code == 403
 
-        self.grant_permission(self.user, 'Admin:Curation')
+        self.grant_permission(self.user, amo.permissions.ADMIN_CURATION)
         response = self.send(url=url)
         assert response.status_code == 403
 
@@ -728,7 +728,7 @@ class TestCollectionViewSetPatch(CollectionViewSetDataMixin, TestCase):
         self.client.login_api(self.user)
         random_user = user_factory()
         self.collection.update(author=random_user)
-        self.grant_permission(random_user, 'Collections:Contribute')
+        self.grant_permission(random_user, amo.permissions.COLLECTIONS_CONTRIBUTE)
         url = self.get_url(random_user)
         setting_key = 'COLLECTION_FEATURED_THEMES_ID'
         with override_settings(**{setting_key: self.collection.id}):
@@ -810,7 +810,7 @@ class TestCollectionViewSetDelete(TestCase):
         assert response.status_code == 403
 
     def test_admin_delete(self):
-        self.grant_permission(self.user, 'Collections:Edit')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_EDIT)
         self.client.login_api(self.user)
         random_user = user_factory()
         self.collection.update(author=random_user)
@@ -818,11 +818,11 @@ class TestCollectionViewSetDelete(TestCase):
         response = self.client.delete(url)
         assert response.status_code == 403
 
-        self.grant_permission(self.user, 'Collections:Contribute')
+        self.grant_permission(self.user, amo.permissions.COLLECTIONS_CONTRIBUTE)
         response = self.client.delete(url)
         assert response.status_code == 403
 
-        self.grant_permission(self.user, 'Admin:Curation')
+        self.grant_permission(self.user, amo.permissions.ADMIN_CURATION)
         response = self.client.delete(url)
         assert response.status_code == 403
         assert Collection.objects.filter(id=self.collection.id).exists()
@@ -837,7 +837,7 @@ class TestCollectionViewSetDelete(TestCase):
         self.client.login_api(self.user)
         different_user = user_factory()
         self.collection.update(author=different_user)
-        self.grant_permission(different_user, 'Collections:Contribute')
+        self.grant_permission(different_user, amo.permissions.COLLECTIONS_CONTRIBUTE)
         url = self.get_url(different_user)
         setting_key = 'COLLECTION_FEATURED_THEMES_ID'
         with override_settings(**{setting_key: self.collection.id}):
@@ -880,16 +880,16 @@ class CollectionAddonViewSetMixin:
     def test_not_listed_admin(self):
         self.collection.update(listed=False)
         admin_user = user_factory()
-        self.grant_permission(admin_user, 'Collections:Edit')
+        self.grant_permission(admin_user, amo.permissions.COLLECTIONS_EDIT)
         self.client.login_api(admin_user)
         response = self.send(self.url)
         assert response.status_code == 403
 
-        self.grant_permission(admin_user, 'Collections:Contribute')
+        self.grant_permission(admin_user, amo.permissions.COLLECTIONS_CONTRIBUTE)
         response = self.send(self.url)
         assert response.status_code == 403
 
-        self.grant_permission(admin_user, 'Admin:Curation')
+        self.grant_permission(admin_user, amo.permissions.ADMIN_CURATION)
         response = self.send(self.url)
         assert response.status_code == 403
 
@@ -899,7 +899,7 @@ class CollectionAddonViewSetMixin:
     def test_contributor(self):
         self.collection.update(listed=False)
         random_user = user_factory()
-        self.grant_permission(random_user, 'Collections:Contribute')
+        self.grant_permission(random_user, amo.permissions.COLLECTIONS_CONTRIBUTE)
         self.client.login_api(random_user)
         # should fail as self.collection isn't special
         response = self.send(self.url)

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -46,7 +46,7 @@ class TestBlockAdmin(TestCase):
 
     def test_can_see_addon_module_in_admin_with_review_admin(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
         response = self.client.get(self.admin_home_url, follow=True)
         assert response.status_code == 200
@@ -67,7 +67,7 @@ class TestBlockAdmin(TestCase):
         addon = addon_factory()
         block_factory(guid=addon.guid, updated_by=user_factory())
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -84,7 +84,7 @@ class TestBlockAdmin(TestCase):
 
     def test_add(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         response = self.client.get(self.add_url, follow=True)
@@ -112,7 +112,7 @@ class TestBlockAdmin(TestCase):
 
     def test_add_from_addon_pk_view(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon = addon_factory(version_kw={'version': '123.456'})
@@ -168,7 +168,7 @@ class TestBlockAdmin(TestCase):
     def test_guid_redirects(self):
         block = block_factory(guid='foo@baa', updated_by=user_factory())
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         response = self.client.post(
@@ -182,7 +182,7 @@ class TestBlockAdmin(TestCase):
 
     def test_view_versions(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon = addon_factory(version_kw={'version': '1.0'})
@@ -209,7 +209,7 @@ class TestBlockAdmin(TestCase):
 
     def test_soften_harden(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon = addon_factory(version_kw={'version': '1.0'})
@@ -243,7 +243,7 @@ class TestBlockAdmin(TestCase):
 
     def test_harden_disabled_only_hard_blocked_versions_already(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon = addon_factory(version_kw={'version': '1.0'})
@@ -265,7 +265,7 @@ class TestBlockAdmin(TestCase):
 
     def test_soften_disabled_only_soft_blocked_versions_already(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon = addon_factory(version_kw={'version': '1.0'})
@@ -324,7 +324,7 @@ class TestBlockAdmin(TestCase):
 
     def _test_upload_mlbf_enabled(self, mock_upload, force_base=False):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
         url = reverse('admin:blocklist_block_upload_mlbf')
         if force_base:
@@ -377,7 +377,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_initial_values_from_add_from_addon_pk_view(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon = addon_factory(guid='guid@')
@@ -449,7 +449,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_version_checkboxes(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon = addon_factory(guid='guid@', average_daily_users=100)
@@ -511,7 +511,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_version_checkboxes_hardening_action(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon = addon_factory(guid='guid@', average_daily_users=100)
@@ -551,7 +551,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_version_checkboxes_softening_action(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon = addon_factory(guid='guid@', average_daily_users=100)
@@ -591,7 +591,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_add_single(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         deleted_addon = addon_factory(version_kw={'version': '1.2.5'})
@@ -762,7 +762,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_add_multiple_from_pks(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         new_addon_adu = addon_adu = 45768
@@ -851,7 +851,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         """addon_adu is important because whether dual signoff is needed is
         based on what the average_daily_users is."""
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         new_addon_adu = addon_adu
@@ -1128,7 +1128,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
             updated_by=user_factory(),
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         response = self.client.get(
@@ -1175,7 +1175,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
             block_type=BlockType.SOFT_BLOCKED,
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         response = self.client.get(
@@ -1253,7 +1253,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_submit_no_metadata_updates(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon_adu = settings.DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD
@@ -1327,7 +1327,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
     @mock.patch('olympia.blocklist.forms.GUID_FULL_LOAD_LIMIT', 1)
     def test_add_multiple_bulk_so_fake_block_objects(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         new_addon = addon_factory(guid='any@new', name='New Danger')
@@ -1387,7 +1387,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_review_links(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
         post_kwargs = {
             'path': self.submission_url,
@@ -1447,7 +1447,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_authors_links(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         user1 = user_factory()
@@ -1491,7 +1491,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_authors_links_existing_submission(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         user1 = user_factory()
@@ -1536,7 +1536,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
     def test_can_not_add_without_create_permission(self):
         user = user_factory(email='someone@mozilla.com')
         # The signoff permission shouldn't be sufficient
-        self.grant_permission(user, 'Blocklist:Signoff')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_SIGNOFF)
         self.client.force_login(user)
 
         addon_factory(guid='guid@', name='Danger Danger')
@@ -1626,10 +1626,10 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert doc('.field-state').text() == 'Pending Sign-off Pending Sign-off'
 
     def test_can_list_with_blocklist_create(self):
-        self._test_can_list_with_permission('Blocklist:Create')
+        self._test_can_list_with_permission(amo.permissions.BLOCKLIST_CREATE)
 
     def test_can_list_with_blocklist_signoff(self):
-        self._test_can_list_with_permission('Blocklist:Signoff')
+        self._test_can_list_with_permission(amo.permissions.BLOCKLIST_SIGNOFF)
 
     def test_can_not_list_without_permission(self):
         BlocklistSubmission.objects.create(updated_by=user_factory(display_name='Bób'))
@@ -1661,7 +1661,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         ]
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
         multi_url = reverse(
             'admin:blocklist_blocklistsubmission_change', args=(mbs.id,)
@@ -1755,7 +1755,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         ]
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Signoff')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_SIGNOFF)
         self.client.force_login(user)
         multi_url = reverse(
             'admin:blocklist_blocklistsubmission_change', args=(mbs.id,)
@@ -1817,7 +1817,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         ]
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Signoff')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_SIGNOFF)
         self.client.force_login(user)
         multi_url = reverse(
             'admin:blocklist_blocklistsubmission_change', args=(mbs.id,)
@@ -1945,7 +1945,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         ]
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Signoff')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_SIGNOFF)
         self.client.force_login(user)
         multi_url = reverse(
             'admin:blocklist_blocklistsubmission_change', args=(mbs.id,)
@@ -2020,7 +2020,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         ]
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
         multi_url = reverse(
             'admin:blocklist_blocklistsubmission_change', args=(mbs.id,)
@@ -2063,7 +2063,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         ]
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
         change_url = reverse(
             'admin:blocklist_blocklistsubmission_change', args=(submission.id,)
@@ -2145,7 +2145,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         addon.update(average_daily_users=1234)
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
         multi_view_url = reverse(
             'admin:blocklist_blocklistsubmission_change', args=(mbs.id,)
@@ -2183,7 +2183,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
     def test_list_filters(self):
         now = datetime.now()
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Signoff')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_SIGNOFF)
         self.client.force_login(user)
         addon_factory(guid='pending1@')
         addon_factory(guid='pending2@')
@@ -2261,7 +2261,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_blocked_deleted_keeps_addon_status(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         deleted_addon = addon_factory(guid='guid@', version_kw={'version': '1.2.5'})
@@ -2310,7 +2310,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_blocking_addon_guid_already_denied(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         deleted_addon = addon_factory(guid='guid@', version_kw={'version': '1.2.5'})
@@ -2404,7 +2404,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert mbs.signoff_state == BlocklistSubmission.SIGNOFF_STATES.PENDING
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Signoff')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_SIGNOFF)
         self.client.force_login(user)
         multi_url = reverse(
             'admin:blocklist_blocklistsubmission_change', args=(mbs.id,)
@@ -2444,7 +2444,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert mbs.to_block[0]['guid'] == 'guid@'
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Signoff')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_SIGNOFF)
         self.client.force_login(user)
         multi_url = reverse(
             'admin:blocklist_blocklistsubmission_change', args=(mbs.id,)
@@ -2491,7 +2491,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_edit_delay(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         threshold = settings.DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD
@@ -2567,7 +2567,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_not_disable_addon(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         new_addon_adu = settings.DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD - 1
@@ -2637,7 +2637,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     def test_soft_block(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         new_addon_adu = settings.DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD - 1
@@ -2719,7 +2719,7 @@ class TestBlockAdminDelete(TestCase):
 
     def test_delete_input(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         response = self.client.get(self.delete_url, follow=True)
@@ -2752,7 +2752,7 @@ class TestBlockAdminDelete(TestCase):
         """addon_adu is important because whether dual signoff is needed is
         based on what the average_daily_users is."""
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         block_one_ver = block_factory(
@@ -2896,7 +2896,7 @@ class TestBlockAdminDelete(TestCase):
         # Note this is similar to the test in BlocklistSubmission for add action,
         # but with the logic around what versions are available to select switched
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
 
         addon = addon_factory(guid='guid@', average_daily_users=100)
@@ -2987,7 +2987,7 @@ class TestBlockAdminDelete(TestCase):
         ]
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
         multi_url = reverse(
             'admin:blocklist_blocklistsubmission_change', args=(mbs.id,)
@@ -3010,7 +3010,7 @@ class TestBlockAdminDelete(TestCase):
         django_delete_url = reverse('admin:blocklist_block_delete', args=(block.pk,))
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Blocklist:Create')
+        self.grant_permission(user, amo.permissions.BLOCKLIST_CREATE)
         self.client.force_login(user)
         assert Block.objects.count() == 1
 

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1833,7 +1833,7 @@ class TestUploadDetail(UploadMixin, TestCase):
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_experiment_xpi_allowed(self, run_addons_linter_mock):
         user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.grant_permission(user, 'Experiments:submit')
+        self.grant_permission(user, amo.permissions.EXPERIMENTS_SUBMIT)
         run_addons_linter_mock.return_value = self.validation_ok()
         self.upload_file(
             '../../../files/fixtures/files/experiment_inside_webextension.xpi'
@@ -1867,7 +1867,7 @@ class TestUploadDetail(UploadMixin, TestCase):
 
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_restricted_guid_addon_allowed(self, run_addons_linter_mock):
-        self.grant_permission(self.user, 'SystemAddon:Submit')
+        self.grant_permission(self.user, amo.permissions.SYSTEM_ADDON_SUBMIT)
         run_addons_linter_mock.return_value = self.validation_ok()
         self.upload_file(self.file_fixture_path('mozilla_guid.xpi'))
         upload = FileUpload.objects.get()
@@ -1900,7 +1900,7 @@ class TestUploadDetail(UploadMixin, TestCase):
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     @mock.patch('olympia.files.utils.get_signer_organizational_unit_name')
     def test_mozilla_signed_allowed(self, get_signer_mock, run_addons_linter_mock):
-        self.grant_permission(self.user, 'SystemAddon:Submit')
+        self.grant_permission(self.user, amo.permissions.SYSTEM_ADDON_SUBMIT)
         run_addons_linter_mock.return_value = self.validation_ok()
         get_signer_mock.return_value = 'Mozilla Extensions'
         self.upload_file(self.file_fixture_path('webextension_signed_already.xpi'))

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -2701,7 +2701,7 @@ class TestVersionSubmitUploadListed(VersionSubmitUploadMixin, UploadMixin, TestC
             'You cannot submit a language pack'
         )
 
-        self.grant_permission(self.user, ':'.join(amo.permissions.LANGPACK_SUBMIT))
+        self.grant_permission(self.user, amo.permissions.LANGPACK_SUBMIT)
 
         response = self.post(expected_status=302)
 

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -244,7 +244,8 @@ class TestFileValidation(TestCase):
         self.client.logout()
         self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
         self.grant_permission(
-            UserProfile.objects.get(email='regular@mozilla.com'), 'ReviewerTools:View'
+            UserProfile.objects.get(email='regular@mozilla.com'),
+            amo.permissions.REVIEWER_TOOLS_VIEW,
         )
         assert self.client.head(self.url, follow=False).status_code == 200
 
@@ -252,7 +253,8 @@ class TestFileValidation(TestCase):
         self.client.logout()
         self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
         self.grant_permission(
-            UserProfile.objects.get(email='regular@mozilla.com'), 'ReviewerTools:View'
+            UserProfile.objects.get(email='regular@mozilla.com'),
+            amo.permissions.REVIEWER_TOOLS_VIEW,
         )
         assert self.client.head(self.json_url, follow=False).status_code == 200
 
@@ -262,7 +264,8 @@ class TestFileValidation(TestCase):
         self.client.logout()
         self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
         self.grant_permission(
-            UserProfile.objects.get(email='regular@mozilla.com'), 'ReviewerTools:View'
+            UserProfile.objects.get(email='regular@mozilla.com'),
+            amo.permissions.REVIEWER_TOOLS_VIEW,
         )
         assert self.client.head(self.json_url, follow=False).status_code == 200
 
@@ -355,7 +358,7 @@ class TestFileValidation(TestCase):
         self.client.force_login(UserProfile.objects.get(email='reviewer@mozilla.com'))
         self.grant_permission(
             UserProfile.objects.get(email='reviewer@mozilla.com'),
-            'Addons:ReviewUnlisted',
+            amo.permissions.ADDONS_REVIEW_UNLISTED,
         )
 
         self.addon.delete()
@@ -366,7 +369,9 @@ class TestFileValidation(TestCase):
 
     def test_unlisted_viewers_can_see_json_results_for_deleted_addon(self):
         unlisted_viewer = user_factory(email='unlisted_viewer@mozilla.com')
-        self.grant_permission(unlisted_viewer, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            unlisted_viewer, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         self.client.logout()
         self.client.force_login(
             UserProfile.objects.get(email='unlisted_viewer@mozilla.com')

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -1516,7 +1516,7 @@ class TestVersionEditDetails(TestVersionEditBase):
     def test_email_is_sent_to_relevant_people_for_source_code_upload(self):
         # Have a reviewer review a version.
         reviewer = user_factory()
-        self.grant_permission(reviewer, 'Addons:Review')
+        self.grant_permission(reviewer, amo.permissions.ADDONS_REVIEW)
         ActivityLog.objects.create(
             amo.LOG.REJECT_VERSION_DELAYED, self.addon, self.version, user=reviewer
         )

--- a/src/olympia/discovery/tests/test_admin.py
+++ b/src/olympia/discovery/tests/test_admin.py
@@ -23,7 +23,7 @@ class TestDiscoveryAdmin(TestCase):
 
     def test_can_see_discovery_module_in_admin_with_discovery_edit(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         url = reverse('admin:index')
         response = self.client.get(url)
@@ -37,7 +37,7 @@ class TestDiscoveryAdmin(TestCase):
     def test_can_list_with_discovery_edit_permission(self):
         DiscoveryItem.objects.create(addon=addon_factory(name='FooBâr'))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -47,7 +47,7 @@ class TestDiscoveryAdmin(TestCase):
         DiscoveryItem.objects.create(addon=addon_factory(name='FooBâr'), position=1)
         DiscoveryItem.objects.create(addon=addon_factory(name='Âbsent'))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url + '?position=yes', follow=True)
         assert response.status_code == 200
@@ -60,7 +60,7 @@ class TestDiscoveryAdmin(TestCase):
         )
         DiscoveryItem.objects.create(addon=addon_factory(name='Âbsent'), position=1)
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url + '?position=no', follow=True)
         assert response.status_code == 200
@@ -73,7 +73,7 @@ class TestDiscoveryAdmin(TestCase):
         )
         DiscoveryItem.objects.create(addon=addon_factory(name='Âbsent'))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url + '?position_china=yes', follow=True)
         assert response.status_code == 200
@@ -86,7 +86,7 @@ class TestDiscoveryAdmin(TestCase):
             addon=addon_factory(name='Âbsent'), position_china=1
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url + '?position_china=no', follow=True)
         assert response.status_code == 200
@@ -100,7 +100,7 @@ class TestDiscoveryAdmin(TestCase):
             'admin:discovery_discoveryitem_change', args=(item.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -129,7 +129,7 @@ class TestDiscoveryAdmin(TestCase):
             'admin:discovery_discoveryitem_change', args=(item.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -156,7 +156,7 @@ class TestDiscoveryAdmin(TestCase):
             'admin:discovery_discoveryitem_change', args=(item.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -188,7 +188,7 @@ class TestDiscoveryAdmin(TestCase):
             'admin:discovery_discoveryitem_change', args=(item.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
 
         # Try changing using an unknown slug.
@@ -228,7 +228,7 @@ class TestDiscoveryAdmin(TestCase):
             'admin:discovery_discoveryitem_delete', args=(item.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         # Can access delete confirmation page.
         response = self.client.get(self.delete_url, follow=True)
@@ -244,7 +244,7 @@ class TestDiscoveryAdmin(TestCase):
         addon = addon_factory(name='BarFöo')
         self.add_url = reverse('admin:discovery_discoveryitem_add')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.add_url, follow=True)
         assert response.status_code == 200
@@ -325,7 +325,7 @@ class TestDiscoveryAdmin(TestCase):
         DiscoveryItem.objects.create(addon=addon_factory(name='FooBâr 6'))
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
 
         # 1. select current user
@@ -357,7 +357,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
 
     def test_can_see_primary_hero_image_in_admin_with_discovery_edit(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         url = reverse('admin:index')
         response = self.client.get(url)
@@ -374,7 +374,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
         uploaded_photo = get_uploaded_file('transparent.png')
         PrimaryHeroImage.objects.create(custom_image=uploaded_photo)
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -387,7 +387,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
             'admin:discovery_primaryheroimageupload_change', args=(item.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -435,7 +435,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
             'admin:discovery_primaryheroimageupload_delete', args=(item.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         # Can access delete confirmation page.
         response = self.client.get(delete_url, follow=True)
@@ -466,7 +466,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
     def test_can_add_with_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_primaryheroimageupload_add')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 200
@@ -601,7 +601,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
 
     def test_can_see_secondary_hero_module_in_admin_with_discovery_edit(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         url = reverse('admin:index')
         response = self.client.get(url)
@@ -615,7 +615,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
     def test_can_list_with_discovery_edit_permission(self):
         SecondaryHero.objects.create(headline='FooBâr')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -630,7 +630,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
         ]
         detail_url = reverse(self.detail_url_name, args=(item.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 200
@@ -681,7 +681,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
             'admin:discovery_secondaryheroshelf_delete', args=(item.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         # Can access delete confirmation page.
         response = self.client.get(delete_url, follow=True)
@@ -716,7 +716,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
     def test_can_add_with_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_secondaryheroshelf_add')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 200
@@ -817,7 +817,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
     def test_need_3_modules(self):
         add_url = reverse('admin:discovery_secondaryheroshelf_add')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 200
@@ -856,7 +856,7 @@ class TestShelfAdmin(TestCase):
 
     def test_can_see_shelf_module_in_admin_with_discovery_edit(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         url = reverse('admin:index')
         response = self.client.get(url)
@@ -870,7 +870,7 @@ class TestShelfAdmin(TestCase):
     def test_can_list_with_discovery_edit_permission(self):
         Shelf.objects.create(title='FooBâr')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -887,7 +887,7 @@ class TestShelfAdmin(TestCase):
         )
         detail_url = reverse(self.detail_url_name, args=(item.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 200
@@ -930,7 +930,7 @@ class TestShelfAdmin(TestCase):
         )
         detail_url = reverse(self.detail_url_name, args=(item.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         data = {
             'title': 'Recommended extensions',
@@ -977,7 +977,7 @@ class TestShelfAdmin(TestCase):
         )
         delete_url = reverse('admin:discovery_homepageshelves_delete', args=(item.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         # Can access delete confirmation page.
         response = self.client.get(delete_url, follow=True)
@@ -992,7 +992,7 @@ class TestShelfAdmin(TestCase):
     def test_can_add_with_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_homepageshelves_add')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 200

--- a/src/olympia/files/tests/test_admin.py
+++ b/src/olympia/files/tests/test_admin.py
@@ -5,6 +5,7 @@ from django.utils.encoding import force_str
 
 from pyquery import PyQuery as pq
 
+from olympia import amo
 from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.files.models import FileManifest, FileValidation, WebextPermission
 
@@ -17,7 +18,7 @@ class TestFileAdmin(TestCase):
         addon = addon_factory()
         file_ = addon.current_version.file
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -28,7 +29,7 @@ class TestFileAdmin(TestCase):
         file_ = addon.current_version.file
         detail_url = reverse('admin:files_file_change', args=(file_.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 200
@@ -71,7 +72,7 @@ class TestFileAdmin(TestCase):
 
         # Just checking that simply changing the permission resolves
         # as wanted
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
 
@@ -80,7 +81,7 @@ class TestFileAdmin(TestCase):
         file_ = addon.current_version.file
         detail_url = reverse('admin:files_file_change', args=(file_.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 200
@@ -99,7 +100,7 @@ class TestFileAdmin(TestCase):
 
         detail_url = reverse('admin:files_file_change', args=(file_.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 200

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -736,7 +736,7 @@ class TestParseXpi(amo.tests.AMOPaths, TestCase):
         )
 
     def test_match_type_extension_for_webextension_experiments(self):
-        self.grant_permission(self.user, 'Experiments:submit')
+        self.grant_permission(self.user, amo.permissions.EXPERIMENTS_SUBMIT)
         parsed = self.parse(filename='experiment_inside_webextension.xpi')
         # See #3315: webextension experiments (type 256) map to extensions.
         assert parsed['type'] == amo.ADDON_EXTENSION
@@ -748,19 +748,19 @@ class TestParseXpi(amo.tests.AMOPaths, TestCase):
         assert not parsed['is_experiment']
 
     def test_experiment_inside_webextension(self):
-        self.grant_permission(self.user, 'Experiments:submit')
+        self.grant_permission(self.user, amo.permissions.EXPERIMENTS_SUBMIT)
         parsed = self.parse(filename='experiment_inside_webextension.xpi')
         assert parsed['type'] == amo.ADDON_EXTENSION
         assert parsed['is_experiment']
 
     def test_theme_experiment_inside_webextension(self):
-        self.grant_permission(self.user, 'Experiments:submit')
+        self.grant_permission(self.user, amo.permissions.EXPERIMENTS_SUBMIT)
         parsed = self.parse(filename='theme_experiment_inside_webextension.xpi')
         assert parsed['type'] == amo.ADDON_STATICTHEME
         assert parsed['is_experiment']
 
     def test_match_mozilla_signed_extension(self):
-        self.grant_permission(self.user, 'SystemAddon:Submit')
+        self.grant_permission(self.user, amo.permissions.SYSTEM_ADDON_SUBMIT)
         parsed = self.parse(filename='webextension_signed_already.xpi')
         assert parsed['is_mozilla_signed_extension']
 
@@ -782,7 +782,7 @@ class TestParseXpi(amo.tests.AMOPaths, TestCase):
         with self.assertRaises(ValidationError):
             result = self.parse(filename='webextension_langpack.xpi')
 
-        self.grant_permission(self.user, 'LanguagePack:Submit')
+        self.grant_permission(self.user, amo.permissions.LANGPACK_SUBMIT)
         result = self.parse(filename='webextension_langpack.xpi')
         assert result['type'] == amo.ADDON_LPAPP
         assert result['strict_compatibility']

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -884,7 +884,7 @@ class TestLanguagePackAndDictionaries(AppVersionsMixin, TestCase):
             utils.check_xpi_info(parsed_data, xpi_file=mock.Mock(), user=user)
 
         # Shouldn't raise for users with proper permissions
-        self.grant_permission(user, ':'.join(amo.permissions.LANGPACK_SUBMIT))
+        self.grant_permission(user, amo.permissions.LANGPACK_SUBMIT)
 
         utils.check_xpi_info(parsed_data, xpi_file=mock.Mock(), user=user)
 
@@ -912,7 +912,7 @@ class TestLanguagePackAndDictionaries(AppVersionsMixin, TestCase):
 
     def test_cant_change_locale_for_langpack(self):
         user = user_factory()
-        self.grant_permission(user, ':'.join(amo.permissions.LANGPACK_SUBMIT))
+        self.grant_permission(user, amo.permissions.LANGPACK_SUBMIT)
         self.create_appversion('firefox', '60.0')
         self.create_appversion('firefox', '60.*')
 

--- a/src/olympia/promoted/tests/test_admin.py
+++ b/src/olympia/promoted/tests/test_admin.py
@@ -27,7 +27,7 @@ class TestDiscoveryPromotedGroupAdmin(TestCase):
 
     def test_can_see_in_admin_with_discovery_edit(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         url = reverse('admin:index')
         response = self.client.get(url)
@@ -51,7 +51,7 @@ class TestDiscoveryPromotedGroupAdmin(TestCase):
     def test_can_list_with_discovery_edit(self):
         addon_factory(name='FooBâr')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(reverse(self.list_url_name), follow=True)
         assert response.status_code == 200
@@ -103,7 +103,7 @@ class TestDiscoveryPromotedGroupAdmin(TestCase):
         )
         addon = addon_factory(promoted_kwargs={'api_name': group.api_name})
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         change_url = reverse(
             'admin:discovery_discoverypromotedgroup_change', args=[group.pk]
@@ -129,7 +129,7 @@ class TestDiscoveryPromotedGroupAdmin(TestCase):
         )
         addon = addon_factory(promoted_kwargs={'api_name': group.api_name})
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         delete_url = reverse(
             'admin:discovery_discoverypromotedgroup_delete', args=[group.pk]
@@ -197,7 +197,7 @@ class TestDiscoveryAddonAdmin(TestCase):
 
     def test_can_see_in_admin_with_discovery_edit(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         url = reverse('admin:index')
         response = self.client.get(url)
@@ -211,7 +211,7 @@ class TestDiscoveryAddonAdmin(TestCase):
     def test_can_list_with_discovery_edit_permission(self):
         addon_factory(name='FooBâr')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
 
         with self.assertNumQueries(10):
@@ -263,7 +263,7 @@ class TestDiscoveryAddonAdmin(TestCase):
             application_id=amo.FIREFOX.id,
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
 
         filters = {
@@ -284,7 +284,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         detail_url = reverse(self.detail_url_name, args=(addon.pk,))
         detail_url_by_slug = reverse(self.detail_url_name, args=(addon.slug,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url_by_slug, follow=False)
         self.assert3xx(response, detail_url, 301)
@@ -294,7 +294,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         detail_url = reverse(self.detail_url_name, args=(addon.pk,))
         detail_url_by_guid = reverse(self.detail_url_name, args=(addon.guid,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url_by_guid, follow=False)
         self.assert3xx(response, detail_url, 301)
@@ -337,7 +337,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         assert addon.approved_applications
         detail_url = reverse(self.detail_url_name, args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 200
@@ -406,7 +406,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         )
         detail_url = reverse(self.detail_url_name, args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
 
         # try to change the approval group
@@ -520,7 +520,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         )
         detail_url = reverse(self.detail_url_name, args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
 
         # And can delete.
@@ -572,7 +572,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         addon = addon_factory()
         detail_url = reverse(self.detail_url_name, args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         # create an approval that doesn't have a matching PromotedAddon yet
         group = PromotedGroup.objects.get(api_name=RECOMMENDED_API_NAME)
@@ -605,7 +605,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         addon = addon_factory(name='unattached')
         detail_url = reverse(self.detail_url_name, args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         # create an approval that doesn't have a matching PromotedAddon yet
         group = PromotedGroup.objects.get(api_name='line')
@@ -658,7 +658,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         hero = PrimaryHero.objects.create(addon=addon, gradient_color='#592ACB')
         self.detail_url = reverse(self.detail_url_name, args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -694,7 +694,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         image = PrimaryHeroImage.objects.create(custom_image=uploaded_photo)
         self.detail_url = reverse(self.detail_url_name, args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200

--- a/src/olympia/ratings/tests/test_admin.py
+++ b/src/olympia/ratings/tests/test_admin.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 
 from pyquery import PyQuery as pq
 
-from olympia import core
+from olympia import amo, core
 from olympia.addons.models import Addon
 from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.ratings.models import Rating
@@ -43,7 +43,7 @@ class TestRatingAdmin(TestCase):
             addon=addon, user=self.user, body='Réply', reply_to=self.rating
         )
 
-        self.grant_permission(self.user, 'Ratings:Moderate')
+        self.grant_permission(self.user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(self.user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -91,7 +91,7 @@ class TestRatingAdmin(TestCase):
             'created__range__gte': even_more_time_ago.isoformat(),
             'created__range__lte': some_time_ago.isoformat(),
         }
-        self.grant_permission(self.user, 'Ratings:Moderate')
+        self.grant_permission(self.user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(self.user)
         response = self.client.get(self.list_url, data, follow=True)
         assert response.status_code == 200
@@ -120,7 +120,7 @@ class TestRatingAdmin(TestCase):
 
     def test_search_tooltip(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Ratings:Moderate')
+        self.grant_permission(user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(user)
         response = self.client.get(self.list_url)
         doc = pq(response.content)
@@ -139,8 +139,8 @@ class TestRatingAdmin(TestCase):
 
     def test_search_by_ip(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Ratings:Moderate')
-        self.grant_permission(user, 'Ratings:Delete')
+        self.grant_permission(user, amo.permissions.RATINGS_MODERATE)
+        self.grant_permission(user, amo.permissions.RATINGS_DELETE)
         self.client.force_login(user)
 
         addon = Addon.objects.get(pk=3615)
@@ -290,8 +290,8 @@ class TestRatingAdmin(TestCase):
                 body='Lôrem Ipsûm',
             )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Ratings:Delete')
-        self.grant_permission(user, 'Ratings:Moderate')
+        self.grant_permission(user, amo.permissions.RATINGS_DELETE)
+        self.grant_permission(user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(user)
         # Find link to sort by IP
         response = self.client.post(self.list_url, {'addon': self.addon.pk})
@@ -330,7 +330,7 @@ class TestRatingAdmin(TestCase):
         data = {
             'created__range__gte': not_long_ago.isoformat(),
         }
-        self.grant_permission(self.user, 'Ratings:Moderate')
+        self.grant_permission(self.user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(self.user)
         response = self.client.get(self.list_url, data, follow=True)
         assert response.status_code == 200
@@ -370,7 +370,7 @@ class TestRatingAdmin(TestCase):
         data = {
             'created__range__lte': some_time_ago.isoformat(),
         }
-        self.grant_permission(self.user, 'Ratings:Moderate')
+        self.grant_permission(self.user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(self.user)
         response = self.client.get(self.list_url, data, follow=True)
         assert response.status_code == 200
@@ -412,7 +412,7 @@ class TestRatingAdmin(TestCase):
             addon=addon, user=self.user, body='Réply', reply_to=self.rating
         )
 
-        self.grant_permission(self.user, 'Ratings:Moderate')
+        self.grant_permission(self.user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(self.user)
         with self.assertNumQueries(9):
             # - 2 Savepoint/release
@@ -430,7 +430,7 @@ class TestRatingAdmin(TestCase):
 
     def test_can_not_access_detail_without_ratings_moderate_permission(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 403
@@ -438,7 +438,7 @@ class TestRatingAdmin(TestCase):
     def test_can_not_delete_without_ratings_delete_permission(self):
         assert Rating.objects.count() == 1
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Ratings:Moderate')  # Not enough!
+        self.grant_permission(user, amo.permissions.RATINGS_MODERATE)  # Not enough!
         self.client.force_login(user)
         response = self.client.get(self.delete_url, follow=True)
         assert response.status_code == 403
@@ -451,8 +451,8 @@ class TestRatingAdmin(TestCase):
     def test_can_delete_with_ratings_delete_permission(self):
         assert Rating.objects.count() == 1
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Ratings:Delete')
-        self.grant_permission(user, 'Ratings:Moderate')
+        self.grant_permission(user, amo.permissions.RATINGS_DELETE)
+        self.grant_permission(user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(user)
 
         response = self.client.get(self.list_url, follow=True)
@@ -470,8 +470,8 @@ class TestRatingAdmin(TestCase):
 
     def test_can_not_change_detail(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Ratings:Delete')
-        self.grant_permission(user, 'Ratings:Moderate')
+        self.grant_permission(user, amo.permissions.RATINGS_DELETE)
+        self.grant_permission(user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(user)
 
         response = self.client.get(self.detail_url, follow=True)
@@ -480,8 +480,8 @@ class TestRatingAdmin(TestCase):
 
     def test_detail(self):
         user = UserProfile.objects.get(pk=999)
-        self.grant_permission(user, 'Ratings:Delete')
-        self.grant_permission(user, 'Ratings:Moderate')
+        self.grant_permission(user, amo.permissions.RATINGS_DELETE)
+        self.grant_permission(user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(user)
 
         response = self.client.get(self.detail_url, follow=True)

--- a/src/olympia/ratings/tests/test_serializers.py
+++ b/src/olympia/ratings/tests/test_serializers.py
@@ -4,6 +4,7 @@ from django.test import override_settings
 
 from rest_framework.test import APIRequestFactory
 
+from olympia import amo
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.ratings.models import Rating, RatingFlag
@@ -183,7 +184,7 @@ class TestBaseRatingSerializer(TestCase):
         )
         # should include account profile url for admins
         admin = user_factory()
-        self.grant_permission(admin, 'Users:Edit')
+        self.grant_permission(admin, amo.permissions.USERS_EDIT)
         self.request.user = admin
         result = self.serialize()
         assert result['user']['url'] == absolutify(self.user.get_url_path())

--- a/src/olympia/ratings/tests/test_views.py
+++ b/src/olympia/ratings/tests/test_views.py
@@ -897,7 +897,7 @@ class TestRatingViewSetGet(TestCase):
 
     def test_detail_show_deleted_admin(self):
         self.user = user_factory()
-        self.grant_permission(self.user, 'Addons:Edit')
+        self.grant_permission(self.user, amo.permissions.ADDONS_EDIT)
         self.client.login_api(self.user)
         review = Rating.objects.create(
             addon=self.addon, body='review', user=user_factory()
@@ -1018,7 +1018,7 @@ class TestRatingViewSetGet(TestCase):
 
     def test_list_by_admin_does_not_show_deleted_by_default(self):
         self.user = user_factory()
-        self.grant_permission(self.user, 'Addons:Edit')
+        self.grant_permission(self.user, amo.permissions.ADDONS_EDIT)
         self.client.login_api(self.user)
         review1 = Rating.objects.create(
             addon=self.addon, body='review 1', user=user_factory()
@@ -1066,7 +1066,7 @@ class TestRatingViewSetGet(TestCase):
 
     def test_list_admin_show_deleted_if_requested(self):
         self.user = user_factory()
-        self.grant_permission(self.user, 'Addons:Edit')
+        self.grant_permission(self.user, amo.permissions.ADDONS_EDIT)
         self.client.login_api(self.user)
         review1 = Rating.objects.create(
             addon=self.addon, body='review 1', user=user_factory()
@@ -1241,7 +1241,7 @@ class TestRatingViewSetDelete(TestCase):
 
     def test_delete_admin(self):
         admin_user = user_factory()
-        self.grant_permission(admin_user, 'Addons:Edit')
+        self.grant_permission(admin_user, amo.permissions.ADDONS_EDIT)
         self.client.login_api(admin_user)
         response = self.client.delete(self.url)
         assert response.status_code == 204
@@ -1251,7 +1251,7 @@ class TestRatingViewSetDelete(TestCase):
     def test_delete_moderator_flagged(self):
         self.rating.update(editorreview=True)
         admin_user = user_factory()
-        self.grant_permission(admin_user, 'Ratings:Moderate')
+        self.grant_permission(admin_user, amo.permissions.RATINGS_MODERATE)
         self.client.login_api(admin_user)
         response = self.client.delete(self.url)
         assert response.status_code == 204
@@ -1260,7 +1260,7 @@ class TestRatingViewSetDelete(TestCase):
 
     def test_delete_moderator_not_flagged(self):
         admin_user = user_factory()
-        self.grant_permission(admin_user, 'Ratings:Moderate')
+        self.grant_permission(admin_user, amo.permissions.RATINGS_MODERATE)
         self.client.login_api(admin_user)
         response = self.client.delete(self.url)
         assert response.status_code == 403
@@ -1269,7 +1269,7 @@ class TestRatingViewSetDelete(TestCase):
     def test_delete_moderator_but_addon_author(self):
         admin_user = user_factory()
         self.addon.addonuser_set.create(user=admin_user)
-        self.grant_permission(admin_user, 'Ratings:Moderate')
+        self.grant_permission(admin_user, amo.permissions.RATINGS_MODERATE)
         self.client.login_api(admin_user)
         response = self.client.delete(self.url)
         assert response.status_code == 403
@@ -1402,7 +1402,7 @@ class TestRatingViewSetEdit(TestCase):
     def test_edit_no_rights_even_reviewer(self):
         # Only admins can edit a review they didn't write themselves.
         reviewer_user = user_factory()
-        self.grant_permission(reviewer_user, 'Addons:Review')
+        self.grant_permission(reviewer_user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(reviewer_user)
         response = self.client.patch(self.url, {'body': 'løl!'})
         assert response.status_code == 403
@@ -1460,7 +1460,7 @@ class TestRatingViewSetEdit(TestCase):
     def test_edit_admin(self):
         original_review_user = self.rating.user
         admin_user = user_factory(username='mylittleadmin')
-        self.grant_permission(admin_user, 'Addons:Edit')
+        self.grant_permission(admin_user, amo.permissions.ADDONS_EDIT)
         self.client.login_api(admin_user)
         response = self.client.patch(self.url, {'body': 'løl!'})
         assert response.status_code == 200
@@ -1568,7 +1568,7 @@ class TestRatingViewSetEdit(TestCase):
             assert self.rating.rating == 5
 
             # Now with the permission we should be ok.
-            self.grant_permission(self.user, 'API:BypassThrottling')
+            self.grant_permission(self.user, amo.permissions.API_BYPASS_THROTTLING)
             response = self.client.patch(
                 self.url,
                 {'score': 1, 'body': 'Eheheh'},
@@ -2980,7 +2980,7 @@ class TestRatingViewSetReply(TestCase):
         ActivityLog.objects.all().delete()
         mail.outbox = []
         self.admin_user = user_factory()
-        self.grant_permission(self.admin_user, 'Addons:Edit')
+        self.grant_permission(self.admin_user, amo.permissions.ADDONS_EDIT)
         self.client.login_api(self.admin_user)
         response = self.client.post(
             self.url,

--- a/src/olympia/reviewers/decorators.py
+++ b/src/olympia/reviewers/decorators.py
@@ -47,7 +47,6 @@ def any_reviewer_required(f):
     - Addons:ReviewUnlisted
     - Addons:ContentReview
     - Addons:ThemeReview
-    - Addons:RecommendedReview
     """
 
     @functools.wraps(f)

--- a/src/olympia/reviewers/tests/test_admin.py
+++ b/src/olympia/reviewers/tests/test_admin.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 
 from pyquery import PyQuery as pq
 
-from olympia import core
+from olympia import amo, core
 from olympia.abuse.models import CinderPolicy
 from olympia.amo.tests import (
     TestCase,
@@ -43,7 +43,7 @@ class TestNeedsHumanReviewAdmin(TestCase):
         assert v2.due_date
 
         user = user_factory(email='admin@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         response = self.client.get(self.list_url)
         doc = pq(response.content)
@@ -77,7 +77,7 @@ class TestNeedsHumanReviewAdmin(TestCase):
     def test_deactivate_selected_action(self):
         request = RequestFactory().get('/')
         request.user = user_factory(email='admin@mozilla.com')
-        self.grant_permission(request.user, '*:*')
+        self.grant_permission(request.user, amo.permissions.SUPERPOWERS)
         core.set_user(request.user)
         request._messages = default_messages_storage(request)
 
@@ -117,7 +117,7 @@ class TestNeedsHumanReviewAdmin(TestCase):
     def test_activate_selected_action(self):
         request = RequestFactory().get('/')
         request.user = user_factory(email='admin@mozilla.com')
-        self.grant_permission(request.user, '*:*')
+        self.grant_permission(request.user, amo.permissions.SUPERPOWERS)
         core.set_user(request.user)
         request._messages = default_messages_storage(request)
 
@@ -163,7 +163,7 @@ class TestReviewActionReasonAdmin(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = user_factory(email='someone@mozilla.com')
-        grant_permission(cls.user, '*:*', 'Admins')
+        grant_permission(cls.user, amo.permissions.SUPERPOWERS, name='Admins')
 
     def setUp(self):
         self.client.force_login(self.user)
@@ -214,7 +214,7 @@ class TestUsageTierAdmin(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = user_factory(email='someone@mozilla.com')
-        grant_permission(cls.user, '*:*', 'Admins')
+        grant_permission(cls.user, amo.permissions.SUPERPOWERS, name='Admins')
 
     def setUp(self):
         self.client.force_login(self.user)

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -75,7 +75,7 @@ class TestReviewForm(TestCase):
         return form.helper.get_actions()
 
     def test_actions_reject(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_NOMINATED, file_status=amo.STATUS_AWAITING_REVIEW
         )
@@ -85,7 +85,7 @@ class TestReviewForm(TestCase):
     def test_actions_addon_status_null(self):
         # If the add-on is null we only show set needs human review, reply,
         # comment.
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_NULL, file_status=amo.STATUS_DISABLED
         )
@@ -100,7 +100,7 @@ class TestReviewForm(TestCase):
         # If an admin reviewer we also show unreject_latest_version and clear
         # pending rejection/needs human review (though the versions form would
         # be empty for the last 2 here). And disable addon.
-        self.grant_permission(self.request.user, 'Reviews:Admin')
+        self.grant_permission(self.request.user, amo.permissions.REVIEWS_ADMIN)
         actions = self.get_form().helper.get_actions()
         assert list(actions.keys()) == [
             'unreject_latest_version',
@@ -118,8 +118,8 @@ class TestReviewForm(TestCase):
         self.make_addon_unlisted(self.addon)
         self.version.reload()
         self.version.update(human_review_date=datetime.now())
-        self.grant_permission(self.request.user, 'Addons:Review')
-        self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_NULL, file_status=amo.STATUS_DISABLED
         )
@@ -136,7 +136,7 @@ class TestReviewForm(TestCase):
 
         # If an admin reviewer we also show unreject_multiple_versions,
         # clear pending rejections/clear needs human review, disable addon.
-        self.grant_permission(self.request.user, 'Reviews:Admin')
+        self.grant_permission(self.request.user, amo.permissions.REVIEWS_ADMIN)
         actions = self.get_form().helper.get_actions()
         assert list(actions.keys()) == [
             'approve_multiple_versions',
@@ -157,7 +157,7 @@ class TestReviewForm(TestCase):
     def test_actions_addon_status_deleted(self):
         # If the add-on is deleted we only show reply, comment and
         # super review.
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_DELETED, file_status=amo.STATUS_DISABLED
         )
@@ -169,7 +169,7 @@ class TestReviewForm(TestCase):
         ]
 
         # Having admin permission gives you some extra actions
-        self.grant_permission(self.request.user, 'Reviews:Admin')
+        self.grant_permission(self.request.user, amo.permissions.REVIEWS_ADMIN)
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_DELETED, file_status=amo.STATUS_DISABLED
         )
@@ -186,7 +186,7 @@ class TestReviewForm(TestCase):
     def test_actions_no_pending_files(self):
         # If the add-on has no pending files we only show
         # reject_multiple_versions, reply, comment and super review.
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED
         )
@@ -199,7 +199,7 @@ class TestReviewForm(TestCase):
         ]
 
         # admins have extra permssions though
-        self.grant_permission(self.request.user, 'Reviews:Admin')
+        self.grant_permission(self.request.user, amo.permissions.REVIEWS_ADMIN)
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED
         )
@@ -231,7 +231,7 @@ class TestReviewForm(TestCase):
         ]
 
     def test_policies_required_with_cinder_jobs(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         job = CinderJob.objects.create(
@@ -262,7 +262,7 @@ class TestReviewForm(TestCase):
 
     @override_switch('enable-policy-review-selection', active=True)
     def test_cannot_resolve_jobs_and_override_decision(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         job = CinderJob.objects.create(
@@ -293,7 +293,7 @@ class TestReviewForm(TestCase):
         }
 
     def test_override_decision_queryset(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         # A decision for this add-on that hasn't been overridden: included.
         decision = ContentDecision.objects.create(
             addon=self.addon, action=DECISION_ACTIONS.AMO_DISABLE_ADDON
@@ -320,7 +320,7 @@ class TestReviewForm(TestCase):
         }
 
     def test_policy_values_parsed(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         policy = CinderPolicy.objects.create(
@@ -370,7 +370,7 @@ class TestReviewForm(TestCase):
         }
 
     def test_appeal_action_require_with_appeal_deny(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         job = CinderJob.objects.create(
@@ -398,7 +398,7 @@ class TestReviewForm(TestCase):
         assert not form.errors
 
     def test_policy_actions(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         job = CinderJob.objects.create(
@@ -477,7 +477,7 @@ class TestReviewForm(TestCase):
     def test_policy_actions_multiple_positive(self):
         # Selecting policies that result in multiple positive enforcement
         # actions should raise an error.
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         job = CinderJob.objects.create(
@@ -511,7 +511,7 @@ class TestReviewForm(TestCase):
 
     @override_switch('enable-policy-review-selection', active=True)
     def test_policy_actions_with_policy_enforcement(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         job = CinderJob.objects.create(
@@ -608,7 +608,7 @@ class TestReviewForm(TestCase):
 
     @override_switch('enable-policy-review-selection', active=True)
     def test_versions_required_when_enforcement_is_on_versions(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         disable_policy = CinderPolicy.objects.create(
@@ -672,7 +672,7 @@ class TestReviewForm(TestCase):
         assert form.errors == {'versions': ['This field is required.']}
 
     def test_cinder_jobs_filtered_for_resolve_reports_job_and_appeal_deny(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         appeal_job = CinderJob.objects.create(
@@ -724,7 +724,7 @@ class TestReviewForm(TestCase):
         assert form.cleaned_data['cinder_jobs_to_resolve'] == [report_job]
 
     def test_cinder_jobs_filtered_for_reject_or_reject_multiple_versions(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         developer_appeal_job = CinderJob.objects.create(
@@ -822,7 +822,7 @@ class TestReviewForm(TestCase):
         ]
 
     def test_boilerplate(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         form = self.get_form()
@@ -834,7 +834,7 @@ class TestReviewForm(TestCase):
         assert doc('input')[4].attrib.get('data-value') is None
 
     def test_action_required_by_default(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         form = self.get_form()
         assert not form.is_bound
         form = self.get_form(
@@ -857,7 +857,7 @@ class TestReviewForm(TestCase):
         assert form.errors == {'action': ['This field is required.']}
 
     def test_versions_queryset(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         # Add a bunch of extra data that shouldn't be picked up.
         addon_factory()
         version_factory(addon=self.addon, channel=amo.CHANNEL_UNLISTED)
@@ -884,7 +884,7 @@ class TestReviewForm(TestCase):
         # We hide some of the versions using JavaScript + some data attributes on each
         # <option>.
         # The queryset should contain both pending, rejected, and approved versions.
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         addon_factory()  # Extra add-on, shouldn't be included.
         pending_version = version_factory(
             addon=self.addon,
@@ -982,7 +982,7 @@ class TestReviewForm(TestCase):
         assert option4.attrib.get('value') == str(blocked_version.pk)
 
     def test_versions_queryset_contains_pending_files_for_listed_admin_reviewer(self):
-        self.grant_permission(self.request.user, 'Reviews:Admin')
+        self.grant_permission(self.request.user, amo.permissions.REVIEWS_ADMIN)
         # No change
         self.test_versions_queryset_contains_pending_files_for_listed(
             expected_select_data_value=[
@@ -1050,7 +1050,7 @@ class TestReviewForm(TestCase):
 
         # With Addons:ReviewUnlisted permission, the reject_multiple_versions
         # action will be available, resetting the queryset of allowed choices.
-        self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         form = self.get_form()
         assert not form.is_bound
         assert form.fields['versions'].required is False
@@ -1134,7 +1134,7 @@ class TestReviewForm(TestCase):
         assert option5.attrib.get('value') == str(deleted_version.pk)
 
     def test_set_needs_human_review_presence(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         deleted_but_signed = version_factory(
             addon=self.addon,
             file_kw={
@@ -1211,7 +1211,7 @@ class TestReviewForm(TestCase):
             ).split(' '), version
 
     def test_versions_queryset_contains_pending_files_for_unlisted_admin_reviewer(self):
-        self.grant_permission(self.request.user, 'Reviews:Admin')
+        self.grant_permission(self.request.user, amo.permissions.REVIEWS_ADMIN)
         self.test_versions_queryset_contains_pending_files_for_unlisted(
             expected_select_data_value=[
                 'approve_multiple_versions',
@@ -1231,7 +1231,7 @@ class TestReviewForm(TestCase):
             AutoApprovalSummary.objects.create(
                 version=version, verdict=amo.AUTO_APPROVED
             )
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         form = self.get_form(
             data={
                 'action': 'reject_multiple_versions',
@@ -1257,7 +1257,7 @@ class TestReviewForm(TestCase):
     @time_machine.travel('2025-02-10 12:09', tick=False)
     def test_delayed_rejection_date_is_readonly_for_regular_reviewers(self):
         # Regular reviewers can't customize the delayed rejection period.
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         form = self.get_form()
         assert 'delayed_rejection_date' in form.fields
         assert 'delayed_rejection' in form.fields
@@ -1292,8 +1292,8 @@ class TestReviewForm(TestCase):
     @time_machine.travel('2025-01-23 12:52', tick=False)
     def test_delayed_rejection_days_shows_up_for_admin_reviewers(self):
         # Admin reviewers can customize the delayed rejection period.
-        self.grant_permission(self.request.user, 'Addons:Review')
-        self.grant_permission(self.request.user, 'Reviews:Admin')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.request.user, amo.permissions.REVIEWS_ADMIN)
         form = self.get_form()
         assert 'delayed_rejection_date' in form.fields
         assert 'delayed_rejection' in form.fields
@@ -1326,7 +1326,8 @@ class TestReviewForm(TestCase):
 
     @time_machine.travel('2025-01-23 12:52', tick=False)
     def test_delayed_rejection_days_value_not_in_the_future(self):
-        self.grant_permission(self.request.user, 'Addons:Review,Reviews:Admin')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.request.user, amo.permissions.REVIEWS_ADMIN)
         data = {
             'action': 'reject_multiple_versions',
             'comments': 'foo!',
@@ -1355,7 +1356,8 @@ class TestReviewForm(TestCase):
         assert form.is_valid(), form.errors
 
     def test_delayable_action_missing_fields(self):
-        self.grant_permission(self.request.user, 'Addons:Review,Reviews:Admin')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.request.user, amo.permissions.REVIEWS_ADMIN)
         data = {
             'action': 'reject_multiple_versions',
             'comments': 'foo!',
@@ -1391,7 +1393,8 @@ class TestReviewForm(TestCase):
         assert form.errors['delayed_rejection_date'] == ['This field is required.']
 
     def test_change_pending_rejection_multiple_versions_different_dates(self):
-        self.grant_permission(self.request.user, 'Addons:Review,Reviews:Admin')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.request.user, amo.permissions.REVIEWS_ADMIN)
         in_the_future = datetime.now() + timedelta(days=15)
         in_the_future2 = datetime.now() + timedelta(days=55)
         VersionReviewerFlags.objects.create(
@@ -1425,7 +1428,7 @@ class TestReviewForm(TestCase):
         }
 
     def test_version_pk(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         data = {'action': 'comment', 'comments': 'lol'}
         form = self.get_form(data=data)
         assert form.is_valid(), form.errors
@@ -1669,7 +1672,7 @@ class TestReviewForm(TestCase):
         ]
 
     def test_upload_attachment(self):
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         attachment = ContentFile('Pseudo File', name='attachment.txt')
         data = {
             'action': 'reply',
@@ -1718,7 +1721,7 @@ class TestReviewForm(TestCase):
             enforcement_actions=[DECISION_ACTIONS.AMO_APPROVE.api_value],
         )
         self.file.update(status=amo.STATUS_AWAITING_REVIEW)
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         form = self.get_form()
 
         content = str(form['cinder_policies'])
@@ -1773,7 +1776,7 @@ class TestReviewForm(TestCase):
             text='No placeholders here',
         )
         self.file.update(status=amo.STATUS_AWAITING_REVIEW)
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         form = self.get_form()
 
         content = str(form['policy_values'])
@@ -1794,7 +1797,7 @@ class TestReviewForm(TestCase):
 
     def test_version_option_label_original_status(self):
         """Disabled version options have '<- was {original_status}' in their label."""
-        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, amo.permissions.ADDONS_REVIEW)
         for version in Version.unfiltered.all():
             AutoApprovalSummary.objects.create(
                 version=version, verdict=amo.AUTO_APPROVED

--- a/src/olympia/reviewers/tests/test_review_reports.py
+++ b/src/olympia/reviewers/tests/test_review_reports.py
@@ -6,10 +6,10 @@ import pytest
 import time_machine
 
 from olympia import amo
+from olympia.access.models import Group, GroupUser
 from olympia.activity.models import ActivityLog
 from olympia.amo.tests import (
     addon_factory,
-    grant_permission,
     user_factory,
     version_factory,
 )
@@ -56,8 +56,11 @@ class TestReviewReports:
             self.reviewer3 = user_factory(display_name=None)
             self.reviewer4 = user_factory(display_name='Staff Content D')
             self.reviewer5 = user_factory(display_name='Deleted')
-            grant_permission(self.reviewer2, '', name='No Reviewer Incentives')
-            grant_permission(self.reviewer4, '', name='No Reviewer Incentives')
+            no_incentives_group = Group.objects.create(
+                name='No Reviewer Incentives', rules=''
+            )
+            GroupUser.objects.create(group=no_incentives_group, user=self.reviewer2)
+            GroupUser.objects.create(group=no_incentives_group, user=self.reviewer4)
 
             data = [
                 (self.reviewer1, 178, amo.AUTO_APPROVED, False),

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -185,7 +185,7 @@ class TestReviewHelper(TestReviewHelperBase):
             self.helper.process()
 
     def test_process_action_good(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.helper = self.get_helper()
         self.helper.set_data(
             {'action': 'reply', 'comments': 'foo', 'versions': [self.review_version]}
@@ -211,7 +211,7 @@ class TestReviewHelper(TestReviewHelperBase):
         ).actions
 
     def test_actions_full_nominated(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         expected = [
             'public',
             'reject',
@@ -232,7 +232,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
 
     def test_actions_full_update(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         expected = [
             'public',
             'reject',
@@ -253,7 +253,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
 
     def test_actions_full_nonpending(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         expected = [
             'reject_multiple_versions',
             'set_needs_human_review_multiple_versions',
@@ -273,7 +273,7 @@ class TestReviewHelper(TestReviewHelperBase):
             )
 
     def test_actions_public_post_review(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         expected = [
             'reject_multiple_versions',
             'set_needs_human_review_multiple_versions',
@@ -337,7 +337,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @override_switch('enable-content-rejection', active=False)
     def test_actions_content_review(self):
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         expected = [
             'approve_listing_content',
             'reject_multiple_versions',
@@ -359,7 +359,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @override_switch('enable-content-rejection', active=True)
     def test_actions_content_review_use_content_rejection(self):
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         expected = [
             'approve_listing_content',
             'reject_listing_content',
@@ -382,7 +382,7 @@ class TestReviewHelper(TestReviewHelperBase):
     def test_actions_content_review_non_approved_addon(self):
         # Content reviewers can also see add-ons before they are approved for
         # the first time.
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         expected = [
             'approve_listing_content',
             'reject_multiple_versions',
@@ -404,7 +404,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @override_switch('enable-content-rejection', active=True)
     def test_actions_content_review_rejected(self):
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         expected = [
             'approve_rejected_listing_content',
             'reject_listing_content',
@@ -432,7 +432,7 @@ class TestReviewHelper(TestReviewHelperBase):
         # Having Addons:Review and dealing with a public add-on would
         # normally be enough to give you access to reject multiple versions
         # action, but it should not be available if you're not theme reviewer.
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.addon.update(type=amo.ADDON_STATICTHEME)
         expected = []
         assert (
@@ -447,7 +447,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
         # Themes reviewers get access to everything, including reject multiple.
         self.user.groupuser_set.all().delete()
-        self.grant_permission(self.user, 'Addons:ThemeReview')
+        self.grant_permission(self.user, amo.permissions.STATIC_THEMES_REVIEW)
         expected = [
             'public',
             'reject',
@@ -489,7 +489,7 @@ class TestReviewHelper(TestReviewHelperBase):
         # Just regular review permissions don't let you do much on an unlisted
         # review page.
         self.review_version.update(channel=amo.CHANNEL_UNLISTED)
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         expected = ['reply', 'comment']
         assert (
             list(
@@ -501,7 +501,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
 
         # Once you have ReviewUnlisted more actions are available.
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         expected = [
             'public',
             'approve_multiple_versions',
@@ -536,7 +536,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
 
         # with admin permission you should be able to unreject and disable too
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         expected = [
             'public',
             'approve_multiple_versions',
@@ -563,7 +563,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
 
     def test_actions_version_blocked(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         # default case
         expected = [
             'public',
@@ -632,7 +632,7 @@ class TestReviewHelper(TestReviewHelperBase):
     def test_actions_pending_rejection(self):
         # An addon having its latest version pending rejection won't be
         # reviewable by regular reviewers...
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
@@ -675,8 +675,8 @@ class TestReviewHelper(TestReviewHelperBase):
     def test_actions_pending_rejection_admin(self):
         # Admins can still do everything when there is a version pending
         # rejection.
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
@@ -736,7 +736,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
 
     def test_actions_disabled_addon(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         expected = ['reply', 'request_legal_review', 'comment']
         actions = list(
             self.get_review_actions(
@@ -750,7 +750,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
         assert expected == actions
 
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         expected = [
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
@@ -768,7 +768,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert expected == actions
 
     def test_actions_rejected_version(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         expected = [
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -782,7 +782,7 @@ class TestReviewHelper(TestReviewHelperBase):
         actions = list(self.get_helper().actions.keys())
         assert expected == actions
 
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         expected = [
             'unreject_latest_version',
             'change_or_clear_pending_rejection_multiple_versions',
@@ -814,7 +814,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert expected == actions
 
     def test_actions_deleted_addon(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         expected = [
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -831,7 +831,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     def test_actions_versions_needing_human_review(self):
         NeedsHumanReview.objects.create(version=self.review_version)
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         expected = [
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -846,7 +846,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
         assert expected == actions
 
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         expected = [
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
@@ -865,7 +865,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert expected == actions
 
     def test_actions_cinder_jobs_to_resolve(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         job = CinderJob.objects.create(
             target_addon=self.addon, resolvable_in_reviewer_tools=True
         )
@@ -905,9 +905,9 @@ class TestReviewHelper(TestReviewHelperBase):
         assert expected == actions
 
     def test_actions_enforcement_actions(self):
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Reviews:Admin')
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         CinderJob.objects.create(
             target_addon=self.addon, resolvable_in_reviewer_tools=True
         )
@@ -966,8 +966,8 @@ class TestReviewHelper(TestReviewHelperBase):
         )
 
     def test_actions_auto_approval_disabled(self):
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         expected = [
             'reject_multiple_versions',
             'change_or_clear_pending_rejection_multiple_versions',
@@ -992,9 +992,9 @@ class TestReviewHelper(TestReviewHelperBase):
         self.review_version.reload()
 
     def test_actions_auto_approval_disabled_unlisted(self):
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.make_addon_unlisted(self.addon)
         self.review_version.reload()
 
@@ -1055,8 +1055,8 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @override_switch('enable-policy-review-selection', active=True)
     def test_actions_with_enable_policy_review_selection(self):
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         expected = [
             'review_with_policy_approve',
             'review_with_policy',
@@ -1105,7 +1105,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @patch('olympia.reviewers.utils.report_decision_to_cinder_and_notify.delay')
     def test_record_decision_sets_policies_with_enforcement_actions(self, report_mock):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         cinder_job = CinderJob.objects.create(
             target_addon=self.addon, resolvable_in_reviewer_tools=True
         )
@@ -1135,7 +1135,7 @@ class TestReviewHelper(TestReviewHelperBase):
         report_mock.assert_called_once()
 
     def test_record_decision_saves_placeholder_values_for_policies(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.helper = self.get_helper()
         data = {
             'cinder_policies': [
@@ -1170,7 +1170,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @patch('olympia.reviewers.utils.report_decision_to_cinder_and_notify.delay')
     def test_record_decision_sets_policies_with_closed_no_action(self, report_mock):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         cinder_job = CinderJob.objects.create(
             target_addon=self.addon, resolvable_in_reviewer_tools=True
         )
@@ -1204,7 +1204,7 @@ class TestReviewHelper(TestReviewHelperBase):
     @override_switch('enable-policy-review-selection', active=True)
     @patch('olympia.reviewers.utils.report_decision_to_cinder_and_notify.delay')
     def test_record_decision_most_negative_enforcement_actions(self, report_mock):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         cinder_job = CinderJob.objects.create(
             target_addon=self.addon, resolvable_in_reviewer_tools=True
         )
@@ -1340,7 +1340,7 @@ class TestReviewHelper(TestReviewHelperBase):
         cinder_job1 = CinderJob.objects.create(job_id='1')
         cinder_job2 = CinderJob.objects.create(job_id='2')
 
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         self.helper.handler.data['cinder_jobs_to_resolve'] = [cinder_job1, cinder_job2]
         self.helper.handler.disable_addon()
@@ -1375,7 +1375,7 @@ class TestReviewHelper(TestReviewHelperBase):
         cinder_job1 = CinderJob.objects.create(job_id='1')
         cinder_job2 = CinderJob.objects.create(job_id='2')
 
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         version_factory(addon=self.addon)
         extra_version = version_factory(addon=self.addon)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
@@ -2011,7 +2011,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.review_version.human_review_date
 
     def test_public_addon_confirm_auto_approval(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         summary = AutoApprovalSummary.objects.create(
             version=self.review_version, verdict=amo.AUTO_APPROVED, weight=151
         )
@@ -2048,7 +2048,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.review_version.reload().human_review_date
 
     def test_public_with_unreviewed_version_addon_confirm_auto_approval(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         self.current_version = self.review_version
         summary = AutoApprovalSummary.objects.create(
@@ -2087,7 +2087,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert activity.details['human_review'] is True
 
     def test_public_with_disabled_version_addon_confirm_auto_approval(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         self.current_version = self.review_version
         summary = AutoApprovalSummary.objects.create(
@@ -2123,8 +2123,8 @@ class TestReviewHelper(TestReviewHelperBase):
         assert activity.details['comments'] == ''
 
     def test_addon_with_versions_pending_rejection_confirm_auto_approval(self):
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         self.review_version = version_factory(
             addon=self.addon, version='3.0', file_kw={'status': amo.STATUS_APPROVED}
@@ -2180,7 +2180,7 @@ class TestReviewHelper(TestReviewHelperBase):
         ).exists()
 
     def test_confirm_auto_approved_approves_for_promoted(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         self.make_addon_promoted(
             addon=self.addon, api_name='notable', listed_pre_review=True
@@ -2224,8 +2224,8 @@ class TestReviewHelper(TestReviewHelperBase):
         assert not previous_version.due_date
 
     def test_deleted_addon_confirm_auto_approval(self):
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         self.review_version = self.addon.current_version
         self.addon.delete()
@@ -2247,8 +2247,8 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.check_log_count(amo.LOG.CONFIRM_AUTO_APPROVED.id) == 1
 
     def test_disabled_by_user_addon_confirm_auto_approval(self):
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         self.review_version = self.addon.current_version
         self.addon.update(disabled_by_user=True)
@@ -2270,8 +2270,8 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.check_log_count(amo.LOG.CONFIRM_AUTO_APPROVED.id) == 1
 
     def test_current_version_not_auto_approved_confirm_auto_approval_not_present(self):
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         self.review_version = version_factory(
             # Prevent new version from becoming the current_version...
@@ -2288,7 +2288,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert 'confirm_auto_approved' not in self.helper.actions
 
     def test_unlisted_version_addon_confirm_multiple_versions(self):
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
 
         # This add-on will have 4 versions:
@@ -2369,8 +2369,8 @@ class TestReviewHelper(TestReviewHelperBase):
         ]
 
     def test_unlisted_manual_approval_clear_pending_rejection(self):
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(
             amo.STATUS_NULL, channel=amo.CHANNEL_UNLISTED, human_review=True
         )
@@ -2828,7 +2828,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.file.status == amo.STATUS_DISABLED
 
     def test_reject_multiple_versions_content_review(self):
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         old_version = self.review_version
         self.review_version = version_factory(addon=self.addon, version='3.0')
         self.setup_data(
@@ -2870,7 +2870,7 @@ class TestReviewHelper(TestReviewHelperBase):
         }
 
     def test_reject_multiple_versions_content_review_with_delay(self):
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         old_version = self.review_version
         self.review_version = version_factory(addon=self.addon, version='3.0')
         self.setup_data(
@@ -3313,7 +3313,7 @@ class TestReviewHelper(TestReviewHelperBase):
         self._test_reject_multiple_versions_delayed_with_human(content_review=True)
 
     def test_approve_listing_content_review(self):
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         self.setup_data(
             amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED, content_review=True
         )
@@ -3360,7 +3360,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert len(mail.outbox) == 0  # No email on approve.
 
     def test_approve_rejected_listing_content_review(self):
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         approvals_counter = AddonApprovalsCounter.objects.create(
             addon=self.addon,
             content_review_status=AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.REQUESTED,
@@ -3414,7 +3414,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @override_switch('enable-content-rejection', active=True)
     def test_reject_listing_content_review(self):
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         self.setup_data(
             amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED, content_review=True
         )
@@ -3756,8 +3756,8 @@ class TestReviewHelper(TestReviewHelperBase):
         assert not unselected.due_date
 
     def test_clear_pending_rejection_multiple_versions(self):
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         VersionReviewerFlags.objects.create(
             version=self.review_version,
@@ -3824,8 +3824,8 @@ class TestReviewHelper(TestReviewHelperBase):
         assert unselected.reviewerflags.pending_rejection is not None
 
     def test_change_pending_rejection_multiple_versions(self):
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         old_pending_rejection_date = datetime.now() + timedelta(days=1)
         VersionReviewerFlags.objects.create(
@@ -3911,7 +3911,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert unselected.reviewerflags.pending_rejection != in_the_future
 
     def test_disable_addon(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         other_version = version_factory(addon=self.addon)
         version_factory(addon=self.addon, file_kw={'status': amo.STATUS_DISABLED})
@@ -3944,7 +3944,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @override_switch('enable-policy-review-selection', active=True)
     def test_review_with_policy_with_disable_addon(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         data = {
             'action': 'review_with_policy',
@@ -3977,7 +3977,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @override_switch('enable-policy-review-selection', active=True)
     def test_review_with_policy_with_version_approval(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.setup_data(amo.STATUS_NOMINATED, file_status=amo.STATUS_AWAITING_REVIEW)
         assert not ContentDecision.objects.exists()
         data = {
@@ -4024,7 +4024,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @override_switch('enable-policy-review-selection', active=True)
     def test_review_with_policy_with_version_approval_overriding_rejection(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.file.update(
             status=amo.STATUS_DISABLED,
             original_status=amo.STATUS_AWAITING_REVIEW,
@@ -4091,7 +4091,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert 'approved' in message.body
 
     def test_enable_addon(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_NULL, file_status=amo.STATUS_APPROVED)
         other_version = version_factory(addon=self.addon)
         version_factory(addon=self.addon, file_kw={'status': amo.STATUS_DISABLED})
@@ -4127,7 +4127,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert 'approved' in message.body
 
     def test_enable_addon_no_public_versions_should_fall_back_to_incomplete(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_DISABLED, file_status=amo.STATUS_APPROVED)
         self.addon.versions.all().delete()
 
@@ -4138,7 +4138,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert len(mail.outbox) == 1
 
     def test_enable_addon_version_is_awaiting_review_fall_back_to_nominated(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.setup_data(amo.STATUS_DISABLED, file_status=amo.STATUS_AWAITING_REVIEW)
 
         self.helper.handler.enable_addon()
@@ -4221,8 +4221,8 @@ class TestReviewHelper(TestReviewHelperBase):
                 transaction.savepoint_rollback(sid)
 
     def test_record_decision_called_everywhere_checkbox_shown_listed(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         AutoApprovalSummary.objects.create(
             version=self.review_version, verdict=amo.AUTO_APPROVED, weight=42
         )
@@ -4310,9 +4310,9 @@ class TestReviewHelper(TestReviewHelperBase):
         )
 
     def test_record_decision_called_everywhere_checkbox_shown_unlisted(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         AutoApprovalSummary.objects.create(
             version=self.review_version, verdict=amo.AUTO_APPROVED, weight=42
         )
@@ -4436,7 +4436,7 @@ class TestReviewHelper(TestReviewHelperBase):
             callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
         )
 
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.file.update(status=amo.STATUS_AWAITING_REVIEW)
         self.helper = self.get_helper()
         data = {
@@ -4508,7 +4508,7 @@ class TestReviewHelper(TestReviewHelperBase):
             callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
         )
 
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.file.update(status=amo.STATUS_AWAITING_REVIEW)
         self.helper = self.get_helper()
         data = {
@@ -4569,7 +4569,7 @@ class TestReviewHelper(TestReviewHelperBase):
             enforcement_actions=[DECISION_ACTIONS.AMO_APPROVE.api_value],
         )
 
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.helper = self.get_helper()
         data = {
             'comments': 'Nope',

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -122,7 +122,7 @@ class TestRatingsModerationLog(ReviewerTest):
     def setUp(self):
         super().setUp()
         user = user_factory()
-        self.grant_permission(user, 'Ratings:Moderate')
+        self.grant_permission(user, amo.permissions.RATINGS_MODERATE)
         self.client.force_login(user)
         self.url = reverse('reviewers.ratings_moderation_log')
         core.set_user(user)
@@ -235,7 +235,7 @@ class TestReviewLog(ReviewerTest):
         assert not doc('tbody tr :not(.hide)')
 
         # But they should have 2 showing for someone with the right perms.
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         with self.assertNumQueries(14):
             # 14 queries:
             # - 2 savepoints because of tests
@@ -468,7 +468,7 @@ class TestReviewLog(ReviewerTest):
     def test_approval_multiple_versions(self):
         addon = Addon.objects.get(pk=3615)
         self.make_addon_unlisted(addon)
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         version_factory(addon=addon, channel=amo.CHANNEL_UNLISTED, version='3.0')
         ActivityLog.objects.create(
             amo.LOG.CONFIRM_AUTO_APPROVED,
@@ -596,23 +596,29 @@ class TestReviewLog(ReviewerTest):
             assert not doc('tbody tr :not(.hide)')
 
         self.make_approvals()
-        for perm in ['Review', 'ContentReview']:
+        for perm in [
+            amo.permissions.ADDONS_REVIEW,
+            amo.permissions.ADDONS_CONTENT_REVIEW,
+        ]:
             GroupUser.objects.filter(user=self.user).delete()
-            self.grant_permission(self.user, 'Addons:%s' % perm)
+            self.grant_permission(self.user, perm)
             # Should have 2 showing.
             check_two_showing()
 
         # Should have none showing if the addons are static themes.
         for addon in Addon.objects.all():
             addon.update(type=amo.ADDON_STATICTHEME)
-        for perm in ['Review', 'ContentReview']:
+        for perm in [
+            amo.permissions.ADDONS_REVIEW,
+            amo.permissions.ADDONS_CONTENT_REVIEW,
+        ]:
             GroupUser.objects.filter(user=self.user).delete()
-            self.grant_permission(self.user, 'Addons:%s' % perm)
+            self.grant_permission(self.user, perm)
             check_none_showing()
 
         # But they should have 2 showing for someone with the right perms.
         GroupUser.objects.filter(user=self.user).delete()
-        self.grant_permission(self.user, 'Addons:ThemeReview')
+        self.grant_permission(self.user, amo.permissions.STATIC_THEMES_REVIEW)
         check_two_showing()
 
         # Check if we set them back to extensions theme reviewers can't see 'em
@@ -779,7 +785,7 @@ class TestDashboard(TestCase):
         )
 
     def test_can_see_all_through_reviewer_view_all_permission(self):
-        self.grant_permission(self.user, 'ReviewerTools:View')
+        self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_VIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -850,7 +856,7 @@ class TestDashboard(TestCase):
         )
 
         # Grant user the permission to see only the legacy/post add-ons section
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
 
         # Test.
         response = self.client.get(self.url)
@@ -881,7 +887,7 @@ class TestDashboard(TestCase):
         )
 
         # Grant user the permission to see only the Content Review section.
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
 
         # Test.
         response = self.client.get(self.url)
@@ -911,7 +917,7 @@ class TestDashboard(TestCase):
         rating.ratingflag_set.create()
 
         # Grant user the permission to see only the ratings to review section.
-        self.grant_permission(self.user, 'Ratings:Moderate')
+        self.grant_permission(self.user, amo.permissions.RATINGS_MODERATE)
 
         # Test.
         response = self.client.get(self.url)
@@ -955,7 +961,7 @@ class TestDashboard(TestCase):
         )
 
         # Grant user the permission to see only the legacy add-ons section.
-        self.grant_permission(self.user, 'Addons:ThemeReview')
+        self.grant_permission(self.user, amo.permissions.STATIC_THEMES_REVIEW)
 
         # Test.
         response = self.client.get(self.url)
@@ -974,8 +980,8 @@ class TestDashboard(TestCase):
     def test_legacy_reviewer_and_ratings_moderator(self):
         # Grant user the permission to see both the legacy add-ons and the
         # ratings moderation sections.
-        self.grant_permission(self.user, 'Addons:Review')
-        self.grant_permission(self.user, 'Ratings:Moderate')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.user, amo.permissions.RATINGS_MODERATE)
 
         # Test.
         response = self.client.get(self.url)
@@ -1001,7 +1007,7 @@ class TestDashboard(TestCase):
         assert doc('.dashboard a')[5].attrib['rel'] == 'noopener noreferrer'
 
     def test_view_mobile_site_link_hidden(self):
-        self.grant_permission(self.user, 'ReviewerTools:View')
+        self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_VIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -1018,7 +1024,7 @@ class QueueTest(ReviewerTest):
         self.login_as_reviewer()
         if self.listed is False:
             # Testing unlisted views: needs Addons:ReviewUnlisted perm.
-            self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+            self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.url = reverse('reviewers.queue_extension')
         self.addons = OrderedDict()
         self.expected_addons = []
@@ -1366,7 +1372,7 @@ class TestQueueBasics(QueueTest):
         expected = [reverse('reviewers.queue_extension')]
         assert links == expected
 
-        self.grant_permission(self.user, 'Ratings:Moderate')
+        self.grant_permission(self.user, amo.permissions.RATINGS_MODERATE)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -1377,7 +1383,7 @@ class TestQueueBasics(QueueTest):
         ]
         assert links == expected
 
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -1385,7 +1391,7 @@ class TestQueueBasics(QueueTest):
         expected.append(reverse('reviewers.queue_content_review'))
         assert links == expected
 
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -1393,7 +1399,7 @@ class TestQueueBasics(QueueTest):
         expected.append(reverse('reviewers.queue_pending_rejection'))
         assert links == expected
 
-        self.grant_permission(self.user, 'Addons:HighImpactApprove')
+        self.grant_permission(self.user, amo.permissions.ADDONS_HIGH_IMPACT_APPROVE)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -1405,7 +1411,7 @@ class TestQueueBasics(QueueTest):
     def test_queue_is_never_executing_the_full_query(self):
         """Test that queue() is paginating without accidentally executing the
         full query."""
-        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, amo.permissions.ADDONS_CONTENT_REVIEW)
         request = RequestFactory().get('/')
         request.user = self.user
 
@@ -1590,7 +1596,7 @@ class TestExtensionQueue(QueueTest):
         self._test_results()
 
     def test_webextension_with_auto_approval_delayed_with_triage_permission(self):
-        self.grant_permission(self.user, 'Addons:TriageDelayed')
+        self.grant_permission(self.user, amo.permissions.ADDONS_TRIAGE_DELAYED)
         self.generate_files()
         AddonReviewerFlags.objects.create(
             addon=self.addons['Pending One'],
@@ -1670,7 +1676,7 @@ class TestExtensionQueue(QueueTest):
         self._test_results()
 
         # Even if you have that permission also
-        self.grant_permission(self.user, 'Addons:ThemeReview')
+        self.grant_permission(self.user, amo.permissions.STATIC_THEMES_REVIEW)
         self._test_results()
 
     def test_pending_rejection_filtered_out(self):
@@ -1726,7 +1732,7 @@ class TestExtensionQueue(QueueTest):
 
     def test_long_due_dates_shown_with_permission(self):
         # self.grant_permission(self.user, 'Addons:AllDueDates')
-        self.grant_permission(self.user, '*:*')
+        self.grant_permission(self.user, amo.permissions.SUPERPOWERS)
         self._setup_queue_with_long_due_dates()
         self.expected_addons = [
             self.addons['Nominated Two'],
@@ -1835,7 +1841,7 @@ class TestThemeQueue(QueueTest):
         self.expected_versions = self.get_expected_versions(self.expected_addons)
         self.url = reverse('reviewers.queue_theme')
         GroupUser.objects.filter(user=self.user).delete()
-        self.grant_permission(self.user, 'Addons:ThemeReview')
+        self.grant_permission(self.user, amo.permissions.STATIC_THEMES_REVIEW)
 
     def test_results(self):
         with self.assertNumQueries(15):
@@ -1934,7 +1940,7 @@ class TestThemeQueue(QueueTest):
         self._test_results()
 
         # Even if you have that permission also
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self._test_results()
 
     def test_redirects_old_urls(self):
@@ -1966,7 +1972,7 @@ class TestModeratedQueue(QueueTest):
         assert RatingFlag.objects.filter(flag=RatingFlag.SPAM).count() == 1
         assert Rating.objects.filter(editorreview=True).count() == 1
         self.user.groupuser_set.all().delete()  # Remove all permissions
-        self.grant_permission(self.user, 'Ratings:Moderate')
+        self.grant_permission(self.user, amo.permissions.RATINGS_MODERATE)
 
     def test_results(self):
         response = self.client.get(self.url)
@@ -2165,7 +2171,7 @@ class TestContentReviewQueue(QueueTest):
     def login_with_permission(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
         self.user.groupuser_set.all().delete()  # Remove all permissions
-        self.grant_permission(user, 'Addons:ContentReview')
+        self.grant_permission(user, amo.permissions.ADDONS_CONTENT_REVIEW)
         self.client.force_login(user)
         return user
 
@@ -2464,7 +2470,7 @@ class TestReview(ReviewBase):
         )
         self.addon.update(status=amo.STATUS_NOMINATED, slug='awaiting')
         self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         assert self.client.get(self.url).status_code == 200
 
     def test_review_unlisted_while_a_listed_version_is_awaiting_review_viewer(self):
@@ -2476,7 +2482,9 @@ class TestReview(ReviewBase):
         )
         self.addon.update(status=amo.STATUS_NOMINATED, slug='awaiting')
         self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
-        self.grant_permission(self.reviewer, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            self.reviewer, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         assert self.client.get(self.url).status_code == 200
 
     def test_needs_unlisted_reviewer_for_only_unlisted(self):
@@ -2494,7 +2502,7 @@ class TestReview(ReviewBase):
         assert self.client.post(self.url).status_code == 403
 
         # It works with the right permission.
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         assert self.client.head(self.url).status_code == 200
 
     def test_needs_unlisted_viewer_for_only_unlisted(self):
@@ -2512,7 +2520,9 @@ class TestReview(ReviewBase):
         assert self.client.post(self.url).status_code == 403
 
         # It works with the right permission.
-        self.grant_permission(self.reviewer, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            self.reviewer, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         assert self.client.head(self.url).status_code == 200
 
     def test_dont_need_unlisted_reviewer_for_mixed_channels(self):
@@ -2521,9 +2531,11 @@ class TestReview(ReviewBase):
         assert self.addon.find_latest_version(channel=amo.CHANNEL_UNLISTED)
         assert self.addon.current_version.channel == amo.CHANNEL_LISTED
         assert self.client.head(self.url).status_code == 200
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         assert self.client.head(self.url).status_code == 200
-        self.grant_permission(self.reviewer, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            self.reviewer, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         assert self.client.head(self.url).status_code == 200
 
     def test_need_correct_reviewer_for_promoted_addon(self):
@@ -2545,7 +2557,7 @@ class TestReview(ReviewBase):
                 "This is a Admin Only add-on. You don't have permission to review it."
             )
 
-        self.grant_permission(self.reviewer, 'Reviews:Admin')
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
         response = self.client.get(self.url)
         assert response.status_code == 200
         choices = list(dict(response.context['form'].fields['action'].choices).keys())
@@ -2599,7 +2611,7 @@ class TestReview(ReviewBase):
         assert doc('#id_whiteboard-private')
 
         # Content review.
-        self.grant_permission(self.reviewer, 'Addons:ContentReview')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_CONTENT_REVIEW)
         AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
@@ -2613,7 +2625,7 @@ class TestReview(ReviewBase):
         )
 
         # Unlisted review.
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         version_factory(addon=self.addon, channel=amo.CHANNEL_UNLISTED)
         self.url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.get(self.url)
@@ -2636,7 +2648,7 @@ class TestReview(ReviewBase):
         )
 
     def test_whiteboard_for_static_themes(self):
-        self.grant_permission(self.reviewer, 'Addons:ThemeReview')
+        self.grant_permission(self.reviewer, amo.permissions.STATIC_THEMES_REVIEW)
         self.addon.update(type=amo.ADDON_STATICTHEME)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -3117,7 +3129,7 @@ class TestReview(ReviewBase):
             file_kw={'status': amo.STATUS_APPROVED},
         )
         self.url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.test_item_history(channel=amo.CHANNEL_UNLISTED)
 
     def test_item_history_with_unlisted_review_page_viewer(self):
@@ -3131,7 +3143,9 @@ class TestReview(ReviewBase):
             file_kw={'status': amo.STATUS_APPROVED},
         )
         self.url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
-        self.grant_permission(self.reviewer, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            self.reviewer, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         self.test_item_history(channel=amo.CHANNEL_UNLISTED)
 
     def test_item_history_compat_ordered(self):
@@ -3189,7 +3203,7 @@ class TestReview(ReviewBase):
         self.addon.update_version()
         assert self.addon.versions.filter(channel=amo.CHANNEL_UNLISTED).count() == 1
 
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
 
         unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.get(unlisted_url)
@@ -3703,7 +3717,7 @@ class TestReview(ReviewBase):
         check_links(expected, doc('#actions-addon a'))
 
     def test_extra_actions_subscribe_checked_state(self):
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.login_as_reviewer()
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -4059,7 +4073,9 @@ class TestReview(ReviewBase):
         assert self.client.get(self.url).status_code == 403
 
         # Unlisted viewers can view but not submit reviews.
-        self.grant_permission(self.reviewer, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            self.reviewer, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         assert self.client.get(self.url).status_code == 200
         response = self.client.post(
             self.url, {'action': 'comment', 'comments': 'hello sailor'}
@@ -4067,7 +4083,7 @@ class TestReview(ReviewBase):
         assert response.status_code == 302
 
         # Unlisted reviewers can submit reviews.
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         assert self.client.get(self.url).status_code == 200
         response = self.client.post(
             self.url, {'action': 'comment', 'comments': 'hello sailor'}
@@ -4292,7 +4308,7 @@ class TestReview(ReviewBase):
         assert info.find('a.compare').length == 0
 
     def test_file_info_for_static_themes(self):
-        self.grant_permission(self.reviewer, 'Addons:ThemeReview')
+        self.grant_permission(self.reviewer, amo.permissions.STATIC_THEMES_REVIEW)
         self.addon.update(type=amo.ADDON_STATICTHEME)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -4344,7 +4360,7 @@ class TestReview(ReviewBase):
         assert b'The developer has provided source code.' in response.content
 
         # A reviewer with source code view access should be able to download too
-        self.grant_permission(user, ':'.join(amo.permissions.ADDONS_SOURCE_DOWNLOAD))
+        self.grant_permission(user, amo.permissions.ADDONS_SOURCE_DOWNLOAD)
         self.client.force_login(user)
         response = self.client.get(url, follow=True)
         assert response.status_code == 200
@@ -4385,7 +4401,6 @@ class TestReview(ReviewBase):
             listed_pre_review=True,
             badged=True,
         )
-        self.grant_permission(self.reviewer, 'Addons:RecommendedReview')
         response = self.client.post(
             self.url,
             {
@@ -4421,8 +4436,8 @@ class TestReview(ReviewBase):
             self.addon, api_name='notable', unlisted_pre_review=True
         )
         self.make_addon_unlisted(self.addon)
-        self.grant_permission(self.reviewer, 'Addons:Review')
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.post(
             unlisted_url,
@@ -4446,7 +4461,6 @@ class TestReview(ReviewBase):
     def test_policy_required_for_approve(self, mock_sign_file):
         self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
-        self.grant_permission(self.reviewer, 'Addons:RecommendedReview')
         data = {'action': 'public', 'comments': 'all good'}
         response = self.client.post(self.url, data)
         self.assertFormError(
@@ -4475,7 +4489,7 @@ class TestReview(ReviewBase):
         summary = AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
-        self.grant_permission(self.reviewer, 'Addons:ContentReview')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_CONTENT_REVIEW)
         response = self.client.post(
             content_url,
             {
@@ -4532,7 +4546,7 @@ class TestReview(ReviewBase):
         self.addon.update(status=amo.STATUS_REJECTED)
         GroupUser.objects.filter(user=self.reviewer).all().delete()
         content_url = reverse('reviewers.review', args=['content', self.addon.pk])
-        self.grant_permission(self.reviewer, 'Addons:ContentReview')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_CONTENT_REVIEW)
         response = self.client.post(
             content_url,
             {
@@ -4577,7 +4591,7 @@ class TestReview(ReviewBase):
         summary = AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
-        self.grant_permission(self.reviewer, 'Addons:ContentReview')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_CONTENT_REVIEW)
 
         response = self.client.post(
             content_url,
@@ -4627,7 +4641,7 @@ class TestReview(ReviewBase):
 
     def test_content_review_redirect_if_only_permission(self):
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:ContentReview')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_CONTENT_REVIEW)
         content_url = reverse('reviewers.review', args=['content', self.addon.pk])
         response = self.client.get(self.url)
         assert response.status_code == 302
@@ -4639,8 +4653,8 @@ class TestReview(ReviewBase):
 
     def test_dont_content_review_redirect_if_theme_reviewer_only(self):
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:ThemeReview')
-        self.grant_permission(self.reviewer, 'Addons:ContentReview')
+        self.grant_permission(self.reviewer, amo.permissions.STATIC_THEMES_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_CONTENT_REVIEW)
         self.addon.update(type=amo.ADDON_STATICTHEME)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -4651,7 +4665,7 @@ class TestReview(ReviewBase):
         AddonReviewerFlags.objects.create(
             addon=self.addon, needs_admin_theme_review=True
         )
-        self.grant_permission(self.reviewer, 'Addons:ThemeReview')
+        self.grant_permission(self.reviewer, amo.permissions.STATIC_THEMES_REVIEW)
         for action in ['public', 'reject']:
             response = self.client.post(self.url, self.get_dict(action=action))
             assert response.status_code == 200  # Form error.
@@ -4685,8 +4699,8 @@ class TestReview(ReviewBase):
         AddonReviewerFlags.objects.create(
             addon=self.addon, needs_admin_theme_review=True
         )
-        self.grant_permission(self.reviewer, 'Addons:ThemeReview')
-        self.grant_permission(self.reviewer, 'Reviews:Admin')
+        self.grant_permission(self.reviewer, amo.permissions.STATIC_THEMES_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
         response = self.client.post(
             self.url, {'action': 'public', 'comments': 'it`s good'}
         )
@@ -4699,7 +4713,7 @@ class TestReview(ReviewBase):
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         response = self.client.post(
             self.url,
             {
@@ -4743,8 +4757,8 @@ class TestReview(ReviewBase):
             file_kw={'status': amo.STATUS_AWAITING_REVIEW},
         )
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
 
         response = self.client.post(
             self.url,
@@ -4782,8 +4796,8 @@ class TestReview(ReviewBase):
             file_kw={'status': amo.STATUS_AWAITING_REVIEW},
         )
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
 
         data = {
             'action': 'approve_multiple_versions',
@@ -4841,7 +4855,7 @@ class TestReview(ReviewBase):
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
 
         response = self.client.post(
             self.url,
@@ -4882,7 +4896,7 @@ class TestReview(ReviewBase):
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
 
         response = self.client.post(
             self.url,
@@ -4928,7 +4942,8 @@ class TestReview(ReviewBase):
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review,Reviews:Admin')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
 
         in_the_future = datetime.now() + timedelta(
             days=REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT, hours=1
@@ -4982,7 +4997,7 @@ class TestReview(ReviewBase):
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
 
         response = self.client.post(
             self.url,
@@ -5030,7 +5045,7 @@ class TestReview(ReviewBase):
         )
         self.version = version_factory(addon=self.addon, version='3.0')
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
 
         response = self.client.post(
             self.url,
@@ -5057,7 +5072,8 @@ class TestReview(ReviewBase):
         assert doc('#id_policy_values_1').attr.value == 'stuff!'
 
     def test_change_pending_rejection_date(self):
-        self.grant_permission(self.reviewer, 'Addons:Review,Reviews:Admin')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
         old_version = self.version
         in_the_future = datetime.now() + timedelta(hours=1)
         in_the_future2 = datetime.now() + timedelta(days=2, hours=1)
@@ -5104,8 +5120,8 @@ class TestReview(ReviewBase):
             file_kw={'status': amo.STATUS_DISABLED},
         )
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
-        self.grant_permission(self.reviewer, 'Reviews:Admin')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
         assert self.addon.status == amo.STATUS_APPROVED
 
         response = self.client.post(self.url, {'action': 'unreject_latest_version'})
@@ -5125,8 +5141,8 @@ class TestReview(ReviewBase):
             file_kw={'status': amo.STATUS_DISABLED},
         )
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
-        self.grant_permission(self.reviewer, 'Reviews:Admin')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
         assert self.addon.status == amo.STATUS_NULL
 
         response = self.client.post(self.url, {'action': 'unreject_latest_version'})
@@ -5144,9 +5160,9 @@ class TestReview(ReviewBase):
         )
         self.make_addon_unlisted(self.addon)
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
-        self.grant_permission(self.reviewer, 'Reviews:Admin')
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         assert self.addon.status == amo.STATUS_NULL
 
         unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
@@ -5170,9 +5186,9 @@ class TestReview(ReviewBase):
         NeedsHumanReview.objects.create(version=old_version)
         self.version = version_factory(addon=self.addon, version='3.0')
         self.make_addon_unlisted(self.addon)
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
-        self.grant_permission(self.reviewer, 'Reviews:Admin')
-        self.grant_permission(self.reviewer, 'Blocklist:Create')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
+        self.grant_permission(self.reviewer, amo.permissions.BLOCKLIST_CREATE)
 
         response = self.client.post(
             self.url,
@@ -5198,7 +5214,7 @@ class TestReview(ReviewBase):
         NeedsHumanReview.objects.create(version=self.version)
 
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
 
         response = self.client.post(
             self.url,
@@ -5213,7 +5229,7 @@ class TestReview(ReviewBase):
         assert self.version.needshumanreview_set.filter(is_active=True).exists()
         assert old_version.needshumanreview_set.filter(is_active=True).exists()
 
-        self.grant_permission(self.reviewer, 'Reviews:Admin')
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
         response = self.client.post(
             self.url,
             {
@@ -5624,7 +5640,7 @@ class TestReview(ReviewBase):
         AutoApprovalSummary.objects.create(
             version=self.version, verdict=amo.AUTO_APPROVED
         )
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -5646,7 +5662,7 @@ class TestReview(ReviewBase):
         assert doc('.listing-content-status td').text() == 'Unreviewed'
 
     def test_no_auto_approval_summaries_since_everything_is_public(self):
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -5734,14 +5750,14 @@ class TestReview(ReviewBase):
 
     def test_abuse_reports_unlisted_addon(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
-        self.grant_permission(user, 'Addons:ReviewUnlisted')
+        self.grant_permission(user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.login_as_reviewer()
         self.make_addon_unlisted(self.addon)
         self.test_abuse_reports()
 
     def test_abuse_reports_unlisted_addon_viewer(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
-        self.grant_permission(user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         self.login_as_reviewer()
         self.make_addon_unlisted(self.addon)
         self.test_abuse_reports()
@@ -5775,14 +5791,14 @@ class TestReview(ReviewBase):
 
     def test_abuse_reports_developers_unlisted_addon(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
-        self.grant_permission(user, 'Addons:ReviewUnlisted')
+        self.grant_permission(user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.login_as_reviewer()
         self.make_addon_unlisted(self.addon)
         self.test_abuse_reports_developers()
 
     def test_abuse_reports_developers_unlisted_addon_viewer(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
-        self.grant_permission(user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         self.login_as_reviewer()
         self.make_addon_unlisted(self.addon)
         self.test_abuse_reports_developers()
@@ -5835,7 +5851,7 @@ class TestReview(ReviewBase):
             user=user,
         )
 
-        self.grant_permission(self.reviewer, 'Ratings:Moderate')
+        self.grant_permission(self.reviewer, amo.permissions.RATINGS_MODERATE)
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -5855,14 +5871,14 @@ class TestReview(ReviewBase):
 
     def test_user_ratings_unlisted_addon(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
-        self.grant_permission(user, 'Addons:ReviewUnlisted')
+        self.grant_permission(user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.login_as_reviewer()
         self.make_addon_unlisted(self.addon)
         self.test_user_ratings()
 
     def test_user_ratings_unlisted_addon_viewer(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
-        self.grant_permission(user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         self.login_as_reviewer()
         self.make_addon_unlisted(self.addon)
         self.test_user_ratings()
@@ -5871,7 +5887,7 @@ class TestReview(ReviewBase):
         AutoApprovalSummary.objects.create(
             verdict=amo.AUTO_APPROVED, version=self.version
         )
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -5925,7 +5941,8 @@ class TestReview(ReviewBase):
         AutoApprovalSummary.objects.create(
             verdict=amo.AUTO_APPROVED, version=self.version
         )
-        self.grant_permission(self.reviewer, 'Addons:Review,Reviews:Admin')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -5989,7 +6006,7 @@ class TestReview(ReviewBase):
         AutoApprovalSummary.objects.create(
             verdict=amo.AUTO_APPROVED, version=self.version
         )
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.get(unlisted_url)
 
@@ -6048,7 +6065,9 @@ class TestReview(ReviewBase):
             verdict=amo.AUTO_APPROVED, version=self.version
         )
         unlisted_viewer = user_factory(email='unlisted_viewer@mozilla.com')
-        self.grant_permission(unlisted_viewer, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(
+            unlisted_viewer, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW
+        )
         self.client.logout()
         self.client.force_login(unlisted_viewer)
         unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
@@ -6104,7 +6123,7 @@ class TestReview(ReviewBase):
     def test_data_value_attributes_static_theme(self):
         self.addon.update(type=amo.ADDON_STATICTHEME)
         self.file.update(status=amo.STATUS_AWAITING_REVIEW)
-        self.grant_permission(self.reviewer, 'Addons:ThemeReview')
+        self.grant_permission(self.reviewer, amo.permissions.STATIC_THEMES_REVIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -6148,7 +6167,7 @@ class TestReview(ReviewBase):
             verdict=amo.AUTO_APPROVED, version=self.version
         )
         version_factory(addon=self.addon, file_kw={'status': amo.STATUS_DISABLED})
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
         expected_actions = [
@@ -6168,7 +6187,7 @@ class TestReview(ReviewBase):
             verdict=amo.AUTO_APPROVED, version=self.version
         )
         version_factory(addon=self.addon, file_kw={'status': amo.STATUS_DISABLED})
-        self.grant_permission(self.reviewer, 'Addons:ContentReview')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_CONTENT_REVIEW)
         self.url = reverse('reviewers.review', args=['content', self.addon.pk])
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -6184,7 +6203,7 @@ class TestReview(ReviewBase):
 
     def test_static_theme_backgrounds(self):
         self.addon.update(type=amo.ADDON_STATICTHEME)
-        self.grant_permission(self.reviewer, 'Addons:ThemeReview')
+        self.grant_permission(self.reviewer, amo.permissions.STATIC_THEMES_REVIEW)
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -6390,7 +6409,7 @@ class TestReview(ReviewBase):
         self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
         self.version = version_factory(addon=self.addon, version='3.0')
         self.make_addon_unlisted(self.addon)
-        self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
 
         response = self.client.post(
             self.url,
@@ -6537,7 +6556,7 @@ class TestReview(ReviewBase):
     def test_abuse_reports_resolved_as_disable_addon_with_disable_action(
         self, mock_resolve_task
     ):
-        self.grant_permission(self.reviewer, 'Reviews:Admin')
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
         policy = CinderPolicy.objects.create(
             uuid='1',
             name='policy 1',
@@ -6589,7 +6608,7 @@ class TestReview(ReviewBase):
         self.version = version_factory(
             addon=self.addon, file_kw={'status': amo.STATUS_AWAITING_REVIEW}
         )
-        self.grant_permission(self.reviewer, 'Reviews:Admin')
+        self.grant_permission(self.reviewer, amo.permissions.REVIEWS_ADMIN)
         cinder_job = CinderJob.objects.create(
             job_id='123', target_addon=self.addon, resolvable_in_reviewer_tools=True
         )
@@ -6769,7 +6788,7 @@ class TestReview(ReviewBase):
             json={'uuid': uuid.uuid4().hex},
             status=201,
         )
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         policy = CinderPolicy.objects.create(
             uuid='1',
             name='policy 1',
@@ -6799,7 +6818,7 @@ class TestReview(ReviewBase):
             json={'uuid': uuid.uuid4().hex},
             status=201,
         )
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         policy = CinderPolicy.objects.create(
             uuid='1',
             name='policy 1',
@@ -6841,7 +6860,7 @@ class TestReview(ReviewBase):
             json={'uuid': uuid.uuid4().hex},
             status=201,
         )
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         policy = CinderPolicy.objects.create(
             uuid='1',
             name='policy 1',
@@ -6881,7 +6900,7 @@ class TestReview(ReviewBase):
             json={'uuid': uuid.uuid4().hex},
             status=201,
         )
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         policy = CinderPolicy.objects.create(
             uuid='1',
             name='policy 1',
@@ -6916,7 +6935,7 @@ class TestReview(ReviewBase):
             json={'uuid': uuid.uuid4().hex},
             status=201,
         )
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         policy = CinderPolicy.objects.create(
             uuid='1',
             name='policy 1',
@@ -7101,7 +7120,7 @@ class TestReviewPending(ReviewBase):
             verdict=amo.NOT_AUTO_APPROVED,
             is_locked=True,
         )
-        self.grant_permission(self.reviewer, 'Addons:Review')
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -7235,7 +7254,7 @@ class TestWhiteboard(ReviewBase):
         public_whiteboard_info = 'New content for public'
         private_whiteboard_info = 'New content for private'
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
-        self.grant_permission(user, 'Addons:ContentReview')
+        self.grant_permission(user, amo.permissions.ADDONS_CONTENT_REVIEW)
         response = self.client.post(
             url,
             {
@@ -7295,7 +7314,7 @@ class TestWhiteboard(ReviewBase):
 
         # Everything works once you have permission.
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
-        self.grant_permission(user, 'Addons:ReviewUnlisted')
+        self.grant_permission(user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         response = self.client.post(
             url,
             {
@@ -7411,7 +7430,7 @@ class TestPolicyView(ReviewerTest):
         assert response.status_code == 403
 
         user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.grant_permission(user, 'Addons:ReviewUnlisted')
+        self.grant_permission(user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.client.force_login(user)
         response = self.client.get(self.eula_url + '?channel=unlisted')
         assert response.status_code == 200
@@ -7449,7 +7468,7 @@ class TestPolicyView(ReviewerTest):
         assert response.status_code == 403
 
         user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.grant_permission(user, 'Addons:ReviewUnlisted')
+        self.grant_permission(user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.client.force_login(user)
         response = self.client.get(self.privacy_url + '?channel=unlisted')
         assert response.status_code == 200
@@ -7666,7 +7685,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 403
 
     def test_subscribe_addon_does_not_exist(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         self.subscribe_url_listed = reverse_ns(
             'reviewers-addon-subscribe-listed', kwargs={'pk': self.addon.pk + 42}
@@ -7684,7 +7703,7 @@ class TestAddonReviewerViewSet(TestCase):
         ReviewerSubscription.objects.create(
             user=self.user, addon=self.addon, channel=amo.CHANNEL_LISTED
         )
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         response = self.client.post(self.subscribe_url_listed)
         assert response.status_code == 202
@@ -7694,7 +7713,7 @@ class TestAddonReviewerViewSet(TestCase):
         ReviewerSubscription.objects.create(
             user=self.user, addon=self.addon, channel=amo.CHANNEL_UNLISTED
         )
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.client.login_api(self.user)
         response = self.client.post(self.subscribe_url_unlisted)
         assert response.status_code == 202
@@ -7704,14 +7723,14 @@ class TestAddonReviewerViewSet(TestCase):
         ReviewerSubscription.objects.create(
             user=self.user, addon=self.addon, channel=amo.CHANNEL_UNLISTED
         )
-        self.grant_permission(self.user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         self.client.login_api(self.user)
         response = self.client.post(self.subscribe_url_unlisted)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 1
 
     def test_subscribe(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         subscribe_url = reverse_ns(
             'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk}
@@ -7721,21 +7740,21 @@ class TestAddonReviewerViewSet(TestCase):
         assert ReviewerSubscription.objects.count() == 1
 
     def test_subscribe_listed(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         response = self.client.post(self.subscribe_url_listed)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 1
 
     def test_subscribe_unlisted(self):
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.client.login_api(self.user)
         response = self.client.post(self.subscribe_url_unlisted)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 1
 
     def test_subscribe_unlisted_viewer(self):
-        self.grant_permission(self.user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         self.client.login_api(self.user)
         response = self.client.post(self.subscribe_url_unlisted)
         assert response.status_code == 202
@@ -7755,7 +7774,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 403
 
     def test_unsubscribe_addon_does_not_exist(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         self.subscribe_url_listed = reverse_ns(
             'reviewers-addon-subscribe-listed', kwargs={'pk': self.addon.pk + 42}
@@ -7770,13 +7789,13 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 404
 
     def test_unsubscribe_not_subscribed(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         response = self.client.post(self.unsubscribe_url_listed)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 0
 
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.client.login_api(self.user)
         response = self.client.post(self.unsubscribe_url_unlisted)
         assert response.status_code == 202
@@ -7786,7 +7805,7 @@ class TestAddonReviewerViewSet(TestCase):
         ReviewerSubscription.objects.create(
             user=self.user, addon=self.addon, channel=amo.CHANNEL_LISTED
         )
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         unsubscribe_url = reverse_ns(
             'reviewers-addon-unsubscribe', kwargs={'pk': self.addon.pk}
@@ -7799,7 +7818,7 @@ class TestAddonReviewerViewSet(TestCase):
         ReviewerSubscription.objects.create(
             user=self.user, addon=self.addon, channel=amo.CHANNEL_LISTED
         )
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         response = self.client.post(self.unsubscribe_url_listed)
         assert response.status_code == 202
@@ -7809,7 +7828,7 @@ class TestAddonReviewerViewSet(TestCase):
         ReviewerSubscription.objects.create(
             user=self.user, addon=self.addon, channel=amo.CHANNEL_UNLISTED
         )
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.client.login_api(self.user)
         response = self.client.post(self.unsubscribe_url_unlisted)
         assert response.status_code == 202
@@ -7819,7 +7838,7 @@ class TestAddonReviewerViewSet(TestCase):
         ReviewerSubscription.objects.create(
             user=self.user, addon=self.addon, channel=amo.CHANNEL_UNLISTED
         )
-        self.grant_permission(self.user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         self.client.login_api(self.user)
         response = self.client.post(self.unsubscribe_url_unlisted)
         assert response.status_code == 202
@@ -7837,7 +7856,7 @@ class TestAddonReviewerViewSet(TestCase):
         ReviewerSubscription.objects.create(
             user=another_user, addon=self.addon, channel=amo.CHANNEL_LISTED
         )
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         response = self.client.post(self.unsubscribe_url_listed)
         assert response.status_code == 202
@@ -7856,12 +7875,12 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 403
 
         # Being a reviewer is not enough.
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         response = self.client.patch(self.flags_url, {'auto_approval_disabled': True})
         assert response.status_code == 403
 
     def test_patch_flags_addon_does_not_exist(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.client.login_api(self.user)
         self.flags_url = reverse_ns(
             'reviewers-addon-flags', kwargs={'pk': self.addon.pk + 42}
@@ -7875,7 +7894,7 @@ class TestAddonReviewerViewSet(TestCase):
 
     def test_patch_flags_only_save_changed(self):
         instance = AddonReviewerFlags.objects.create(addon=self.addon)
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.client.login_api(self.user)
         with mock.patch(
             'olympia.reviewers.views.AddonReviewerFlags.objects.get_or_create',
@@ -7901,7 +7920,7 @@ class TestAddonReviewerViewSet(TestCase):
 
     def test_patch_flags_no_flags_yet_still_works_transparently(self):
         assert not AddonReviewerFlags.objects.filter(addon=self.addon).exists()
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.client.login_api(self.user)
         response = self.client.patch(self.flags_url, {'auto_approval_disabled': True})
         assert response.status_code == 200
@@ -7918,7 +7937,7 @@ class TestAddonReviewerViewSet(TestCase):
             auto_approval_delayed_until=self.days_ago(42),
             auto_approval_delayed_until_unlisted=self.days_ago(0),
         )
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.client.login_api(self.user)
         data = {
             'auto_approval_disabled': False,
@@ -7942,7 +7961,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert reviewer_flags.auto_approval_delayed_until_unlisted is None
 
     def test_deny_resubmission(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.client.login_api(self.user)
         assert DeniedGuid.objects.count() == 0
         response = self.client.post(self.deny_resubmission_url)
@@ -7950,7 +7969,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert DeniedGuid.objects.count() == 1
 
     def test_deny_resubmission_with_denied_guid(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.client.login_api(self.user)
         self.addon.deny_resubmission()
         assert DeniedGuid.objects.count() == 1
@@ -7959,7 +7978,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert DeniedGuid.objects.count() == 1
 
     def test_allow_resubmission(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.client.login_api(self.user)
         self.addon.deny_resubmission()
         assert DeniedGuid.objects.count() == 1
@@ -7968,7 +7987,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert DeniedGuid.objects.count() == 0
 
     def test_allow_resubmission_with_non_denied_guid(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.client.login_api(self.user)
         response = self.client.post(self.allow_resubmission_url)
         assert response.status_code == 409
@@ -7976,7 +7995,7 @@ class TestAddonReviewerViewSet(TestCase):
 
     def test_due_date(self):
         user_factory(pk=settings.TASK_USER_ID)
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.client.login_api(self.user)
         version = self.addon.current_version
         NeedsHumanReview.objects.create(version=version)
@@ -7994,7 +8013,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.assertCloseToNow(version.due_date, now=new_due_date)
 
     def test_set_needs_human_review(self):
-        self.grant_permission(self.user, 'Reviews:Admin')
+        self.grant_permission(self.user, amo.permissions.REVIEWS_ADMIN)
         self.client.login_api(self.user)
         version = self.addon.current_version
         assert not version.needshumanreview_set.exists()
@@ -8036,25 +8055,25 @@ class TestAddonReviewerViewSetJsonValidation(TestCase):
         )
 
     def test_reviewer_can_see_json_results(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         assert self.client.get(self.url).status_code == 200
 
     def test_deleted_addon(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
 
         self.addon.delete()
         assert self.client.get(self.url).status_code == 200
 
     def test_unlisted_reviewer_can_see_results_for_unlisted(self):
-        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.client.login_api(self.user)
         self.make_addon_unlisted(self.addon)
         assert self.client.get(self.url).status_code == 200
 
     def test_unlisted_viewer_can_see_results_for_unlisted(self):
-        self.grant_permission(self.user, 'ReviewerTools:ViewUnlisted')
+        self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         self.client.login_api(self.user)
         self.make_addon_unlisted(self.addon)
         assert self.client.get(self.url).status_code == 200
@@ -8068,7 +8087,7 @@ class TestAddonReviewerViewSetJsonValidation(TestCase):
 
     @mock.patch.object(acl, 'is_reviewer', lambda user, addon: False)
     def test_wrong_type_of_reviewer_cannot_see_json_results(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         assert self.client.get(self.url).status_code in [
             401,
@@ -8076,7 +8095,7 @@ class TestAddonReviewerViewSetJsonValidation(TestCase):
         ]  # JWT auth is a 401; web auth is 403
 
     def test_non_unlisted_reviewer_cannot_see_results_for_unlisted(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.client.login_api(self.user)
         self.make_addon_unlisted(self.addon)
         assert self.client.get(self.url).status_code in [
@@ -8219,7 +8238,7 @@ class TestReviewVersionRedirect(ReviewerTest):
     def login_as_reviewer(self):
         self.grant_permission(
             UserProfile.objects.get(email='reviewer@mozilla.com'),
-            'Addons:ReviewUnlisted',
+            amo.permissions.ADDONS_REVIEW_UNLISTED,
         )
         return super().login_as_reviewer()
 
@@ -8330,7 +8349,7 @@ class TestHeldDecisionQueue(ReviewerTest):
 
     def test_results(self):
         user = user_factory()
-        self.grant_permission(user, 'Addons:HighImpactApprove')
+        self.grant_permission(user, amo.permissions.ADDONS_HIGH_IMPACT_APPROVE)
         self.client.force_login(user)
 
         response = self.client.get(self.url)
@@ -8380,7 +8399,7 @@ class TestHeldDecisionQueue(ReviewerTest):
 
     def test_reviewer_viewer_can_access(self):
         user = user_factory()
-        self.grant_permission(user, 'ReviewerTools:View')
+        self.grant_permission(user, amo.permissions.REVIEWER_TOOLS_VIEW)
         self.client.force_login(user)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -8416,7 +8435,7 @@ class TestHeldDecisionReview(ReviewerTest):
         )
         self.url = reverse('reviewers.decision_review', args=(self.decision.id,))
         self.user = user_factory()
-        self.grant_permission(self.user, 'Addons:HighImpactApprove')
+        self.grant_permission(self.user, amo.permissions.ADDONS_HIGH_IMPACT_APPROVE)
         self.client.force_login(self.user)
 
     def _test_review_page_addon(self):
@@ -8592,7 +8611,7 @@ class TestHeldDecisionReview(ReviewerTest):
 
     def test_reviewer_viewer_can_access(self):
         user = user_factory()
-        self.grant_permission(user, 'ReviewerTools:View')
+        self.grant_permission(user, amo.permissions.REVIEWER_TOOLS_VIEW)
         self.client.force_login(user)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -8600,7 +8619,7 @@ class TestHeldDecisionReview(ReviewerTest):
 
     def test_reviewer_viewer_cannot_submit(self):
         user = user_factory()
-        self.grant_permission(user, 'ReviewerTools:View')
+        self.grant_permission(user, amo.permissions.REVIEWER_TOOLS_VIEW)
         self.client.force_login(user)
         response = self.client.post(self.url, {'choice': 'yes'})
 

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -69,8 +69,8 @@ class TestScannerResultAdmin(TestCase):
         super().setUp()
 
         self.user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(self.user, 'Admin:ScannersResultsEdit')
-        self.grant_permission(self.user, 'Admin:ScannersResultsView')
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_RESULTS_EDIT)
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_RESULTS_VIEW)
         self.client.force_login(self.user)
         self.list_url = reverse('admin:scanners_scannerresult_changelist')
 
@@ -97,19 +97,19 @@ class TestScannerResultAdmin(TestCase):
         request.user = user_factory()
         assert list(scanner_result_admin.get_actions(request).keys()) == []
 
-        self.grant_permission(request.user, 'Users:Edit')
+        self.grant_permission(request.user, amo.permissions.USERS_EDIT)
         assert list(scanner_result_admin.get_actions(request).keys()) == [
             'search_for_authors_action',
         ]
 
-        self.grant_permission(request.user, 'Blocklist:Create')
+        self.grant_permission(request.user, amo.permissions.BLOCKLIST_CREATE)
         assert list(scanner_result_admin.get_actions(request).keys()) == [
             'block_addons_action',
             'search_for_authors_action',
         ]
 
     def test_block_addons_action(self):
-        self.grant_permission(self.user, 'Blocklist:Create')
+        self.grant_permission(self.user, amo.permissions.BLOCKLIST_CREATE)
         rule = ScannerRule.objects.create(name='my_rule', scanner=WEBHOOK)
         addon1 = addon_factory()
         version_factory(addon=addon1)
@@ -131,7 +131,7 @@ class TestScannerResultAdmin(TestCase):
         assert response['location'] == submission_url + query_string
 
     def test_search_for_authors_action(self):
-        self.grant_permission(self.user, 'Users:Edit')
+        self.grant_permission(self.user, amo.permissions.USERS_EDIT)
         rule = ScannerRule.objects.create(name='my_rule', scanner=WEBHOOK)
         user1_1 = user_factory()
         user1_2 = user_factory()
@@ -159,7 +159,7 @@ class TestScannerResultAdmin(TestCase):
 
     def test_list_view_is_restricted(self):
         user = user_factory(email='curator@mozilla.com')
-        self.grant_permission(user, 'Admin:Curation')
+        self.grant_permission(user, amo.permissions.ADMIN_CURATION)
         self.client.force_login(user)
         response = self.client.get(self.list_url)
         assert response.status_code == 403
@@ -823,7 +823,7 @@ class TestScannerRuleAdmin(TestCase):
         super().setUp()
 
         self.user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(self.user, 'Admin:*')
+        self.grant_permission(self.user, amo.permissions.AclPermission('Admin', '*'))
         self.client.force_login(self.user)
         self.list_url = reverse('admin:scanners_scannerrule_changelist')
         self.admin = ScannerRuleAdmin(model=ScannerRule, admin_site=AdminSite())
@@ -835,7 +835,7 @@ class TestScannerRuleAdmin(TestCase):
 
     def test_list_view_is_restricted(self):
         user = user_factory(email='curator@mozilla.com')
-        self.grant_permission(user, 'Admin:Curation')
+        self.grant_permission(user, amo.permissions.ADMIN_CURATION)
         self.client.force_login(user)
         response = self.client.get(self.list_url)
         assert response.status_code == 403
@@ -895,7 +895,7 @@ class TestScannerRuleAdmin(TestCase):
 
     def test_get_fields_for_non_admins(self):
         user = user_factory(email='somebodyelse@mozilla.com')
-        self.grant_permission(user, 'Admin:ScannersRulesView')
+        self.grant_permission(user, amo.permissions.ADMIN_SCANNERS_RULES_VIEW)
         request = RequestFactory().get('/')
         request.user = user
         assert 'definition' not in self.admin.get_fields(request=request)
@@ -954,7 +954,7 @@ class TestScannerQueryRuleAdmin(TestCase):
         super().setUp()
 
         self.user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(self.user, 'Admin:ScannersQueryEdit')
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_QUERY_EDIT)
         self.client.force_login(self.user)
         self.list_url = reverse('admin:scanners_scannerqueryrule_changelist')
 
@@ -973,7 +973,7 @@ class TestScannerQueryRuleAdmin(TestCase):
 
     def test_list_view_viewer(self):
         self.user.groupuser_set.all().delete()
-        self.grant_permission(self.user, 'Admin:ScannersQueryView')
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)
         ScannerQueryRule.objects.create(name='bar', scanner=YARA)
         response = self.client.get(self.list_url)
         assert response.status_code == 200
@@ -989,7 +989,7 @@ class TestScannerQueryRuleAdmin(TestCase):
 
     def test_list_view_is_restricted(self):
         user = user_factory(email='curator@mozilla.com')
-        self.grant_permission(user, 'Admin:Curation')
+        self.grant_permission(user, amo.permissions.ADMIN_CURATION)
         self.client.force_login(user)
         response = self.client.get(self.list_url)
         assert response.status_code == 403
@@ -1034,7 +1034,7 @@ class TestScannerQueryRuleAdmin(TestCase):
 
     def test_change_view_viewer(self):
         self.user.groupuser_set.all().delete()
-        self.grant_permission(self.user, 'Admin:ScannersQueryView')
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)
         rule = ScannerQueryRule.objects.create(name='bar', scanner=YARA)
         url = reverse('admin:scanners_scannerqueryrule_change', args=(rule.pk,))
         response = self.client.get(url)
@@ -1202,7 +1202,7 @@ class TestScannerQueryRuleAdmin(TestCase):
 
     def test_run_actions_no_permission(self):
         user = user_factory(email='somebodyelse@mozilla.com')
-        self.grant_permission(user, 'Admin:ScannersQueryView')
+        self.grant_permission(user, amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)
         self.client.force_login(user)
         rule = ScannerQueryRule.objects.create(name='bar', scanner=YARA, state=NEW)
         response = self.client.post(
@@ -1253,7 +1253,7 @@ class TestScannerQueryRuleAdmin(TestCase):
 
     def test_abort_action_no_permission(self):
         user = user_factory(email='somebodyelse@mozilla.com')
-        self.grant_permission(user, 'Admin:ScannersQueryView')
+        self.grant_permission(user, amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)
         self.client.force_login(user)
         rule = ScannerQueryRule.objects.create(name='bar', scanner=YARA, state=RUNNING)
         response = self.client.post(
@@ -1322,7 +1322,7 @@ class TestScannerQueryRuleAdmin(TestCase):
         response = self.client.post(url, {'post': 'yes'})
         assert response.status_code == 403
 
-        self.grant_permission(user, 'Admin:ScannersQueryView')
+        self.grant_permission(user, amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)
         response = self.client.get(url)
         assert response.status_code == 403
         response = self.client.post(url, {'post': 'yes'})
@@ -1334,7 +1334,7 @@ class TestScannerQueryResultAdmin(TestCase):
         super().setUp()
 
         self.user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(self.user, 'Admin:ScannersQueryEdit')
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_QUERY_EDIT)
         self.client.force_login(self.user)
         self.list_url = reverse('admin:scanners_scannerqueryresult_changelist')
 
@@ -1431,19 +1431,19 @@ class TestScannerQueryResultAdmin(TestCase):
         request.user = user_factory()
         assert list(scanner_query_result_admin.get_actions(request).keys()) == []
 
-        self.grant_permission(request.user, 'Users:Edit')
+        self.grant_permission(request.user, amo.permissions.USERS_EDIT)
         assert list(scanner_query_result_admin.get_actions(request).keys()) == [
             'search_for_authors_action',
         ]
 
-        self.grant_permission(request.user, 'Blocklist:Create')
+        self.grant_permission(request.user, amo.permissions.BLOCKLIST_CREATE)
         assert list(scanner_query_result_admin.get_actions(request).keys()) == [
             'block_addons_action',
             'search_for_authors_action',
         ]
 
     def test_block_addons_action(self):
-        self.grant_permission(self.user, 'Blocklist:Create')
+        self.grant_permission(self.user, amo.permissions.BLOCKLIST_CREATE)
         addon1 = addon_factory()
         version_factory(addon=addon1)
         addon2 = addon_factory()
@@ -1464,7 +1464,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response['location'] == submission_url + query_string
 
     def test_search_for_authors_action(self):
-        self.grant_permission(self.user, 'Users:Edit')
+        self.grant_permission(self.user, amo.permissions.USERS_EDIT)
         user1_1 = user_factory()
         user1_2 = user_factory()
         addon1 = addon_factory(users=[user1_1, user1_2])
@@ -1537,14 +1537,14 @@ class TestScannerQueryResultAdmin(TestCase):
         self.user = user_factory(email='somebodyelse@mozilla.com')
         # Give the user permission to edit ScannersResults, but not
         # ScannerQueryResults.
-        self.grant_permission(self.user, 'Admin:ScannersResultsEdit')
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_RESULTS_EDIT)
         self.client.force_login(self.user)
         response = self.client.get(self.list_url)
         assert response.status_code == 403
 
     def test_list_view_query_view_permission(self):
         self.user = user_factory(email='somebodyelse@mozilla.com')
-        self.grant_permission(self.user, 'Admin:ScannersQueryView')
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)
         self.client.force_login(self.user)
         self.test_list_view()
 
@@ -2087,7 +2087,7 @@ class TestScannerQueryResultAdmin(TestCase):
         self.user = user_factory(email='somebodyelse@mozilla.com')
         # Give the user permission to edit ScannersResults, but not
         # ScannerQueryResults.
-        self.grant_permission(self.user, 'Admin:ScannersResultsEdit')
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_RESULTS_EDIT)
         self.client.force_login(self.user)
         result = self.scanner_query_result_factory(
             version=addon_factory().current_version
@@ -2098,7 +2098,7 @@ class TestScannerQueryResultAdmin(TestCase):
 
     def test_change_view_query_view_permission(self):
         self.user = user_factory(email='somebodyelse@mozilla.com')
-        self.grant_permission(self.user, 'Admin:ScannersQueryView')
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_QUERY_VIEW)
         self.client.force_login(self.user)
         self.test_change_page()
 
@@ -2212,8 +2212,8 @@ class TestScannerWebhookAdmin(TestCase):
         super().setUp()
 
         self.user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(self.user, 'Admin:ScannersWebhooksView')
-        self.grant_permission(self.user, 'Admin:ScannersWebhooksEdit')
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_WEBHOOKS_VIEW)
+        self.grant_permission(self.user, amo.permissions.ADMIN_SCANNERS_WEBHOOKS_EDIT)
         self.client.force_login(self.user)
         self.add_url = reverse('admin:scanners_scannerwebhook_add')
         self.list_url = reverse('admin:scanners_scannerwebhook_changelist')

--- a/src/olympia/scanners/tests/test_views.py
+++ b/src/olympia/scanners/tests/test_views.py
@@ -210,8 +210,8 @@ class TestPushScannerResult(APIKeyAuthTestMixin, TestCase):
         self.api_key = APIKey.get_jwt_key(user=self.webhook.service_account)
         self.grant_permission(
             self.webhook.service_account,
-            'Scanners:PushResults',
-            'some access group',
+            amo.permissions.SCANNERS_PUSH_RESULTS,
+            name='some access group',
         )
 
         self.version = version_factory(addon=addon_factory())
@@ -374,8 +374,8 @@ class TestPushScannerResult(APIKeyAuthTestMixin, TestCase):
         self.api_key = APIKey.get_jwt_key(user=other_webhook.service_account)
         self.grant_permission(
             other_webhook.service_account,
-            'Scanners:PushResults',
-            'some access group',
+            amo.permissions.SCANNERS_PUSH_RESULTS,
+            name='some access group',
         )
 
         second = self._push_scanner_result(
@@ -433,10 +433,14 @@ class TestScannerQueryRuleViewSet(APIKeyAuthTestMixin, TestCase):
         super().setUp()
         self.create_api_user()
         self.grant_permission(
-            self.user, 'Admin:ScannersQueryEdit', 'Scanner query editors'
+            self.user,
+            amo.permissions.ADMIN_SCANNERS_QUERY_EDIT,
+            name='Scanner query editors',
         )
         self.grant_permission(
-            self.user, 'Admin:ScannersQueryView', 'Scanner query viewers'
+            self.user,
+            amo.permissions.ADMIN_SCANNERS_QUERY_VIEW,
+            name='Scanner query viewers',
         )
         self.list_url = reverse_ns('scanner-query-rule-list', api_version='v5')
 
@@ -469,7 +473,9 @@ class TestScannerQueryRuleViewSet(APIKeyAuthTestMixin, TestCase):
         self.user.groupuser_set.all().delete()
         # Read-only permission, no write access
         self.grant_permission(
-            self.user, 'Admin:ScannersQueryView', 'Scanner query viewers'
+            self.user,
+            amo.permissions.ADMIN_SCANNERS_QUERY_VIEW,
+            name='Scanner query viewers',
         )
         detail_url = self._detail_url(rule)
         payload = {'scanner': 'yara', 'definition': VALID_YARA_DEFINITION}
@@ -617,7 +623,9 @@ class TestScannerQueryResultViewSet(APIKeyAuthTestMixin, TestCase):
         super().setUp()
         self.create_api_user()
         self.grant_permission(
-            self.user, 'Admin:ScannersQueryView', 'Scanner query viewers'
+            self.user,
+            amo.permissions.ADMIN_SCANNERS_QUERY_VIEW,
+            name='Scanner query viewers',
         )
         self.rule = ScannerQueryRule.objects.create(
             name='some_rule', scanner=YARA, definition=VALID_YARA_DEFINITION

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -322,7 +322,7 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         )
 
     def test_version_added_is_experiment(self):
-        self.grant_permission(self.user, 'Experiments:submit')
+        self.grant_permission(self.user, amo.permissions.EXPERIMENTS_SUBMIT)
         guid = '@experiment-inside-webextension-guid'
         qs = Addon.unfiltered.filter(guid=guid)
         assert not qs.exists()
@@ -362,7 +362,7 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
 
     def test_mozilla_signed_allowed(self):
         guid = '@webextension-guid'
-        self.grant_permission(self.user, 'SystemAddon:Submit')
+        self.grant_permission(self.user, amo.permissions.SYSTEM_ADDON_SUBMIT)
         qs = Addon.unfiltered.filter(guid=guid)
         assert not qs.exists()
         response = self.request(
@@ -398,7 +398,7 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
 
     def test_restricted_guid_addon_allowed(self):
         guid = 'systemaddon@mozilla.org'
-        self.grant_permission(self.user, 'SystemAddon:Submit')
+        self.grant_permission(self.user, amo.permissions.SYSTEM_ADDON_SUBMIT)
         qs = Addon.unfiltered.filter(guid=guid)
         assert not qs.exists()
         response = self.request(
@@ -942,9 +942,7 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         self._test_throttling_verb_user_daily('PUT', url, expected_status=202)
 
     def test_throttling_ignored_for_special_users(self):
-        self.grant_permission(
-            self.user, ':'.join(amo.permissions.API_BYPASS_THROTTLING)
-        )
+        self.grant_permission(self.user, amo.permissions.API_BYPASS_THROTTLING)
         url = self.url(self.guid, '3.0')
         with time_machine.travel('2019-04-08 15:16:23.42', tick=False):
             for _x in range(0, 60):

--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -1160,7 +1160,7 @@ class TestStatsWithBigQuery(TestCase):
         url = reverse('stats.overview', args=[self.addon.id])
         # Login as privileged user to be able to access the stats for a deleted add-on.
         self.client.logout()
-        self.grant_permission(self.user, '*:*')
+        self.grant_permission(self.user, amo.permissions.SUPERPOWERS)
         self.client.force_login(self.user)
 
         response = self.client.get(url)

--- a/src/olympia/tags/tests/test_admin.py
+++ b/src/olympia/tags/tests/test_admin.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 
+from olympia import amo
 from olympia.amo.tests import TestCase, user_factory
 
 from ..models import Tag
@@ -12,7 +13,7 @@ class TestTagAdmin(TestCase):
     def test_can_list_with_discovery_edit_permission(self):
         item = Tag.objects.all().first()
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
@@ -23,7 +24,7 @@ class TestTagAdmin(TestCase):
         tag_count = Tag.objects.count()
         self.detail_url = reverse('admin:tags_tag_change', args=(item.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -48,7 +49,7 @@ class TestTagAdmin(TestCase):
         item = Tag.objects.all().first()
         self.delete_url = reverse('admin:tags_tag_delete', args=(item.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         # Can access delete confirmation page.
         response = self.client.get(self.delete_url, follow=True)
@@ -64,7 +65,7 @@ class TestTagAdmin(TestCase):
         tag_count = Tag.objects.count()
         self.add_url = reverse('admin:tags_tag_add')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Discovery:Edit')
+        self.grant_permission(user, amo.permissions.DISCOVERY_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.add_url, follow=True)
         assert response.status_code == 200

--- a/src/olympia/users/tests/test_admin.py
+++ b/src/olympia/users/tests/test_admin.py
@@ -53,7 +53,7 @@ class TestUserAdmin(TestCase):
 
     def test_list(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         banned_date = self.days_ago(1)
         banned_user = user_factory(banned=banned_date)
@@ -70,8 +70,8 @@ class TestUserAdmin(TestCase):
 
     def test_list_has_bulk_ban_link(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
-        self.grant_permission(user, 'Users:Ban')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
+        self.grant_permission(user, amo.permissions.USERS_BAN)
         self.client.force_login(user)
         response = self.client.get(self.list_url)
         doc = pq(response.content)
@@ -81,7 +81,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_by_email_simple(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         another_user = user_factory()
         response = self.client.get(
@@ -96,7 +96,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_by_id_simple(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         another_user = user_factory()
         response = self.client.get(
@@ -111,7 +111,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_by_email_like(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         another_user = user_factory(email='someone@notzilla.org')
         response = self.client.get(
@@ -127,7 +127,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_by_email_multiple(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         another_user = user_factory()
         response = self.client.get(
@@ -143,7 +143,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_by_email_multiple_like(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         another_user = user_factory(email='someone@notzilla.com')
         response = self.client.get(
@@ -160,7 +160,7 @@ class TestUserAdmin(TestCase):
     def test_search_for_multiple_user_ids(self):
         """Test the optimization when just searching for matching ids."""
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         another_user = user_factory()
         with CaptureQueriesContext(connection) as queries:
@@ -180,7 +180,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_ip_as_int_isnt_considered_an_ip(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         self.user.update(last_login_ip='127.0.0.1')
         response = self.client.get(self.list_url, {'q': '2130706433'}, follow=True)
@@ -191,7 +191,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_for_single_ip(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         with core.override_remote_addr_or_metadata(ip_address='127.0.0.2'):
             self.user.update(email='foo@bar.com')
@@ -216,7 +216,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_for_single_ip_other_ips_are_shown(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         with core.override_remote_addr_or_metadata(ip_address='127.0.0.2'):
             self.user.update(email='foo@bar.com')
@@ -248,7 +248,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_for_single_ip_multiple_results_for_different_reasons(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
 
         # Extra user that will match but not thanks to their last login ip...
@@ -291,7 +291,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_for_multiple_ips(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         with core.override_remote_addr_or_metadata(ip_address='127.0.0.2'):
             ActivityLog.objects.create(amo.LOG.ADD_RATING, user=self.user)
@@ -313,7 +313,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_for_ip_range(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         with core.override_remote_addr_or_metadata(ip_address='127.0.0.2'):
             ActivityLog.objects.create(amo.LOG.ADD_RATING, user=self.user)
@@ -335,7 +335,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_for_ip_network(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         with core.override_remote_addr_or_metadata(ip_address='127.0.0.2'):
             ActivityLog.objects.create(amo.LOG.ADD_RATING, user=self.user)
@@ -357,7 +357,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_for_multiple_ips_with_garbage(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         with core.override_remote_addr_or_metadata(ip_address='127.0.0.2'):
             ActivityLog.objects.create(amo.LOG.ADD_RATING, user=self.user)
@@ -379,7 +379,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_for_multiple_ips_with_deduplication(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         # Will match once with the last_login
         with core.override_remote_addr_or_metadata(ip_address='127.0.0.3'):
@@ -424,7 +424,7 @@ class TestUserAdmin(TestCase):
 
     def test_search_for_ip_network_with_deduplication(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         # Will match once with the last_login
         with core.override_remote_addr_or_metadata(ip_address='127.0.0.3'):
@@ -470,7 +470,7 @@ class TestUserAdmin(TestCase):
     def test_search_for_mixed_strings(self):
         # IP search is deactivated if the search term don't all look like IPs
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         user_factory(last_login_ip='127.0.0.2')
         self.user.update(email='foo@bar.com', last_login_ip='127.0.0.2')
@@ -481,7 +481,7 @@ class TestUserAdmin(TestCase):
 
     def test_can_not_edit_without_users_edit_permission(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 403
@@ -495,7 +495,7 @@ class TestUserAdmin(TestCase):
         old_display_name = 'old-foo'
         self.user.update(display_name=old_display_name)
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         core.set_user(user)
         response = self.client.get(self.detail_url, follow=True)
@@ -519,7 +519,7 @@ class TestUserAdmin(TestCase):
     def test_queries_detail(self):
         user = user_factory(email='someone@mozilla.com')
         # We want to see absolutely everything, so make our user a superadmin.
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         with self.assertNumQueries(25 if self.is_django42 else 23):
             # - 4 savepoint/release
@@ -544,7 +544,7 @@ class TestUserAdmin(TestCase):
     @mock.patch.object(UserProfile, '_delete_related_content')
     def test_can_not_delete(self, _delete_related_content_mock):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         assert not user.deleted
         self.client.force_login(user)
         response = self.client.get(self.delete_url, follow=True)
@@ -563,13 +563,13 @@ class TestUserAdmin(TestCase):
         assert list(user_admin.get_actions(request).keys()) == []
 
         request.user = user_factory()
-        self.grant_permission(request.user, 'Users:Edit')
+        self.grant_permission(request.user, amo.permissions.USERS_EDIT)
         assert list(user_admin.get_actions(request).keys()) == [
             'reset_api_key_action',
             'reset_session_action',
         ]
 
-        self.grant_permission(request.user, 'Users:Ban')
+        self.grant_permission(request.user, amo.permissions.USERS_BAN)
         assert list(user_admin.get_actions(request).keys()) == [
             'ban_action',
             'unban_action',
@@ -636,8 +636,8 @@ class TestUserAdmin(TestCase):
         ban_url = reverse('admin:users_userprofile_ban', args=(self.user.pk,))
         unban_url = reverse('admin:users_userprofile_unban', args=(self.user.pk,))
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
-        self.grant_permission(user, 'Users:Ban')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
+        self.grant_permission(user, amo.permissions.USERS_BAN)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -712,7 +712,7 @@ class TestUserAdmin(TestCase):
             'admin:users_userprofile_reset_api_key', args=(self.user.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -723,7 +723,7 @@ class TestUserAdmin(TestCase):
             'admin:users_userprofile_reset_session', args=(self.user.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -734,7 +734,7 @@ class TestUserAdmin(TestCase):
             'admin:users_userprofile_delete_picture', args=(self.user.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
@@ -754,8 +754,8 @@ class TestUserAdmin(TestCase):
         create_signed_url_for_file_backup_mock.return_value = backup_picture_url
 
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Edit')
-        self.grant_permission(user, 'Admin:Advanced')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
+        self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
         response = self.client.get(self.detail_url, follow=True)
 
@@ -777,10 +777,10 @@ class TestUserAdmin(TestCase):
         core.set_user(user)
         response = self.client.post(ban_url, follow=True)
         assert response.status_code == 403
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         response = self.client.post(ban_url, follow=True)
         assert response.status_code == 403
-        self.grant_permission(user, 'Users:Ban')
+        self.grant_permission(user, amo.permissions.USERS_BAN)
         response = self.client.get(ban_url, follow=True)
         assert response.status_code == 405  # Wrong http method.
         response = self.client.post(wrong_ban_url, follow=True)
@@ -812,7 +812,7 @@ class TestUserAdmin(TestCase):
         target2 = user_factory()
         innocent = user_factory()
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Ban')
+        self.grant_permission(user, amo.permissions.USERS_BAN)
         self.client.force_login(user)
         url = reverse('admin:users_userprofile_bulk_ban')
         response = self.client.get(url)
@@ -853,7 +853,7 @@ class TestUserAdmin(TestCase):
 
     def test_bulk_ban_invalid(self):
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Users:Ban')
+        self.grant_permission(user, amo.permissions.USERS_BAN)
         self.client.force_login(user)
         url = reverse('admin:users_userprofile_bulk_ban')
         data = {'user_ids': 'invalid'}
@@ -876,10 +876,10 @@ class TestUserAdmin(TestCase):
         core.set_user(user)
         response = self.client.post(unban_url, follow=True)
         assert response.status_code == 403
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         response = self.client.post(unban_url, follow=True)
         assert response.status_code == 403
-        self.grant_permission(user, 'Users:Ban')
+        self.grant_permission(user, amo.permissions.USERS_BAN)
         response = self.client.get(unban_url, follow=True)
         assert response.status_code == 405  # Wrong http method.
         response = self.client.post(wrong_unban_url, follow=True)
@@ -915,7 +915,7 @@ class TestUserAdmin(TestCase):
         core.set_user(user)
         response = self.client.post(reset_api_key_url, follow=True)
         assert response.status_code == 403
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         response = self.client.get(reset_api_key_url, follow=True)
         assert response.status_code == 405  # Wrong http method.
         response = self.client.post(wrong_reset_api_key_url, follow=True)
@@ -950,7 +950,7 @@ class TestUserAdmin(TestCase):
         self.client.force_login(user)
         response = self.client.post(reset_session_url, follow=True)
         assert response.status_code == 403
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         response = self.client.get(reset_session_url, follow=True)
         assert response.status_code == 405  # Wrong http method.
         response = self.client.post(wrong_reset_session_url, follow=True)
@@ -981,7 +981,7 @@ class TestUserAdmin(TestCase):
         core.set_user(user)
         response = self.client.post(delete_picture_url, follow=True)
         assert response.status_code == 403
-        self.grant_permission(user, 'Users:Edit')
+        self.grant_permission(user, amo.permissions.USERS_EDIT)
         response = self.client.get(delete_picture_url, follow=True)
         assert response.status_code == 405  # Wrong http method.
         response = self.client.post(wrong_delete_picture_url, follow=True)
@@ -1292,7 +1292,7 @@ class TestUserAdmin(TestCase):
             'admin:users_userprofile_change', args=(lookup_user.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url_by_email, follow=False)
         self.assert3xx(response, detail_url_final, 302)
@@ -1305,7 +1305,7 @@ class TestUserAdmin(TestCase):
         )
         list_url_with_email = self.list_url + '?email=foo@bar.xyz'
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(detail_url_by_email, follow=False)
         self.assert3xx(response, list_url_with_email, 302)
@@ -1333,7 +1333,7 @@ class TestUserAdmin(TestCase):
 class TestEmailUserRestrictionAdmin(TestCase):
     def setUp(self):
         self.user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(self.user, 'Admin:Advanced')
+        self.grant_permission(self.user, amo.permissions.ADMIN_ADVANCED)
 
         self.client.force_login(self.user)
         self.list_url = reverse('admin:users_emailuserrestriction_changelist')
@@ -1347,7 +1347,7 @@ class TestEmailUserRestrictionAdmin(TestCase):
 class TestIPNetworkUserRestrictionAdmin(TestCase):
     def setUp(self):
         self.user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(self.user, 'Admin:Advanced')
+        self.grant_permission(self.user, amo.permissions.ADMIN_ADVANCED)
 
         self.client.force_login(self.user)
         self.list_url = reverse('admin:users_ipnetworkuserrestriction_changelist')
@@ -1361,7 +1361,7 @@ class TestIPNetworkUserRestrictionAdmin(TestCase):
 class TestUserRestrictionHistoryAdmin(TestCase):
     def setUp(self):
         self.user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(self.user, 'Admin:Advanced')
+        self.grant_permission(self.user, amo.permissions.ADMIN_ADVANCED)
 
         self.client.force_login(self.user)
         self.list_url = reverse('admin:users_userrestrictionhistory_changelist')
@@ -1386,7 +1386,7 @@ class TestUserRestrictionHistoryAdmin(TestCase):
 class TestUserHistoryAdmin(TestCase):
     def setUp(self):
         self.user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(self.user, 'Admin:Advanced')
+        self.grant_permission(self.user, amo.permissions.ADMIN_ADVANCED)
 
         self.client.force_login(self.user)
         self.list_url = reverse('admin:users_userhistory_changelist')

--- a/src/olympia/versions/tests/test_admin.py
+++ b/src/olympia/versions/tests/test_admin.py
@@ -20,7 +20,7 @@ class TestVersionAdmin(TestCase):
         )
         self.list_url = reverse('admin:versions_version_changelist')
         self.user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(self.user, 'Admin:Advanced')
+        self.grant_permission(self.user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(self.user)
         user_factory(pk=settings.TASK_USER_ID)
 
@@ -192,7 +192,7 @@ class TestInstallOriginAdmin(TestCase):
         )
         list_url = reverse('admin:versions_installorigin_changelist')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         with self.assertNumQueries(6):
             # - 2 SAVEPOINTs
@@ -235,7 +235,7 @@ class TestInstallOriginAdmin(TestCase):
     def test_add_disabled(self):
         add_url = reverse('admin:versions_installorigin_add')
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 403
@@ -250,7 +250,7 @@ class TestInstallOriginAdmin(TestCase):
             'admin:versions_installorigin_delete', args=(install_origin.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         response = self.client.get(delete_url, follow=True)
         assert response.status_code == 403
@@ -265,7 +265,7 @@ class TestInstallOriginAdmin(TestCase):
             'admin:versions_installorigin_change', args=(install_origin.pk,)
         )
         user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
+        self.grant_permission(user, amo.permissions.SUPERPOWERS)
         self.client.force_login(user)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 200

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -511,7 +511,7 @@ class NonPublicFileDownloadsMixin:
 
     def test_file_download_permission_allowed_with_perm(self):
         user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.grant_permission(user, ':'.join(amo.permissions.ADDONS_FILE_DOWNLOAD))
+        self.grant_permission(user, amo.permissions.ADDONS_FILE_DOWNLOAD)
         self.login(user)
         self.assert_served_successfully(self.client.get(self.file_url), cache=False)
 
@@ -574,7 +574,7 @@ class TestUnlistedFileDownloads(
         self.make_addon_unlisted(self.addon)
         self.grant_permission(
             UserProfile.objects.get(email='reviewer@mozilla.com'),
-            'Addons:ReviewUnlisted',
+            amo.permissions.ADDONS_REVIEW_UNLISTED,
         )
 
 
@@ -908,9 +908,7 @@ class TestDownloadSource(TestCase):
 
     def test_download_for_source_download_permission(self):
         """File downloading is allowed for users with source download permission."""
-        self.grant_permission(
-            self.user, ':'.join(amo.permissions.ADDONS_SOURCE_DOWNLOAD)
-        )
+        self.grant_permission(self.user, amo.permissions.ADDONS_SOURCE_DOWNLOAD)
         self.addon.authors.clear()
         self.login(self.user)
         assert self.client.get(self.url).status_code == 200


### PR DESCRIPTION
Follow-on from mozilla/addons#16318

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Finishes what I started in mozilla/addons#16318 - to use AclPermission constants in `grant_permission` calls.

### Context

I made the changes to `grant_permission`; then Claude did the grunt work of converting all the hundreds of references in tests.  I've read through them and they seem correct - in almost all test cases the tests would fail if the permissions were wrong anyway.

### Testing

n/a - no live code changes.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
