### PR TITLE
Remove Redundant and Breaking Error on Enterprise Upload

### DIFF
--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -414,9 +414,6 @@ class Version(OnChangeMixin, ModelBase):
         if channel == amo.CHANNEL_ENTERPRISE and addon.type != amo.ADDON_EXTENSION:
             raise VersionCreateError('Only extensions can be enterprise add-ons.')
 
-        if channel == amo.CHANNEL_ENTERPRISE and upload.source:
-            raise VersionCreateError('Enterprise versions cannot have source uploads.')
-
         if addon.status == amo.STATUS_DISABLED:
             raise VersionCreateError(
                 'Addon is Mozilla Disabled; no new versions are allowed.'

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1955,20 +1955,6 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
             )
         assert str(e.exception) == 'Only extensions can be enterprise add-ons.'
 
-    @override_switch('enterprise-channel', active=True)
-    def test_enterprise_channel_disallow_source(self):
-        self.upload.source = 'src'
-
-        with self.assertRaises(VersionCreateError) as e:
-            Version.from_upload(
-                self.upload,
-                self.addon,
-                amo.CHANNEL_ENTERPRISE,
-                selected_apps=[self.selected_app],
-                parsed_data=self.dummy_parsed_data,
-            )
-        assert str(e.exception) == 'Enterprise versions cannot have source uploads.'
-
     def test_enterprise_addon_disabled_waffle_switch(self):
         with self.assertRaises(VersionCreateError) as e:
             Version.from_upload(

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1966,6 +1966,18 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
             )
         assert str(e.exception) == 'The enterprise channel is not enabled.'
 
+    @override_switch('enterprise-channel', active=True)
+    def test_enterprise_addon_enabled_waffle_switch(self):
+        version = Version.from_upload(
+            self.upload,
+            self.addon,
+            amo.CHANNEL_ENTERPRISE,
+            selected_apps=[self.selected_app],
+            parsed_data=self.dummy_parsed_data,
+        )
+        assert version
+        assert version.channel == amo.CHANNEL_ENTERPRISE
+
     def test_addon_is_attached_to_upload_if_it_wasnt(self):
         assert self.upload.addon is None
         version = Version.from_upload(


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/16368

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Redundant due to lines 1766, 1798 in `src/olympia/devhub/views.py`. Covered by `src/olympia/devhub/tests/test_views_submit.py#1236`

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
