### PR TITLE
Skip describe version on new version enterprise upload

### DIFF
--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -2924,6 +2924,26 @@ class TestVersionSubmitDetails(TestSubmitBase):
             ),
         )
 
+    def test_submit_details_enterprise_should_redirect(self):
+        # Should be redirecting even with an existing listed channel.
+        assert self.version.channel == amo.CHANNEL_LISTED
+        enterprise_version = version_factory(
+            addon=self.addon,
+            channel=amo.CHANNEL_ENTERPRISE,
+        )
+        url = reverse(
+            'devhub.submit.version.details',
+            args=[self.addon.slug, enterprise_version.pk],
+        )
+        response = self.client.get(url)
+        self.assert3xx(
+            response,
+            reverse(
+                'devhub.submit.version.source',
+                args=[self.addon.slug, enterprise_version.pk],
+            ),
+        )
+
     def test_public_addon_stays_public_even_if_had_missing_metadata(self):
         """Posting details for a new version for a public add-on that somehow
         had missing metadata despite being public shouldn't reset it to

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1853,9 +1853,10 @@ def submit_version_source(request, addon_id, addon, version_id):
 def _submit_details(request, addon, version, next_view):
     static_theme = addon.type == amo.ADDON_STATICTHEME
     if version:
-        skip_details_step = version.channel == amo.CHANNEL_UNLISTED or (
-            static_theme and addon.has_complete_metadata()
-        )
+        skip_details_step = version.channel in (
+            amo.CHANNEL_UNLISTED,
+            amo.CHANNEL_ENTERPRISE,
+        ) or (static_theme and addon.has_complete_metadata())
         if skip_details_step:
             # Nothing to do here.
             return redirect(next_view, addon.slug, version.pk)


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/16391

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Prevents new enterprise versions from seeing the 'describe version' page when a listed version exists already.

### Testing

1. Enable `enterprise-channel` waffle switch.
2. Upload a listed add-on.
3. Upload an enterprise version.
4. The enterprise version should not see the 'describe version' page.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
