### PR TITLE
Prevent Scanner Actions on Enterprise Versions

### DIFF
--- a/src/olympia/reviewers/management/commands/auto_approve.py
+++ b/src/olympia/reviewers/management/commands/auto_approve.py
@@ -155,8 +155,7 @@ class Command(BaseCommand):
                         version.pk,
                     )
                 else:
-                    ScannerResult.run_actions(version)
-                    scanner_actions_executed = True
+                    scanner_actions_executed = ScannerResult.run_actions(version)
 
                 version.autoapprovalsummary, info = (
                     AutoApprovalSummary.create_summary_for_version(

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -584,7 +584,11 @@ class AutoApprovalSummary(ModelBase):
         - Delayed until a future date
 
         Those flags are set by scanners or reviewers for a specific channel.
+        They are ignored for enterprise versions, which should not have their
+        auto-approval disabled or delayed.
         """
+        if version.channel == amo.CHANNEL_ENTERPRISE:
+            return False
         addon = version.addon
         flag_suffix = '_unlisted' if version.channel == amo.CHANNEL_UNLISTED else ''
         auto_approval_disabled = bool(

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -320,8 +320,10 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
         assert not AutoApprovalSummary.objects.exists()
         call_command('auto_approve')
         self.version.reload()
+        self.version.file.reload()
         summary = AutoApprovalSummary.objects.get(version=self.version)
         assert summary.verdict == amo.AUTO_APPROVED
+        assert self.version.file.status == amo.STATUS_APPROVED
         assert not self.version.needshumanreview_set.filter(is_active=True).exists()
 
     @mock.patch('olympia.reviewers.management.commands.auto_approve.statsd.incr')
@@ -885,6 +887,79 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
 
         call_command('auto_approve')  # Shouldn't matter if it's called twice.
         check_assertions()
+
+    @mock.patch('olympia.reviewers.utils.sign_file')
+    def test_run_actions_enterprise(self, sign_file_mock):
+        responses.add_callback(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}v1/create_decision',
+            callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
+        )
+
+        reject_policy = CinderPolicy.objects.create(
+            enforcement_actions=[DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON.api_value],
+            name='Reject Policy',
+            expose_in_reviewer_tools=POLICY_EXPOSURE.BOTH,
+            uuid=uuid.uuid4().hex,
+        )
+
+        self.create_switch('enable-narc', active=True)
+        rule = ScannerRule.objects.create(
+            is_active=True,
+            name='foo',
+            policy=reject_policy,
+            scanner=NARC,
+            definition='.*',
+        )
+
+        listed_version = version_factory(
+            addon=self.addon,
+            channel=amo.CHANNEL_LISTED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW},
+        )
+        enterprise_version = version_factory(
+            addon=self.addon,
+            channel=amo.CHANNEL_ENTERPRISE,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW},
+        )
+        for version in (listed_version, enterprise_version):
+            FileValidation.objects.create(file=version.file, validation='{}')
+            FileManifest.objects.create(
+                file=version.file, manifest_data={'name': 'Foo'}
+            )
+
+        assert not ScannerResult.objects.exists()
+        assert not AddonReviewerFlags.objects.filter(addon=self.addon).exists()
+
+        call_command('auto_approve')
+
+        # Listed version matched a rule, enables flag.
+        listed_version.reload()
+        listed_version.file.reload()
+        listed_result = ScannerResult.objects.get(version=listed_version, scanner=NARC)
+        assert list(listed_result.matched_rules.all()) == [rule]
+        assert listed_version.file.status == amo.STATUS_DISABLED
+        assert listed_version.autoapprovalsummary.verdict == amo.NOT_AUTO_APPROVED
+
+        flags = self.addon.reviewerflags.reload()
+        assert flags.auto_approval_disabled_until_next_approval
+
+        # Enterprise version ignores both rule match and flag.
+        enterprise_version.reload()
+        enterprise_version.file.reload()
+        assert enterprise_version.file.status == amo.STATUS_APPROVED
+        enterprise_summary = AutoApprovalSummary.objects.get(version=enterprise_version)
+        assert enterprise_summary.verdict == amo.AUTO_APPROVED
+        assert enterprise_summary.scanner_actions_executed is False
+
+        # Reviewers can still see the match: only the action was gated.
+        enterprise_result = ScannerResult.objects.get(version=enterprise_version)
+        assert enterprise_result.has_matches
+        assert list(enterprise_result.matched_rules.all()) == [rule]
+
+        # No NHR.
+        assert enterprise_version.due_date is None
+        assert not enterprise_version.needshumanreview_set.exists()
 
     @mock.patch('olympia.reviewers.utils.sign_file')
     def test_run_actions_delay_approval_with_run_narc(self, sign_file_mock):

--- a/src/olympia/reviewers/tests/test_models.py
+++ b/src/olympia/reviewers/tests/test_models.py
@@ -1168,6 +1168,24 @@ class TestAutoApprovalSummary(TestCase):
             AutoApprovalSummary.check_has_auto_approval_disabled(self.version) is False
         )
 
+    def test_check_has_auto_approval_disabled_enterprise(self):
+        # Enterprise versions should be unaffected by scanner flags.
+        assert self.version.channel == amo.CHANNEL_LISTED
+        enterprise_version = version_factory(
+            addon=self.addon, channel=amo.CHANNEL_ENTERPRISE
+        )
+        AddonReviewerFlags.objects.create(
+            addon=self.addon,
+            auto_approval_disabled=True,
+        )
+        assert (
+            AutoApprovalSummary.check_has_auto_approval_disabled(self.version) is True
+        )
+        assert (
+            AutoApprovalSummary.check_has_auto_approval_disabled(enterprise_version)
+            is False
+        )
+
     def test_check_is_promoted_prereview(self):
         assert AutoApprovalSummary.check_is_promoted_prereview(self.version) is False
 

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -420,6 +420,8 @@ class AbstractScannerResultAdminMixin:
                                 'listed'
                                 if obj.version.channel == amo.CHANNEL_LISTED
                                 else 'unlisted'
+                                if obj.version.channel == amo.CHANNEL_UNLISTED
+                                else 'enterprise'
                             ),
                             obj.version.addon.id,
                         ],

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -460,8 +460,15 @@ class ScannerResult(AbstractScannerResult):
 
     @classmethod
     def run_actions(cls, version):
+        if version.channel == amo.CHANNEL_ENTERPRISE:
+            log.info(
+                'Not running actions on version %s as it is an enterprise version',
+                version.pk,
+            )
+            return False
         cls.execute_workflow_action(version)
         cls.execute_policy_enforcement_action(version)
+        return True
 
     @classmethod
     def execute_policy_enforcement_action(cls, version):

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -211,6 +211,25 @@ class TestScannerResultAdmin(TestCase):
         assert f'Version:</td><td>{version.version}' in formatted_addon
         assert f'Channel:</td><td>{version.get_channel_display()}' in formatted_addon
 
+    def test_formatted_enterprise_addon(self):
+        addon = addon_factory()
+        version = version_factory(addon=addon, channel=amo.CHANNEL_ENTERPRISE)
+        result = ScannerResult(version=version)
+
+        formatted_addon = self.admin.formatted_addon(result)
+        assert (
+            '<a href="{}">Link to review page</a>'.format(
+                urljoin(
+                    settings.EXTERNAL_SITE_URL,
+                    reverse('reviewers.review', args=['enterprise', addon.id]),
+                ),
+            )
+            in formatted_addon
+        )
+        assert f'Name:</td><td>{addon.name}' in formatted_addon
+        assert f'Version:</td><td>{version.version}' in formatted_addon
+        assert f'Channel:</td><td>{version.get_channel_display()}' in formatted_addon
+
     def test_formatted_addon_without_version(self):
         result = ScannerResult(version=None)
 


### PR DESCRIPTION
Closes https://github.com/mozilla/addons/issues/16298, Relates to mozilla/addons#14853

### Description

Prevents scanner actions from running on enterprise versions and from blocking said versions from auto-approval.

### Testing

1. Enable `enterprise-channel` and `enable-yara` or `enable-narc` waffle switches.
2. In admin, add a yara or narc scanner rule that would expect to trigger on some subset of versions, including the enterprise version.
3. Submit un/listed and enterprise versions.
4. Run `./manage.py auto_approve`.
5. The un/listed version should trigger the rule's action. The enterprise version should not.
6. Additional enterprise version uploads should not be blocked by any scanner flags.
7. The scannerresults admin page 'Link to review page' redirects back to the review-enterprise page.

<img width="716" height="74" alt="image" src="https://github.com/user-attachments/assets/6a0bed8f-35db-4e5e-b6b0-1820df09966b" />

Enterprise version:
<img width="1199" height="329" alt="image" src="https://github.com/user-attachments/assets/6ea68a1b-766d-47d8-a062-eac32898e816" />
<img width="455" height="322" alt="image" src="https://github.com/user-attachments/assets/703bd278-f8bd-422a-b169-5a514e754e93" />

Unlisted version:
<img width="1195" height="264" alt="image" src="https://github.com/user-attachments/assets/9b1f09b8-06de-4e48-a172-9442edbea500" />


### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
