### PR TITLE
Show radio inputs for non-negative policies

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -361,6 +361,14 @@ class CinderPolicyWidget(forms.CheckboxSelectMultiple):
         attrs['data-enforcement-actions-order'] = hash_addon_negative_actions(
             enforcement_actions
         ).hex()
+        self.input_type = (
+            forms.CheckboxSelectMultiple.input_type
+            if not any(
+                enf not in DECISION_ACTIONS.ADDON_NEGATIVE_SORTED
+                for enf in enforcement_actions.primary
+            )
+            else forms.RadioSelect.input_type
+        )
         return super().create_option(
             name, value, label, selected, index, subindex, attrs
         )

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -1732,6 +1732,7 @@ class TestReviewForm(TestCase):
         assert label_0.attr['data-enforcement-primary-actions'] == '[]'
         assert label_0.attr['data-enforcement-followup-actions'] == '[]'
         assert label_0.attr['data-enforcement-actions-order'] == ''
+        assert label_0('input')[0].type == 'checkbox'
 
         assert label_1.attr['class'] == 'data-toggle'
         assert label_1.attr['data-value'] == 'reject reject_multiple_versions'
@@ -1744,6 +1745,7 @@ class TestReviewForm(TestCase):
             f'{DECISION_ACTIONS.AMO_FU_DELAY_SHORT_HARD_BLOCK_ADDON.value}]'
         )
         assert label_1.attr['data-enforcement-actions-order'] == '090500'
+        assert label_1('input')[0].type == 'checkbox'
 
         assert label_2.attr['class'] == 'data-toggle'
         assert label_2.attr['data-value'] == 'public'
@@ -1753,6 +1755,7 @@ class TestReviewForm(TestCase):
         )
         assert label_2.attr['data-enforcement-followup-actions'] == '[]'
         assert label_2.attr['data-enforcement-actions-order'] == ''
+        assert label_2('input')[0].type == 'radio'
 
     def test_policy_values_fields(self):
         policy_0 = CinderPolicy.objects.create(

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -115,14 +115,18 @@ $(document).ready(function () {
   }
 
   let policySelectionInputs = $('.review-actions-policies-select input[name="cinder_policies"]');
-  policySelectionInputs.change((event) => {
-    let checkbox = event.target;
-    $("#policy-text-" + checkbox.value)[0].hidden = !checkbox.checked;
 
+  function updatePolicyText() {
+    policySelectionInputs.each(function () {
+      $("#policy-text-" + this.value)[0].hidden = !this.checked;
+    });
+  }
+  policySelectionInputs.change(() => {
+    updatePolicyText();
     updatePolicyEnforcementActionsDisplay();
   });
-  policySelectionInputs.trigger("click").trigger("click");
-
+  updatePolicyText();
+  updatePolicyEnforcementActionsDisplay();
 });
 
 function updatePolicyEnforcementActionsDisplay() {


### PR DESCRIPTION
Fixes mozilla/addons#16306

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Displays radio inputs for policies with non-negative enforcement actions, because only one can be selected

<img width="2208" height="590" alt="image" src="https://github.com/user-attachments/assets/e5095973-636c-40a6-97fc-3d72ea7d87e2" />


### Context

Some of the form validation isn't as necessary now - there are cases where we validate that only one type of non-negative enforcement action is chosen, but with a radio selection only one will be chosen - I figured it was safer to leave that existing code in place.

### Testing

- `enable-policy-review-selection` waffle switch on
- some cinder policies enabled for exposure in reviewer tools - both some with negative enforcement actions (disable, etc), and the two approve non-negative policies (approve and approve_version)
- in the reviewer tools see that the policies under Positive Review are radio buttons, but the policies under Negative Review are checkboxes 
  - (if you have any other actions, e.g. appeal related, they should work similarly - it's defined at the policy level)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
