### PR TITLE
Expose more detail about enforcement actions with delays

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -42,7 +42,7 @@ log = olympia.core.logger.getLogger('z.abuse')
 
 
 class ContentAction:
-    description = 'Action has been taken'
+    description = 'Action will be taken'
     valid_targets = ()
     # No reporter emails will be sent while the paths are set to None
     reporter_template_path = None
@@ -350,7 +350,7 @@ class AnyOwnerEmailMixin:
 
 
 class ContentActionBanUser(ContentAction):
-    description = 'Account has been banned'
+    description = 'Account will be banned'
     valid_targets = (UserProfile,)
     reporter_template_path = 'abuse/emails/reporter_takedown_user.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_takedown.txt'
@@ -507,7 +507,7 @@ class ContentActionAddon(ContentAction):
 
 
 class ContentActionDisableAddon(ContentActionAddon):
-    description = 'Add-on has been disabled'
+    description = 'Add-on will be disabled'
     reporter_template_path = 'abuse/emails/reporter_takedown_addon.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_takedown.txt'
     action = DECISION_ACTIONS.AMO_DISABLE_ADDON
@@ -593,7 +593,7 @@ class ContentActionDisableAddon(ContentActionAddon):
 
 
 class ContentActionRejectVersion(ContentActionDisableAddon):
-    description = 'Add-on version(s) have been rejected'
+    description = 'Add-on version(s) will be rejected'
     stakeholder_template_path = 'abuse/emails/stakeholder_notification.txt'
     stakeholder_acl_group_name = 'Stakeholder-Rejection-Notifications'
     action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
@@ -795,7 +795,6 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
 
 
 class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
-    description = 'Add-on version(s) will be rejected'
     reporter_template_path = 'abuse/emails/reporter_takedown_addon_delayed.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_takedown_delayed.txt'
     action = DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON
@@ -817,6 +816,13 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
                 days=self.delayed_rejection_days,
                 hours=1,
             )
+
+    @classproperty
+    def description(cls):
+        return (
+            'Add-on version(s) will be rejected, '
+            f'after {REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT} days'
+        )
 
     def log_action(self, activity_log_action, *extra_args, extra_details=None):
         extra_details = {
@@ -938,7 +944,7 @@ class ContentActionRejectVersionAfterDelay(ContentActionRejectVersion):
 
 
 class ContentActionBlockAddon(ContentActionDisableAddon):
-    description = 'Add-on has been (disabled and) blocked'
+    description = 'Add-on will be (disabled and) blocked'
     block_type = BlockType.SOFT_BLOCKED
     action = DECISION_ACTIONS.AMO_BLOCK_ADDON
 
@@ -1216,7 +1222,7 @@ class ContentActionDelayedLongHardBlockAddon(_ContentActionDelayedBlockAddon):
 
 
 class ContentActionRejectListingContent(ContentActionDisableAddon):
-    description = 'Add-on listing content has been rejected'
+    description = 'Add-on listing content will be rejected'
     action = DECISION_ACTIONS.AMO_REJECT_LISTING_CONTENT
 
     @property
@@ -1270,7 +1276,7 @@ class ContentActionForwardToLegal(ContentActionAddon):
 
 
 class ContentActionChangePendingRejectionDate(ContentActionAddon):
-    description = 'Add-on pending rejection date has changed'
+    description = 'Add-on pending rejection date will change'
     action = DECISION_ACTIONS.AMO_CHANGE_PENDING_REJECTION_DATE
 
     def get_owners(self):
@@ -1279,7 +1285,7 @@ class ContentActionChangePendingRejectionDate(ContentActionAddon):
 
 class ContentActionDeleteCollection(ContentAction):
     valid_targets = (Collection,)
-    description = 'Collection has been deleted'
+    description = 'Collection will be deleted'
     reporter_template_path = 'abuse/emails/reporter_takedown_collection.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_takedown.txt'
     action = DECISION_ACTIONS.AMO_DELETE_COLLECTION
@@ -1315,7 +1321,7 @@ class ContentActionDeleteCollection(ContentAction):
 
 class ContentActionDeleteRating(ContentAction):
     valid_targets = (Rating,)
-    description = 'Rating has been deleted'
+    description = 'Rating will be deleted'
     reporter_template_path = 'abuse/emails/reporter_takedown_rating.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_takedown.txt'
     action = DECISION_ACTIONS.AMO_DELETE_RATING
@@ -1376,7 +1382,9 @@ class ContentActionDeleteRating(ContentAction):
 class ContentActionTargetAppealApprove(
     AnyTargetMixin, AnyOwnerEmailMixin, ContentAction
 ):
-    description = 'Reported content is within policy, after appeal'
+    description = (
+        'Previous decision(s) will be reverted because the appeal was approved'
+    )
 
     @property
     def previous_decisions(self):
@@ -1415,7 +1423,7 @@ class ContentActionTargetAppealApprove(
 class ContentActionApproveListingContent(
     AnyTargetMixin, AnyOwnerEmailMixin, ContentAction
 ):
-    description = 'Reported content is within policy'
+    description = 'Content will be approved, because it is within policy'
     reporter_template_path = 'abuse/emails/reporter_content_approve.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_approve.txt'
     action = DECISION_ACTIONS.AMO_APPROVE
@@ -1451,9 +1459,7 @@ class ContentActionApproveListingContent(
 
 
 class ContentActionApproveVersion(ContentActionAddon):
-    description = (
-        'Reported content is within policy, initial decision, approving versions'
-    )
+    description = 'Add-on version(s) will be approved, because it is within policy'
     reporter_template_path = 'abuse/emails/reporter_content_approve.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_approve.txt'
     action = DECISION_ACTIONS.AMO_APPROVE_VERSION
@@ -1641,7 +1647,10 @@ class ContentActionApproveVersion(ContentActionAddon):
 class ContentActionTargetAppealRemovalAffirmation(
     AnyTargetMixin, AnyOwnerEmailMixin, ContentAction
 ):
-    description = 'Reported content is still offending, after appeal.'
+    description = (
+        'Previous decisions are unchanged despite appeal, because content is still '
+        'offending'
+    )
 
     def process_action(self, release_hold=False):
         previous_decision_actions = (
@@ -1658,21 +1667,23 @@ class ContentActionTargetAppealRemovalAffirmation(
 
 
 class ContentActionIgnore(AnyTargetMixin, NoActionMixin, ContentAction):
-    description = 'Report is invalid, so no action'
+    description = 'No action will be taken, as Report is invalid'
     reporter_template_path = 'abuse/emails/reporter_invalid_ignore.txt'
     # no appeal template because no appeals possible
     action = DECISION_ACTIONS.AMO_IGNORE
 
 
 class ContentActionAlreadyModerated(AnyTargetMixin, NoActionMixin, ContentAction):
-    description = 'Content is already moderated, disabled or deleted, so no action'
+    description = (
+        'No action will be taken, as content is already moderated, disabled or deleted'
+    )
     reporter_template_path = 'abuse/emails/reporter_moderated_ignore.txt'
     # no appeal template because no appeals possible
     action = DECISION_ACTIONS.AMO_CLOSED_NO_ACTION
 
 
 class ContentActionLegalTakedownDisableAddon(ContentActionDisableAddon):
-    description = 'Add-on has been disabled, due to legal action'
+    description = 'Add-on will be disabled, due to legal action'
     legal_takedown_template_path = 'abuse/emails/legal_takedown_notification.txt'
     legal_takedown_group_name = 'Legal-Takedown-Notifications'
     action = DECISION_ACTIONS.AMO_LEGAL_DISABLE_ADDON

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -2094,6 +2094,14 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
             fragment='information on its availability',
         )
 
+    def test_description(self):
+        assert ContentActionRejectVersion.description == (
+            'Add-on version(s) will be rejected'
+        )
+        assert ContentActionRejectVersionDelayed.description == (
+            'Add-on version(s) will be rejected, after 30 days'
+        )
+
 
 class TestContentActionBlockAddon(TestContentActionDisableAddon):
     ActionClass = ContentActionBlockAddon

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -215,10 +215,8 @@
               <h4>Enforcement actions:</h4>
               <ol id="policy-enforcement-actions">
                 <li class="action-0 primary-enf">No Action</li>
-                {% for action in DECISION_ACTIONS %}
-                {% with enf='primary-enf' if not action in DECISION_ACTIONS.FOLLOWUP_CINDER_ACTIONS else 'followup-enf' %}
-                <li class="action-{{ action.value }} hidden {{ enf }}">{{ action.label }}</li>
-                {% endwith %}
+                {% for class, value, label in decision_actions %}
+                <li class="action-{{ value }} hidden {{ class }}">{{ label }}</li>
                 {% endfor %}
               </ol>
             </div>

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -26,6 +26,7 @@ from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 
 from olympia import amo, core, ratings
+from olympia.abuse.actions import CONTENT_ACTION_FROM_DECISION_ACTION
 from olympia.abuse.models import AbuseReport, CinderJob, CinderPolicy, ContentDecision
 from olympia.access import acl
 from olympia.access.models import Group, GroupUser
@@ -6349,7 +6350,7 @@ class TestReview(ReviewBase):
     def test_blocked_versions(self):
         response = self.client.get(self.url)
         assert response.status_code == 200
-        assert b'Blocked' not in response.content
+        assert b'-Blocked' not in response.content
 
         block = block_factory(guid=self.addon.guid, updated_by=user_factory())
         response = self.client.get(self.url)
@@ -6977,6 +6978,9 @@ class TestReview(ReviewBase):
                 assert 'primary-enf' in item[0].classes
             else:
                 assert 'followup-enf' in item[0].classes
+            assert item.text() == (
+                CONTENT_ACTION_FROM_DECISION_ACTION[action].description
+            )
 
 
 class TestAbuseReportsView(ReviewerTest):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -23,7 +23,11 @@ from rest_framework.viewsets import GenericViewSet
 
 import olympia.core.logger
 from olympia import amo
-from olympia.abuse.models import AbuseReport, CinderPolicy, ContentDecision
+from olympia.abuse.models import (
+    AbuseReport,
+    CinderPolicy,
+    ContentDecision,
+)
 from olympia.abuse.tasks import report_decision_to_cinder_and_notify
 from olympia.access import acl
 from olympia.activity.models import ActivityLog, CommentLog
@@ -70,6 +74,7 @@ from olympia.stats.utils import (
 from olympia.users.models import UserProfile
 from olympia.versions.models import Version
 from olympia.zadmin.models import get_config, set_config
+from src.olympia.abuse.actions import CONTENT_ACTION_FROM_DECISION_ACTION
 
 from .decorators import (
     any_reviewer_or_moderator_required,
@@ -706,7 +711,16 @@ def review(request, addon, channel=None):
             else AddonApprovalsCounter().get_content_review_status_display()
         ),
         count=count,
-        DECISION_ACTIONS=DECISION_ACTIONS,
+        decision_actions=[
+            (
+                'primary-enf'
+                if action not in DECISION_ACTIONS.FOLLOWUP_CINDER_ACTIONS
+                else 'followup-enf',
+                action.value,
+                CONTENT_ACTION_FROM_DECISION_ACTION[action].description,
+            )
+            for action in DECISION_ACTIONS
+        ],
         flags=flags,
         form=form,
         format_matched_rules=formatted_matched_rules_with_files_and_data,


### PR DESCRIPTION
Fixes mozilla/addons#16305

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Expose the ActionClass description in the reviewer tools, which is more verbose and includes delay days, rather than the enforcement action label.

<img width="890" height="756" alt="image" src="https://github.com/user-attachments/assets/ff9cbaa7-c16c-4263-a3a5-9a01ae9847c7" />

### Context

Also changed all the tenses on the description properties to future tense (including all the none Add-on action classes for consistency, even though they aren't displayed anywhere).  Follow-up actions didn't need the description (re)defining - we were already doing it to expose in the emails to developers.

### Testing

- enable `enable-policy-review-selection` waffle switch
- expose a selection of policies in the reviewer tools via django admin
  - at least one with follow-up actions - amo-fu-*
  - at least one with amo-addon-version-rejection-warning
- select policies in the reviewer tools to see the enforcement action labels

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
