### PR TITLE
Group dependabot updates for ssdlc-actions together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,10 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  groups:
+    ssdlc-actions:
+      patterns:
+        - "mozilla/ssdlc-actions/*"
   cooldown:
     default-days: 7
   open-pull-requests-limit: 99


### PR DESCRIPTION
We don't need 2 separate PRs for `mozilla/ssdlc-actions/.github/workflows/code-security-analysis-public-repo.yml` and `mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml` every time there is a release...