### PR TITLE
Add enterprise review link to admin

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -485,6 +485,11 @@ class AddonAdmin(AddonAdminByGuidOrSlugMixin, AMOModelAdmin):
                 'has_unlisted_versions': obj.has_unlisted_versions(include_deleted=True)
                 if obj
                 else False,
+                'has_enterprise_versions': obj.has_enterprise_versions(
+                    include_deleted=True
+                )
+                if obj
+                else False,
             }
         )
 

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -387,6 +387,9 @@ class AddonAdmin(AddonAdminByGuidOrSlugMixin, AMOModelAdmin):
             '_listed_versions_exists': Exists(
                 sub_qs.filter(channel=amo.CHANNEL_LISTED)
             ),
+            '_enterprise_versions_exists': Exists(
+                sub_qs.filter(channel=amo.CHANNEL_ENTERPRISE)
+            ),
         }
         return annotations
 
@@ -465,6 +468,16 @@ class AddonAdmin(AddonAdminByGuidOrSlugMixin, AMOModelAdmin):
                         reverse('reviewers.review', args=['unlisted', obj.id]),
                     ),
                     'Review (unlisted)',
+                )
+            )
+        if obj._enterprise_versions_exists:
+            links.append(
+                (
+                    urljoin(
+                        settings.EXTERNAL_SITE_URL,
+                        reverse('reviewers.review', args=['enterprise', obj.id]),
+                    ),
+                    'Review (enterprise)',
                 )
             )
         return format_html(

--- a/src/olympia/addons/templates/admin/addons/addon/change_form.html
+++ b/src/olympia/addons/templates/admin/addons/addon/change_form.html
@@ -17,6 +17,14 @@
   </li>
   {% endif %}
 
+  {% if has_enterprise_versions %}
+  <li>
+    <a href="{{ external_site_url }}{% url 'reviewers.review' 'enterprise' object_id %}">
+      Reviewer Tools (enterprise)
+    </a>
+  </li>
+  {% endif %}
+
   {{ block.super }}
 {% endblock %}
 

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -155,16 +155,29 @@ class TestAddonAdmin(TestCase):
         assert b'Review (listed)' not in response.content
         assert b'Review (unlisted)' in response.content
 
-    def test_list_show_link_to_reviewer_tools_with_both_channels(self):
+    def test_list_show_link_to_reviewer_tools_enterprise(self):
+        version_kw = {'channel': amo.CHANNEL_ENTERPRISE}
+        addon_factory(guid='@foo', version_kw=version_kw)
+        user = user_factory(email='someone@mozilla.com')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
+        self.client.force_login(user)
+        response = self.client.get(self.list_url, follow=True)
+        assert b'Review (listed)' not in response.content
+        assert b'Review (unlisted)' not in response.content
+        assert b'Review (enterprise)' in response.content
+
+    def test_list_show_link_to_reviewer_tools_with_all_channels(self):
         addon = addon_factory()
         version_factory(addon=addon, channel=amo.CHANNEL_LISTED)
         version_factory(addon=addon, channel=amo.CHANNEL_UNLISTED)
+        version_factory(addon=addon, channel=amo.CHANNEL_ENTERPRISE)
         user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.client.force_login(user)
         response = self.client.get(self.list_url, follow=True)
         assert b'Review (listed)' in response.content
         assert b'Review (unlisted)' in response.content
+        assert b'Review (enterprise)' in response.content
 
     def test_list_queries(self):
         addon_factory(guid='@foo')

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -385,6 +385,7 @@ class TestAddonAdmin(TestCase):
         response = self.client.get(detail_url, follow=True)
         assert b'Reviewer Tools (listed)' in response.content
         assert b'Reviewer Tools (unlisted)' not in response.content
+        assert b'Reviewer Tools (enterprise)' not in response.content
 
     def test_show_link_to_reviewer_tools_unlisted(self):
         version_kw = {'channel': amo.CHANNEL_UNLISTED}
@@ -396,11 +397,25 @@ class TestAddonAdmin(TestCase):
         response = self.client.get(detail_url, follow=True)
         assert b'Reviewer Tools (listed)' not in response.content
         assert b'Reviewer Tools (unlisted)' in response.content
+        assert b'Reviewer Tools (enterprise)' not in response.content
 
-    def test_show_links_to_reviewer_tools_with_both_channels(self):
+    def test_show_link_to_reviewer_tools_enterprise(self):
+        version_kw = {'channel': amo.CHANNEL_ENTERPRISE}
+        addon = addon_factory(guid='@foo', version_kw=version_kw)
+        detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
+        user = user_factory(email='someone@mozilla.com')
+        self.grant_permission(user, amo.permissions.ADDONS_EDIT)
+        self.client.force_login(user)
+        response = self.client.get(detail_url, follow=True)
+        assert b'Reviewer Tools (listed)' not in response.content
+        assert b'Reviewer Tools (unlisted)' not in response.content
+        assert b'Reviewer Tools (enterprise)' in response.content
+
+    def test_show_links_to_reviewer_tools_with_multiple_channels(self):
         addon = addon_factory(guid='@foo')
         version_factory(addon=addon, version='0.1', channel=amo.CHANNEL_LISTED)
         version_factory(addon=addon, version='0.2', channel=amo.CHANNEL_UNLISTED)
+        version_factory(addon=addon, version='0.3', channel=amo.CHANNEL_ENTERPRISE)
         detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
         user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, amo.permissions.ADDONS_EDIT)
@@ -418,6 +433,13 @@ class TestAddonAdmin(TestCase):
         assert (
             'http://testserver{}'.format(
                 reverse('reviewers.review', args=('unlisted', addon.pk))
+            )
+            in content
+        )
+        assert 'Reviewer Tools (enterprise)' in content
+        assert (
+            'http://testserver{}'.format(
+                reverse('reviewers.review', args=('enterprise', addon.pk))
             )
             in content
         )
@@ -742,7 +764,7 @@ class TestAddonAdmin(TestCase):
         self.grant_permission(user, amo.permissions.ADDONS_EDIT)
         self.grant_permission(user, amo.permissions.ADMIN_ADVANCED)
         self.client.force_login(user)
-        with self.assertNumQueries(20 if self.is_django42 else 18):
+        with self.assertNumQueries(21 if self.is_django42 else 19):
             # It's very high because most of AddonAdmin is unoptimized but we
             # don't want it unexpectedly increasing.
             # FIXME: explain each query
@@ -752,7 +774,7 @@ class TestAddonAdmin(TestCase):
 
         version_factory(addon=addon)
         version_factory(addon=addon)
-        with self.assertNumQueries(20 if self.is_django42 else 18):
+        with self.assertNumQueries(21 if self.is_django42 else 19):
             # Confirm it scales correctly by doing the same number of queries
             # when number of versions increases.
             # FIXME: explain each query


### PR DESCRIPTION
Fixes mozilla/addons#16401

### Description

Adds review links to the /admin page.

<img width="1910" height="163" alt="image" src="https://github.com/user-attachments/assets/3e829bd3-d6f3-4696-9ede-b96e4d3ba810" />
<img width="1666" height="267" alt="image" src="https://github.com/user-attachments/assets/bf6b5053-2784-449d-bd2e-eb5a555c23d5" />

### Testing

1. Enable `enterprise-channel` waffle switch.
2. Upload an enterprise add-on or version.
3. The `admin/models/addons/addon/` page should include a link to the enterprise review page under `Reviewer links`.
4. The `admin/models/addons/addon/<id>/change` page should include a similar button in the top right.

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
