### PR TITLE
update failing test

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -4092,7 +4092,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     @override_switch('enable-policy-review-selection', active=True)
     def test_review_with_policy_disable_override_to_disable(self):
-        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW)
         self.file.update(
             status=amo.STATUS_DISABLED,
             original_status=amo.STATUS_AWAITING_REVIEW,


### PR DESCRIPTION
fixes breakage in https://github.com/mozilla/addons-server/pull/25214

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

updates a breaking test

### Context

github.com/mozilla/addons-server/pull/25226 changed the allowable types for grant_permission from AclPermission,str,tuple,list to just AclPermission, and it was merged earlier today. 


### Testing

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
