### PR TITLE
Handle overriding a reject_version to a reject_version properly

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -582,6 +582,7 @@ class ContentActionDisableAddon(ContentActionAddon):
             # empty. These aren't tied to the new decision's target_versions
             # (those belong to the new action being applied)
             target_versions = list(get_target_versions())
+            new_decision.target_versions.set(target_versions)
             target.force_enable(skip_activity_log=True)
             return cls.reverse_action_log_action(
                 new_decision, amo.LOG.FORCE_ENABLE, target_versions
@@ -766,7 +767,7 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
         target = new_decision.target
         # We only need to un-reject the versions we disabled as part of the
         # rejection (and that haven't been disabled again for another reason).
-        versions = list(
+        versions = (
             reversed_decision.target_versions.all()
             .no_transforms()
             .filter(
@@ -775,8 +776,14 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
             )
             .order_by('-pk')
         )
-        if not versions:
+        # We can also exclude versions we're still going to reject with new_decision.
+        if new_decision.action == cls.action:
+            versions = versions.exclude(
+                id__in=new_decision.target_versions.values_list('id', flat=True)
+            )
+        if not versions.exists():
             return None
+        versions = list(versions)
         for version in versions:
             version.file.update(
                 datestatuschanged=datetime.now(),
@@ -789,6 +796,10 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
                 original_status=amo.STATUS_NULL,
             )
         target.update_status()
+        # For appeals the new (approve) decision has no target_versions of its own,
+        # set it. For overrides the target_versions are already set in reviewer tools.
+        if not new_decision.target_versions.exists():
+            new_decision.target_versions.set(versions)
         return cls.reverse_action_log_action(
             new_decision, amo.LOG.UNREJECT_VERSION, versions
         )
@@ -905,11 +916,17 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
 
     @classmethod
     def reverse_action(cls, *, reversed_decision, new_decision):
-        versions = list(
+        versions = (
             reversed_decision.target_versions.all().no_transforms().order_by('-pk')
         )
-        if not versions:
+        # We can also exclude versions we're still going to reject with new_decision.
+        if new_decision.action == cls.action:
+            versions = versions.exclude(
+                id__in=new_decision.target_versions.values_list('id', flat=True)
+            )
+        if not versions.exists():
             return None
+        versions = list(versions)
         for version in versions:
             VersionReviewerFlags.objects.update_or_create(
                 version=version,
@@ -919,6 +936,10 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
                     'pending_content_rejection': None,
                 },
             )
+        # For appeals the new (approve) decision has no target_versions of its own,
+        # set it. For overrides the target_versions are already set in reviewer tools.
+        if not new_decision.target_versions.exists():
+            new_decision.target_versions.set(versions)
         return cls.reverse_action_log_action(
             new_decision, amo.LOG.CLEAR_PENDING_REJECTION, versions
         )
@@ -1106,12 +1127,20 @@ class _ContentActionDelayedBlockAddon(ContentActionBlockAddon):
         return None
 
     @classmethod
-    def reverse_action(cls, *, reversed_decision, new_decision=None):
+    def reverse_action(cls, *, reversed_decision, new_decision):
         # Note: when the original primary action was ContentDisableAddon, the versions
         # blocked may have been more than target_versions, but we're leaving the other
         # versions blocked.
         guid = reversed_decision.target.guid
         versions = reversed_decision.target_versions.all()
+        # We can also exclude versions we're still going to block with new_decision.
+        if new_decision.action == cls.action:
+            versions = versions.exclude(
+                id__in=new_decision.target_versions.values_list('id', flat=True)
+            )
+        if not versions.exists():
+            # if they're the same versions, we can just abort
+            return
         # First unblock any versions that have already been blocked
         already_blocked_version_ids = list(
             versions.filter(blockversion__block_type=cls.block_type).values_list(
@@ -1414,7 +1443,7 @@ class ContentActionTargetAppealApprove(
                 followup_action.action
             ]
             FollowUpActionClass.reverse_action(
-                reversed_decision=followup_action.decision
+                reversed_decision=followup_action.decision, new_decision=self.decision
             )
 
         return log_entry

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1386,7 +1386,8 @@ class ContentDecision(ModelBase):
         if not overridden:
             return None
 
-        if overridden.action != self.action:
+        version_specific = self.action in DECISION_ACTIONS.VERSION_SPECIFIC
+        if overridden.action != self.action or version_specific:
             OverriddenActionClass = CONTENT_ACTION_FROM_DECISION_ACTION[
                 overridden.action
             ]
@@ -1399,16 +1400,20 @@ class ContentDecision(ModelBase):
 
         # Reverse any follow-up actions (e.g. delayed blocks) of the overridden
         # decision too.
-        new_followup_actions = list(
-            self.followup_actions.values_list('action', flat=True)
+        reversing_followup_actions = overridden.followup_actions.filter(
+            action_date__isnull=False
         )
-        for followup in overridden.followup_actions.filter(action_date__isnull=False):
-            if followup.action in new_followup_actions:
-                # If the follow-up action is the same as the new action, we don't need
-                # to reverse it.
-                continue
+        # If the action is not version specific, and the follow-up action is the same as
+        # the new action, we don't need to reverse it.
+        if not version_specific:
+            reversing_followup_actions = reversing_followup_actions.exclude(
+                action__in=self.followup_actions.values_list('action', flat=True)
+            )
+        for followup in reversing_followup_actions:
             FollowUpActionClass = CONTENT_ACTION_FROM_DECISION_ACTION[followup.action]
-            FollowUpActionClass.reverse_action(reversed_decision=followup.decision)
+            FollowUpActionClass.reverse_action(
+                reversed_decision=followup.decision, new_decision=self
+            )
         return log_entry
 
     def execute_action(self, *, release_hold=False):
@@ -1520,11 +1525,9 @@ class ContentDecision(ModelBase):
                 self.action == DECISION_ACTIONS.AMO_APPROVE_VERSION
                 and not details.get('human_review', True)
             )
-            version_numbers = (
-                log_entry.versionlog_set.values_list('version__version', flat=True)
-                if log_entry
-                else []
-            )
+            version_numbers = self.target_versions.values_list(
+                'version', flat=True
+            ).order_by('pk')
             is_addon_enabled = not (
                 details.get('is_addon_being_disabled') or self.addon.is_disabled
             )
@@ -1537,7 +1540,7 @@ class ContentDecision(ModelBase):
                 'details': details,
                 'is_addon_being_blocked': details.get('is_addon_being_blocked'),
                 'is_addon_enabled': is_addon_enabled,
-                'version_list': ', '.join(ver_str for ver_str in version_numbers),
+                'version_list': ', '.join(version_numbers),
                 'has_attachment': has_attachment,
                 'dev_url': absolutify(self.target.get_dev_url('versions')),
                 # If we expanded the reason/policy text into notes in the reviewer tools

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -816,6 +816,28 @@ class TestContentActionDisableAddon(
             action_helper, f'Mozilla Add-ons: {self.addon.name}'
         )
 
+    def test_reverse_action_appeal_sets_target_versions_on_new_decision(self):
+        for version in (self.old_version, self.version):
+            version.file.update(
+                status=amo.STATUS_DISABLED,
+                original_status=amo.STATUS_APPROVED,
+                status_disabled_reason=File.STATUS_DISABLED_REASONS.ADDON_DISABLE,
+            )
+        self.addon.update(status=amo.STATUS_DISABLED)
+        new_decision = ContentDecision.objects.create(
+            addon=self.addon, action=DECISION_ACTIONS.AMO_APPROVE
+        )
+        assert not new_decision.target_versions.exists()
+
+        ContentActionDisableAddon.reverse_action(
+            reversed_decision=self.past_negative_decision, new_decision=new_decision
+        )
+
+        assert set(new_decision.target_versions.all()) == {
+            self.old_version,
+            self.version,
+        }
+
     def test_target_appeal_decline(self):
         self.addon.update(status=amo.STATUS_DISABLED)
         ActivityLog.objects.all().delete()
@@ -1205,6 +1227,8 @@ class TestContentActionDisableAddon(
 
     def test_approve_appeal_success_but_not_approved(self):
         self.past_negative_decision.update(appeal_job=self.cinder_job)
+        # A successful appeal is an approval, so its decision has no target_versions
+        self.decision.target_versions.clear()
         self._test_approve_appeal_or_override_but_not_approved(
             ContentActionTargetAppealApprove
         )
@@ -1357,6 +1381,8 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
             content_review_status=AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.FAIL,
         )
         self.past_negative_decision.update(appeal_job=self.cinder_job)
+        # A successful appeal is an approval, so its decision has no target_versions
+        self.decision.target_versions.clear()
         self._test_approve_appeal_or_override(
             ContentActionTargetAppealApprove, fragment='we have re-enabled'
         )
@@ -2094,6 +2120,116 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
             fragment='information on its availability',
         )
 
+    def test_reverse_action_override_same_action_excludes_new_target_versions(self):
+        for version in (self.old_version, self.version):
+            version.file.update(
+                status=amo.STATUS_DISABLED,
+                original_status=amo.STATUS_APPROVED,
+                status_disabled_reason=File.STATUS_DISABLED_REASONS.NONE,
+            )
+        # Only self.version rejected is still rejected in the override decision
+        self.decision.target_versions.set((self.version,))
+
+        alog = ContentActionRejectVersion.reverse_action(
+            reversed_decision=self.past_negative_decision, new_decision=self.decision
+        )
+
+        assert self.old_version.file.reload().status == amo.STATUS_APPROVED
+        assert self.version.file.reload().status == amo.STATUS_DISABLED
+        assert alog.action == amo.LOG.UNREJECT_VERSION.id
+        assert alog.versionlog_set.get().version == self.old_version
+        assert self.decision.target_versions.get() == self.version
+
+    def test_reverse_action_override_same_action_same_versions_returns_none(self):
+        for version in (self.old_version, self.version):
+            version.file.update(
+                status=amo.STATUS_DISABLED,
+                original_status=amo.STATUS_APPROVED,
+                status_disabled_reason=File.STATUS_DISABLED_REASONS.NONE,
+            )
+        # both versions are still rejected in the override decision
+        self.decision.target_versions.set((self.version, self.old_version))
+
+        alog = ContentActionRejectVersion.reverse_action(
+            reversed_decision=self.past_negative_decision,
+            new_decision=self.decision,
+        )
+        # no files are re-enabled
+        assert self.old_version.file.reload().status == amo.STATUS_DISABLED
+        assert self.version.file.reload().status == amo.STATUS_DISABLED
+        # and because no unreject has taken place, there is no log
+        assert alog is None
+
+    def test_reverse_action_appeal_sets_target_versions_on_new_decision(self):
+        for version in (self.old_version, self.version):
+            version.file.update(
+                status=amo.STATUS_DISABLED,
+                original_status=amo.STATUS_APPROVED,
+                status_disabled_reason=File.STATUS_DISABLED_REASONS.NONE,
+            )
+        new_decision = ContentDecision.objects.create(
+            addon=self.addon, action=DECISION_ACTIONS.AMO_APPROVE
+        )
+        assert not new_decision.target_versions.exists()
+
+        ContentActionRejectVersion.reverse_action(
+            reversed_decision=self.past_negative_decision, new_decision=new_decision
+        )
+
+        assert set(new_decision.target_versions.all()) == {
+            self.old_version,
+            self.version,
+        }
+
+    def _set_pending_rejections(self):
+        for version in (self.old_version, self.version):
+            VersionReviewerFlags.objects.update_or_create(
+                version=version,
+                defaults={
+                    'pending_rejection': datetime.now(),
+                    'pending_rejection_by': self.task_user,
+                    'pending_content_rejection': False,
+                },
+            )
+
+    def test_reverse_action_delayed_override_same_action_excludes_new_versions(self):
+        # Similarly to immediate rejection
+        self._set_pending_rejections()
+        self.decision.update(action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON)
+        self.decision.target_versions.set((self.version,))
+
+        alog = ContentActionRejectVersionDelayed.reverse_action(
+            reversed_decision=self.past_negative_decision, new_decision=self.decision
+        )
+
+        assert alog.action == amo.LOG.CLEAR_PENDING_REJECTION.id
+        assert (
+            VersionReviewerFlags.objects.get(version=self.old_version).pending_rejection
+            is None
+        )
+        assert (
+            VersionReviewerFlags.objects.get(version=self.version).pending_rejection
+            is not None
+        )
+        assert alog.versionlog_set.get().version == self.old_version
+        assert set(self.decision.target_versions.all()) == {self.version}
+
+    def test_reverse_action_delayed_appeal_sets_target_versions(self):
+        self._set_pending_rejections()
+        new_decision = ContentDecision.objects.create(
+            addon=self.addon, action=DECISION_ACTIONS.AMO_APPROVE
+        )
+        assert not new_decision.target_versions.exists()
+
+        ContentActionRejectVersionDelayed.reverse_action(
+            reversed_decision=self.past_negative_decision, new_decision=new_decision
+        )
+
+        assert set(new_decision.target_versions.all()) == {
+            self.old_version,
+            self.version,
+        }
+
     def test_description(self):
         assert ContentActionRejectVersion.description == (
             'Add-on version(s) will be rejected'
@@ -2576,6 +2712,27 @@ class TestContentActionDelayedShortSoftBlockAddon(
     def test_email_content_not_escaped(self):
         # TODO: If/when we support emails we should implement this
         pass
+
+    def test_reverse_action_override_same_action_excludes_new_target_versions(self):
+        BlockVersion.objects.create(
+            block=self.existing_block, version=self.version, block_type=self.block_type
+        )
+        new_decision = ContentDecision.objects.create(
+            addon=self.addon, action=self.default_decision_action
+        )
+        # The new decision keeps self.version blocked.
+        new_decision.target_versions.set((self.version,))
+
+        self.ActionClass.reverse_action(
+            reversed_decision=self.past_negative_decision, new_decision=new_decision
+        )
+
+        assert not BlockVersion.objects.filter(
+            version=self.old_version, block_type=self.block_type
+        ).exists()
+        assert BlockVersion.objects.filter(
+            version=self.version, block_type=self.block_type
+        ).exists()
 
     def test_description(self):
         assert self.ActionClass.description == (

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -3750,9 +3750,8 @@ class TestContentDecision(TestCase):
         # and version approval means the owner is notified.
         addon = addon_factory(users=[user_factory()])
         older_version = addon.versions.get()
-        version_factory(
-            addon=addon
-        )  # add a middle version that wasn't rejected or changed
+        # add a middle version that wasn't rejected or changed
+        version_factory(addon=addon)
         older_version.file.update(
             status=amo.STATUS_DISABLED, original_status=amo.STATUS_APPROVED
         )
@@ -3773,12 +3772,16 @@ class TestContentDecision(TestCase):
             override_of=original_decision,
         )
         original_decision.target_versions.set([older_version, newer_version])
+        new_decision.target_versions.set([older_version, newer_version])
         assert new_decision.action_date is None
 
-        new_decision.execute_action()
+        with mock.patch('olympia.abuse.actions.sign_file') as sign_file_mock:
+            new_decision.execute_action()
+            sign_file_mock.assert_called_once_with(newer_version.file)
+
         self.assertCloseToNow(new_decision.reload().action_date)
         assert older_version.file.reload().status == amo.STATUS_APPROVED
-        assert newer_version.file.reload().status == amo.STATUS_AWAITING_REVIEW
+        assert newer_version.file.reload().status == amo.STATUS_APPROVED
 
         new_decision.send_notifications()
         assert len(mail.outbox) == 1
@@ -3833,6 +3836,64 @@ class TestContentDecision(TestCase):
         assert list(decision.target_versions.all()) == list(
             overridden.target_versions.all()
         )
+
+    def test_execute_action_override_to_same_enforcement_different_versions(self):
+        addon = addon_factory(users=[user_factory()])
+        v1 = addon.current_version
+        assert v1.file.status == amo.STATUS_APPROVED
+        v2 = version_factory(
+            addon=addon,
+            file_kw={
+                'status': amo.STATUS_DISABLED,
+                'original_status': amo.STATUS_APPROVED,
+            },
+        )
+        v3 = version_factory(
+            addon=addon,
+            file_kw={
+                'status': amo.STATUS_DISABLED,
+                'original_status': amo.STATUS_APPROVED,
+            },
+        )
+        overridden = ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
+            action_date=datetime.now(),
+            metadata={ContentDecision.POLICY_DYNAMIC_VALUES: {}},
+        )
+        overridden.policies.add(
+            CinderPolicy.objects.create(uuid='1234', name='Bad policy')
+        )
+        overridden.target_versions.set((v2, v3))
+        decision = ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
+            reasoning='some review text',
+            reviewer_user=self.reviewer_user,
+            override_of=overridden,
+            metadata={ContentDecision.POLICY_DYNAMIC_VALUES: {}},
+        )
+        decision.policies.add(
+            CinderPolicy.objects.create(uuid='12345', name='Other bad policy')
+        )
+        decision.target_versions.set((v1, v2))
+
+        decision.execute_action()
+        assert addon.reload().status == amo.STATUS_APPROVED  # no change
+        assert v1.file.reload().status == amo.STATUS_DISABLED
+        assert v2.file.reload().status == amo.STATUS_DISABLED
+        assert v3.file.reload().status == amo.STATUS_APPROVED
+
+        assert decision.activities.count() == 2
+        assert decision.activities.first().action == amo.LOG.REJECT_VERSION.id
+        assert decision.activities.last().action == amo.LOG.UNREJECT_VERSION.id
+
+        decision.send_notifications()
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [addon.authors.get().email]
+        assert 'versions of your extension have been disabled' in mail.outbox[0].body
+        assert f'Affected versions: {v1.version}, {v2.version}' in mail.outbox[0].body
+        assert 'Other bad policy' in mail.outbox[0].body
 
     def _test_execute_action_reject_version_delayed_outcome(self, decision):
         decision.send_notifications()


### PR DESCRIPTION
Fixes mozilla/addons#16360

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds additional handling for overrides for version specific actions, where it's the same action. 

### Context

A common case is overriding a decision with policies that have `amo-reject-version-addon` for versions 1 & 2, with the a new decision also with policies that have `amo-reject-version-addon` for versions 2 & 3.  The override reversal step needs to unreject version 1, and only version 1.  Because the patch makes changes to rely more on target_versions, there were additional adjustments needed for how target_versions are set for appeals, so the same functions work for both.

### Testing

- enable policy selection (`enable-policy-review-selection`) waffle switch
- you need at least one policy exposed in the reviewer tools that has `amo-reject-version-addon` (or the -warning variant), preferably 2 of them
- select or set up an add-on with at least two unrejected/undisabled versions (three is better)
- make a decision and choose a policy that rejects versions and select some versions, selecting at least one version, and leaving at least one version unrejected
  - see the version(s) you selected are rejected
- then override that decision with a new decision that still has a policy that rejects versions, but with a _different_ selection of versions. 
  - (if you enabled more than one policy for the reviewer tools, a different policy, but the exact policy isn't important, it's the underlying actions linked to the polices)
- see that the version(s) you didn't select for rejection in the override are unrejected; and new version(s) that you did select for rejection in the override are rejected.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
