### PR TITLE
expose devhub submit_notification_warning via site status api

### DIFF
--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -281,6 +281,7 @@ See :ref:`maintenance mode <api-overview-maintenance>` for more details of when 
 
     :>json boolean read_only: Whether the site in read-only mode.
     :>json string|null notice: A site-wide notice about any current known difficulties or restrictions.  If this API is being consumed by a tool/frontend it should be displayed to the user.
+    :>json string|null submit_notification_warning: A notice for add-on developers for about submission of new add-ons or versions.  If this API is being consumed by a tool/frontend, and the user is in the process of submitting new add-ons or versions, it should be displayed to the user.
 
 
 ------------
@@ -484,6 +485,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2026-02-19: added the ability to patch a scanner result. https://github.com/mozilla/addons/issues/16004
 * 2026-03-05: removed /scanner/results/ (internal API endpoint). https://github.com/mozilla/addons/issues/16088
 * 2026-04-02: added /scanner/results/ endpoint to allow scanners to push results. https://github.com/mozilla/addons/issues/16115
+* 2026-08-20: added 'submit_notification_warning' to site status endpoint. https://github.com/mozilla/addons-server/pull/25302
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -250,6 +250,7 @@ class TestSelfUserProfileSerializer(
         assert data['site_status'] == {
             'read_only': False,
             'notice': None,
+            'submit_notification_warning': None,
         }
 
         set_config('site_notice', 'THIS is NOT Á TEST!')
@@ -257,6 +258,7 @@ class TestSelfUserProfileSerializer(
         assert data['site_status'] == {
             'read_only': False,
             'notice': 'THIS is NOT Á TEST!',
+            'submit_notification_warning': None,
         }
 
         with override_settings(READ_ONLY=True):
@@ -264,14 +266,17 @@ class TestSelfUserProfileSerializer(
         assert data['site_status'] == {
             'read_only': True,
             'notice': 'THIS is NOT Á TEST!',
+            'submit_notification_warning': None,
         }
 
         Config.objects.get(key='site_notice').delete()
+        set_config('submit_notification_warning', 'Warning!')
         with override_settings(READ_ONLY=True):
             data = super().test_basic()
         assert data['site_status'] == {
             'read_only': True,
             'notice': None,
+            'submit_notification_warning': 'Warning!',
         }
 
 

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -618,6 +618,14 @@ class TestSiteStatusAPI(TestCase):
         assert response.data == {
             'read_only': False,
             'notice': None,
+            'submit_notification_warning': None,
+        }
+        set_config('submit_notification_warning', 'Warning!')
+        response = self.client.get(self.url)
+        assert response.data == {
+            'read_only': False,
+            'notice': None,
+            'submit_notification_warning': 'Warning!',
         }
 
         set_config('site_notice', 'THIS is NOT Á TEST!')
@@ -626,6 +634,7 @@ class TestSiteStatusAPI(TestCase):
         assert response.data == {
             'read_only': True,
             'notice': 'THIS is NOT Á TEST!',
+            'submit_notification_warning': 'Warning!',
         }
 
 

--- a/src/olympia/api/serializers.py
+++ b/src/olympia/api/serializers.py
@@ -15,7 +15,7 @@ from olympia.translations.utils import (
     fetch_translations_from_instance,
     get_translation_differences,
 )
-from olympia.zadmin.models import get_config
+from olympia.zadmin.models import Config
 
 
 class AMOModelSerializer(BaseModelSerializerAndFormMixin, serializers.ModelSerializer):
@@ -97,9 +97,21 @@ class BaseESSerializer(AMOModelSerializer):
 
 class SiteStatusSerializer(serializers.BaseSerializer):
     def to_representation(self, obj):
+        notices = {
+            'notice': amo.config_keys.SITE_NOTICE,
+            'submit_notification_warning': amo.config_keys.SUBMIT_NOTIFICATION_WARNING,
+        }
+        configs = dict(
+            Config.objects.filter(
+                key__in=[config_key.key for config_key in notices.values()]
+            ).values_list('key', 'value')
+        )
         return {
             'read_only': settings.READ_ONLY,
-            'notice': get_config(amo.config_keys.SITE_NOTICE),
+            **{
+                field: configs.get(config_key.key, config_key.default)
+                for field, config_key in notices.items()
+            },
         }
 
 


### PR DESCRIPTION
Fixes mozilla/addons#16380

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Exposes devhub submission warning config text in site status response, if defined

### Context

<!--
Often a pull request contains changes that are not fully self explanatory. Maybe this PR is a part of a series,
or maybe it is a partial change now with a more ambitious plan for the future. Add this additional context here.
If it is not relevant for your PR, remove this section.
-->

### Testing

- in django admin create a Config instance with the key `submit_notification_warning` and some text
- see that text displayed in current devhub in the upload flow
- access /api/v5/site/ and see the text value in the json response too

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
