### PR TITLE
Clarify nominated status is not public tip in addon_details.html

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/addon_details.html
+++ b/src/olympia/devhub/templates/devhub/includes/addon_details.html
@@ -23,10 +23,9 @@
 {% set status_tips = {
     amo.STATUS_NULL: _('Please complete your add-on by adding a version or missing metadata.'),
     amo.STATUS_NOMINATED: _("You will receive an email when the review is complete. Until "
-                            "then, your add-on is not listed in our gallery but can be "
-                            "accessed directly from its details page. "),
+                            "then, this version is not publicly available."),
     amo.STATUS_APPROVED: _("Your add-on is displayed in our gallery and users are "
-                         "receiving automatic updates."),
+                           "receiving automatic updates."),
     amo.STATUS_DISABLED: _("Your add-on was disabled by a site administrator and is no "
                            "longer shown in our gallery."),
     amo.STATUS_REJECTED: _("Your add-on listing was rejected. It is not listed in our gallery. "

--- a/src/olympia/devhub/templates/devhub/includes/addon_details.html
+++ b/src/olympia/devhub/templates/devhub/includes/addon_details.html
@@ -23,7 +23,8 @@
 {% set status_tips = {
     amo.STATUS_NULL: _('Please complete your add-on by adding a version or missing metadata.'),
     amo.STATUS_NOMINATED: _("You will receive an email when the review is complete. Until "
-                            "then, this version is not publicly available."),
+                            "then, your add-on is not publicly available. You, the "
+                            "authenticated author, can access its details page."),
     amo.STATUS_APPROVED: _("Your add-on is displayed in our gallery and users are "
                            "receiving automatic updates."),
     amo.STATUS_DISABLED: _("Your add-on was disabled by a site administrator and is no "


### PR DESCRIPTION
Clarify nominated status is not public tip in addon_details.html

#16420

Fixes mozilla/addons#16420

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

### Context

https://github.com/mozilla/addons/issues/16420

### Testing

I did not test this change. But let me know if you would like me to try.

If there is an automated build that I can look at from the PR then I will use that.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
