### PR TITLE
Add Enterprise Version Link to Blocklist Submission

### DIFF
--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -608,6 +608,7 @@ class BlockAdmin(BlockAdminAddMixin, AMOModelAdmin):
         'users',
         'review_listed_link',
         'review_unlisted_link',
+        'review_enterprise_link',
         'block_history',
         'url_link',
         'blocked_versions',
@@ -683,7 +684,11 @@ class BlockAdmin(BlockAdminAddMixin, AMOModelAdmin):
                     'addon_name',
                     'addon_updated',
                     'users',
-                    ('review_listed_link', 'review_unlisted_link'),
+                    (
+                        'review_listed_link',
+                        'review_unlisted_link',
+                        'review_enterprise_link',
+                    ),
                 )
             },
         )

--- a/src/olympia/blocklist/models.py
+++ b/src/olympia/blocklist/models.py
@@ -131,6 +131,19 @@ class Block(ModelBase):
             return format_html('· <a href="{}">{}</a>', url, 'Review Unlisted')
         return ''
 
+    def review_enterprise_link(self):
+        has_enterprise = any(
+            True
+            for version in self.addon_versions
+            if version.channel == amo.CHANNEL_ENTERPRISE
+        )
+        if has_enterprise:
+            url = absolutify(
+                reverse('reviewers.review', args=('enterprise', self.addon.pk))
+            )
+            return format_html('· <a href="{}">{}</a>', url, 'Review Enterprise')
+        return ''
+
     def all_authors_link(self):
         if self.addon and self.addon.all_authors:
             parameter = '?q=' + ','.join(

--- a/src/olympia/blocklist/templates/admin/blocklist/includes/blocks.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/includes/blocks.html
@@ -15,6 +15,8 @@
 
       {{ block_obj.review_listed_link }}
       {{ block_obj.review_unlisted_link }}
+      {{ block_obj.review_enterprise_link }}
+
       {{ block_obj.all_authors_link }}
       {% if block_obj.id %}
         <span class="existing_block">[<a href="{% url 'admin:blocklist_block_change' block_obj.id %}">Edit Block</a>]</span>

--- a/src/olympia/blocklist/templates/admin/blocklist/widgets/blocks.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/widgets/blocks.html
@@ -15,6 +15,8 @@
 
       {{ block_obj.review_listed_link }}
       {{ block_obj.review_unlisted_link }}
+      {{ block_obj.review_enterprise_link }}
+
       {{ block_obj.all_authors_link }}
       {% if block_obj.id %}
         <span class="existing_block">[<a href="{% url 'admin:blocklist_block_change' block_obj.id %}">Edit Block</a>]</span>

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -1407,6 +1407,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         response = self.client.post(**post_kwargs)
         assert b'Review Listed' in response.content
         assert b'Review Unlisted' not in response.content
+        assert b'Review Enterprise' not in response.content
         assert b'Edit Block' not in response.content
         assert not pq(response.content)('.existing_block')
 
@@ -1417,6 +1418,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         response = self.client.post(**post_kwargs)
         assert b'Review Listed' in response.content
         assert b'Review Unlisted' not in response.content
+        assert b'Review Enterprise' not in response.content
         assert pq(response.content)('.existing_block a').attr('href') == (
             reverse('admin:blocklist_block_change', args=(existing_block.pk,))
         )
@@ -1427,6 +1429,18 @@ class TestBlocklistSubmissionAdmin(TestCase):
         response = self.client.post(**post_kwargs)
         assert b'Review Listed' in response.content
         assert b'Review Unlisted' in response.content
+        assert b'Review Enterprise' not in response.content
+        assert pq(response.content)('.existing_block a').attr('href') == (
+            reverse('admin:blocklist_block_change', args=(existing_block.pk,))
+        )
+        assert pq(response.content)('.existing_block').text() == ('[Edit Block]')
+
+        # And enterprise.
+        version_factory(addon=addon, channel=amo.CHANNEL_ENTERPRISE, version='0.3')
+        response = self.client.post(**post_kwargs)
+        assert b'Review Listed' in response.content
+        assert b'Review Unlisted' in response.content
+        assert b'Review Enterprise' in response.content
         assert pq(response.content)('.existing_block a').attr('href') == (
             reverse('admin:blocklist_block_change', args=(existing_block.pk,))
         )
@@ -1437,6 +1451,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         response = self.client.post(**post_kwargs)
         assert b'Review Listed' in response.content
         assert b'Review Unlisted' in response.content
+        assert b'Review Enterprise' in response.content
         assert b'Edit Block' not in response.content
         assert not pq(response.content)('.existing_block')
 

--- a/static/css/admin/blocklist_block.css
+++ b/static/css/admin/blocklist_block.css
@@ -1,5 +1,6 @@
 .field-review_listed_link label,
 .field-review_unlisted_link label,
+.field-review_enterprise_link label,
 .field-block_history label,
 .fieldBox.field-url_link label {
     display: none;


### PR DESCRIPTION
Relates to mozilla/addons#14855

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds a link to the enterprise review page on blocklist submissions when add-on has enterprise versions.

<img width="969" height="200" alt="image" src="https://github.com/user-attachments/assets/3486084b-8145-4ad0-b34d-97bbf0f71f23" />


### Testing

1. Enable `enterprise-channel` waffle switch.
2. Upload a new add-on with the enterprise channel.
3. Navigate to `admin/models/blocklist/block/add/`. Input GUID of uploaded add-on.
4. A link to the enterprise review page should be visible.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
