### PR TITLE
Enable Enterprise Version Upload Subscriptions

### DIFF
--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -153,8 +153,8 @@ class ReviewerSubscription(ModelBase):
                 reverse('addons.detail', args=[self.addon.pk], add_prefix=False)
             )
         else:
-            # If the submission went to the unlisted channel,
-            # do not link to the listing.
+            # If the submission went to the unlisted or enterprise
+            # channels, do not link to the listing.
             listing_url = None
         context = {
             'name': self.addon.name,
@@ -214,9 +214,15 @@ def send_notifications(sender=None, instance=None, signal=None, **kw):
             and instance.channel == amo.CHANNEL_UNLISTED
             and any(acl.action_allowed_for(user, perm) for perm in unlisted_perms)
         )
+        is_unlisted_reviewer_and_enterprise_submission = (
+            subscriber.channel == amo.CHANNEL_ENTERPRISE
+            and instance.channel == amo.CHANNEL_ENTERPRISE
+            and any(acl.action_allowed_for(user, perm) for perm in unlisted_perms)
+        )
         if is_active_user and (
             is_reviewer_and_listed_submission
             or is_unlisted_reviewer_and_unlisted_submission
+            or is_unlisted_reviewer_and_enterprise_submission
         ):
             subscriber.send_notification(instance)
 

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -160,6 +160,7 @@ class ReviewerSubscription(ModelBase):
             'name': self.addon.name,
             'url': listing_url,
             'number': version.version,
+            'channel': amo.CHANNEL_CHOICES_API[version.channel],
             'review': absolutify(
                 reverse(
                     'reviewers.review',
@@ -209,15 +210,18 @@ def send_notifications(sender=None, instance=None, signal=None, **kw):
             and instance.channel == amo.CHANNEL_LISTED
             and any(acl.action_allowed_for(user, perm) for perm in listed_perms)
         )
+        action_allowed_unlisted = any(
+            acl.action_allowed_for(user, perm) for perm in unlisted_perms
+        )
         is_unlisted_reviewer_and_unlisted_submission = (
             subscriber.channel == amo.CHANNEL_UNLISTED
             and instance.channel == amo.CHANNEL_UNLISTED
-            and any(acl.action_allowed_for(user, perm) for perm in unlisted_perms)
+            and action_allowed_unlisted
         )
         is_unlisted_reviewer_and_enterprise_submission = (
             subscriber.channel == amo.CHANNEL_ENTERPRISE
             and instance.channel == amo.CHANNEL_ENTERPRISE
-            and any(acl.action_allowed_for(user, perm) for perm in unlisted_perms)
+            and action_allowed_unlisted
         )
         if is_active_user and (
             is_reviewer_and_listed_submission

--- a/src/olympia/reviewers/templates/reviewers/emails/notify_update.ltxt
+++ b/src/olympia/reviewers/templates/reviewers/emails/notify_update.ltxt
@@ -14,4 +14,4 @@ Thanks!
 Mozilla Add-ons
 {{ SITE_URL }}
 
-This is a notification sent to you because you requested a follow up email regarding new version uploads for {{ name }}. To unsubscribe, visit the review link above and uncheck the respective "Notify me about new <channel> versions" checkbox.
+This is a notification sent to you because you requested a follow up email regarding new version uploads for {{ name }}. To unsubscribe, visit the review link above and uncheck the respective "Notify me about new {{ channel }} versions" checkbox.

--- a/src/olympia/reviewers/templates/reviewers/emails/notify_update.ltxt
+++ b/src/olympia/reviewers/templates/reviewers/emails/notify_update.ltxt
@@ -14,4 +14,4 @@ Thanks!
 Mozilla Add-ons
 {{ SITE_URL }}
 
-This is a notification sent to you because you requested a follow up email regarding new version uploads for {{ name }}. To unsubscribe, visit the review link above and uncheck the respective "Notify me about new listed/unlisted versions" checkbox.
+This is a notification sent to you because you requested a follow up email regarding new version uploads for {{ name }}. To unsubscribe, visit the review link above and uncheck the respective "Notify me about new <channel> versions" checkbox.

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -310,7 +310,7 @@
   <p><strong>More Actions</strong></p>
   <div class="more-actions-inner">
     <ul>
-      {% if not addon.is_deleted and not addon.has_enterprise_versions()  %}
+      {% if not addon.is_deleted  %}
         {% if acl_is_reviewer or action_allowed_for(request.user, amo.permissions.REVIEWER_TOOLS_VIEW) %}
         <li>
           <input type="checkbox" id="notify_new_listed_versions"
@@ -327,6 +327,15 @@
             data-api-url-unsubscribe-unlisted="{{ drf_url('reviewers-addon-unsubscribe-unlisted', addon.pk) }}"
             {% if subscribed_unlisted %}checked="checked"{% endif %} autocomplete="off" />
             <label for="notify_new_unlisted_versions">Notify me about new unlisted versions</label>
+        </li>
+        {% endif %}
+        {% if acl_is_unlisted_addons_viewer_or_reviewer and waffle.switch('enterprise-channel') %}
+        <li>
+          <input type="checkbox" id="notify_new_enterprise_versions"
+            data-api-url-subscribe-enterprise="{{ drf_url('reviewers-addon-subscribe-enterprise', addon.pk) }}"
+            data-api-url-unsubscribe-enterprise="{{ drf_url('reviewers-addon-unsubscribe-enterprise', addon.pk) }}"
+            {% if subscribed_enterprise %}checked="checked"{% endif %} autocomplete="off" />
+            <label for="notify_new_enterprise_versions">Notify me about new enterprise versions</label>
         </li>
         {% endif %}
       {% endif %}

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3717,6 +3717,19 @@ class TestReview(ReviewBase):
         ]
         check_links(expected, doc('#actions-addon a'))
 
+    def test_enterprise_subscription_when_waffle_disabled(self):
+        self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
+        self.login_as_reviewer()
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        subscribe_listed_input = doc('#notify_new_listed_versions')[0]
+        assert 'checked' not in subscribe_listed_input.attrib
+        subscribe_unlisted_input = doc('#notify_new_unlisted_versions')[0]
+        assert 'checked' not in subscribe_unlisted_input.attrib
+        assert not doc('#notify_new_enterprise_versions')
+
+    @override_switch('enterprise-channel', active=True)
     def test_extra_actions_subscribe_checked_state(self):
         self.grant_permission(self.reviewer, amo.permissions.ADDONS_REVIEW_UNLISTED)
         self.login_as_reviewer()
@@ -3727,6 +3740,8 @@ class TestReview(ReviewBase):
         assert 'checked' not in subscribe_listed_input.attrib
         subscribe_unlisted_input = doc('#notify_new_unlisted_versions')[0]
         assert 'checked' not in subscribe_unlisted_input.attrib
+        subscribe_enterprise_input = doc('#notify_new_enterprise_versions')[0]
+        assert 'checked' not in subscribe_enterprise_input.attrib
 
         ReviewerSubscription.objects.create(
             addon=self.addon, user=self.reviewer, channel=amo.CHANNEL_LISTED
@@ -3744,6 +3759,15 @@ class TestReview(ReviewBase):
         assert response.status_code == 200
         doc = pq(response.content)
         subscribe_input = doc('#notify_new_unlisted_versions')[0]
+        assert subscribe_input.attrib['checked'] == 'checked'
+
+        ReviewerSubscription.objects.create(
+            addon=self.addon, user=self.reviewer, channel=amo.CHANNEL_ENTERPRISE
+        )
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        subscribe_input = doc('#notify_new_enterprise_versions')[0]
         assert subscribe_input.attrib['checked'] == 'checked'
 
     def test_extra_actions_token(self):
@@ -7659,6 +7683,12 @@ class TestAddonReviewerViewSet(TestCase):
         self.unsubscribe_url_unlisted = reverse_ns(
             'reviewers-addon-unsubscribe-unlisted', kwargs={'pk': self.addon.pk}
         )
+        self.subscribe_url_enterprise = reverse_ns(
+            'reviewers-addon-subscribe-enterprise', kwargs={'pk': self.addon.pk}
+        )
+        self.unsubscribe_url_enterprise = reverse_ns(
+            'reviewers-addon-unsubscribe-enterprise', kwargs={'pk': self.addon.pk}
+        )
         self.flags_url = reverse_ns(
             'reviewers-addon-flags', kwargs={'pk': self.addon.pk}
         )
@@ -7764,6 +7794,20 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 1
 
+    def test_subscribe_enterprise(self):
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
+        self.client.login_api(self.user)
+        response = self.client.post(self.subscribe_url_enterprise)
+        assert response.status_code == 202
+        assert ReviewerSubscription.objects.count() == 1
+
+    def test_subscribe_enterprise_viewer(self):
+        self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
+        self.client.login_api(self.user)
+        response = self.client.post(self.subscribe_url_enterprise)
+        assert response.status_code == 202
+        assert ReviewerSubscription.objects.count() == 1
+
     def test_unsubscribe_not_logged_in(self):
         response = self.client.post(self.unsubscribe_url_listed)
         assert response.status_code == 401
@@ -7845,6 +7889,26 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
         self.client.login_api(self.user)
         response = self.client.post(self.unsubscribe_url_unlisted)
+        assert response.status_code == 202
+        assert ReviewerSubscription.objects.count() == 0
+
+    def test_unsubscribe_enterprise(self):
+        ReviewerSubscription.objects.create(
+            user=self.user, addon=self.addon, channel=amo.CHANNEL_ENTERPRISE
+        )
+        self.grant_permission(self.user, amo.permissions.ADDONS_REVIEW_UNLISTED)
+        self.client.login_api(self.user)
+        response = self.client.post(self.unsubscribe_url_enterprise)
+        assert response.status_code == 202
+        assert ReviewerSubscription.objects.count() == 0
+
+    def test_unsubscribe_enterprise_viewer(self):
+        ReviewerSubscription.objects.create(
+            user=self.user, addon=self.addon, channel=amo.CHANNEL_ENTERPRISE
+        )
+        self.grant_permission(self.user, amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW)
+        self.client.login_api(self.user)
+        response = self.client.post(self.unsubscribe_url_enterprise)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 0
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -755,6 +755,9 @@ def review(request, addon, channel=None):
         subscribed_unlisted=ReviewerSubscription.objects.filter(
             user=request.user, addon=addon, channel=amo.CHANNEL_UNLISTED
         ).exists(),
+        subscribed_enterprise=ReviewerSubscription.objects.filter(
+            user=request.user, addon=addon, channel=amo.CHANNEL_ENTERPRISE
+        ).exists(),
         user_ratings=user_ratings,
         version=version,
         VERSION_ADU_LIMIT=VERSION_ADU_LIMIT,
@@ -1043,28 +1046,36 @@ class AddonReviewerViewSet(GenericViewSet):
     @drf_action(
         detail=True, methods=['post'], permission_classes=[AllowAnyKindOfReviewer]
     )
-    def subscribe_listed(self, request, **kwargs):
+    def unsubscribe(self, request, **kwargs):
+        return self.unsubscribe_listed(request, **kwargs)
+
+    def _subscribe_to_channel(self, request, channel, **kwargs):
         addon = get_object_or_404(Addon, pk=kwargs['pk'])
         ReviewerSubscription.objects.get_or_create(
-            user=request.user, addon=addon, channel=amo.CHANNEL_LISTED
+            user=request.user, addon=addon, channel=channel
         )
+        return Response(status=status.HTTP_202_ACCEPTED)
+
+    def _unsubscribe_from_channel(self, request, channel, **kwargs):
+        addon = get_object_or_404(Addon, pk=kwargs['pk'])
+        ReviewerSubscription.objects.filter(
+            user=request.user, addon=addon, channel=channel
+        ).delete()
         return Response(status=status.HTTP_202_ACCEPTED)
 
     @drf_action(
         detail=True, methods=['post'], permission_classes=[AllowAnyKindOfReviewer]
     )
-    def unsubscribe(self, request, **kwargs):
-        return self.unsubscribe_listed(request, **kwargs)
+    def subscribe_listed(self, request, **kwargs):
+        return self._subscribe_to_channel(request, channel=amo.CHANNEL_LISTED, **kwargs)
 
     @drf_action(
         detail=True, methods=['post'], permission_classes=[AllowAnyKindOfReviewer]
     )
     def unsubscribe_listed(self, request, **kwargs):
-        addon = get_object_or_404(Addon, pk=kwargs['pk'])
-        ReviewerSubscription.objects.filter(
-            user=request.user, addon=addon, channel=amo.CHANNEL_LISTED
-        ).delete()
-        return Response(status=status.HTTP_202_ACCEPTED)
+        return self._unsubscribe_from_channel(
+            request, channel=amo.CHANNEL_LISTED, **kwargs
+        )
 
     @drf_action(
         detail=True,
@@ -1072,11 +1083,9 @@ class AddonReviewerViewSet(GenericViewSet):
         permission_classes=[AllowUnlistedViewerOrReviewer],
     )
     def subscribe_unlisted(self, request, **kwargs):
-        addon = get_object_or_404(Addon, pk=kwargs['pk'])
-        ReviewerSubscription.objects.get_or_create(
-            user=request.user, addon=addon, channel=amo.CHANNEL_UNLISTED
+        return self._subscribe_to_channel(
+            request, channel=amo.CHANNEL_UNLISTED, **kwargs
         )
-        return Response(status=status.HTTP_202_ACCEPTED)
 
     @drf_action(
         detail=True,
@@ -1084,11 +1093,29 @@ class AddonReviewerViewSet(GenericViewSet):
         permission_classes=[AllowUnlistedViewerOrReviewer],
     )
     def unsubscribe_unlisted(self, request, **kwargs):
-        addon = get_object_or_404(Addon, pk=kwargs['pk'])
-        ReviewerSubscription.objects.filter(
-            user=request.user, addon=addon, channel=amo.CHANNEL_UNLISTED
-        ).delete()
-        return Response(status=status.HTTP_202_ACCEPTED)
+        return self._unsubscribe_from_channel(
+            request, channel=amo.CHANNEL_UNLISTED, **kwargs
+        )
+
+    @drf_action(
+        detail=True,
+        methods=['post'],
+        permission_classes=[AllowUnlistedViewerOrReviewer],
+    )
+    def subscribe_enterprise(self, request, **kwargs):
+        return self._subscribe_to_channel(
+            request, channel=amo.CHANNEL_ENTERPRISE, **kwargs
+        )
+
+    @drf_action(
+        detail=True,
+        methods=['post'],
+        permission_classes=[AllowUnlistedViewerOrReviewer],
+    )
+    def unsubscribe_enterprise(self, request, **kwargs):
+        return self._unsubscribe_from_channel(
+            request, channel=amo.CHANNEL_ENTERPRISE, **kwargs
+        )
 
     @drf_action(
         detail=True,
@@ -1146,7 +1173,7 @@ class AddonReviewerViewSet(GenericViewSet):
     def json_file_validation(self, request, **kwargs):
         addon = get_object_or_404(Addon.unfiltered.id_or_slug(kwargs['pk']))
         file = get_object_or_404(File, version__addon=addon, id=kwargs['file_id'])
-        if file.version.channel == amo.CHANNEL_UNLISTED:
+        if file.version.channel in (amo.CHANNEL_UNLISTED, amo.CHANNEL_ENTERPRISE):
             if not acl.is_unlisted_addons_viewer_or_reviewer(request.user):
                 raise PermissionDenied
         elif not acl.is_reviewer(request.user, addon):

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -464,6 +464,23 @@ function initExtraReviewActions() {
     }),
   );
 
+  $('#notify_new_enterprise_versions').click(
+    _pd(function () {
+      let $input = $(this).prop('disabled', true); // Prevent double-send.
+      let checked = !$input.prop('checked'); // It's already changed.
+      let apiUrl;
+      if (checked) {
+        apiUrl = $input.data('api-url-unsubscribe-enterprise');
+      } else {
+        apiUrl = $input.data('api-url-subscribe-enterprise');
+      }
+      callReviewersAPI(apiUrl, 'post', null, function () {
+        $input.prop('disabled', false);
+        $input.prop('checked', !checked);
+      });
+    }),
+  );
+
   $('#due_date_update').on(
     'change',
     _pd(function () {


### PR DESCRIPTION
Relates to mozilla/addons#14855

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Enables reviewer e-mail subscriptions to new enterprise versions for an add-on.
<img width="1330" height="229" alt="image" src="https://github.com/user-attachments/assets/367aec5c-dad8-49b6-8ec8-3f4797bb3a8f" />
<img width="1712" height="508" alt="image" src="https://github.com/user-attachments/assets/b42e4096-4e65-4318-be9c-962c891cda84" />

### Testing

1. Enable `enterprise-channel` waffle switch.
3. Navigate to a `reviewers/review-<channel>` page for an add-on.
4. Toggle `Notify me about new enterprise versions`.
5. Upload a new enterprise version of said add-on.
6. In admin's FakeEmail, the logged-in email should receive a notification that a new enterprise version has been uploaded.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
