### PR TITLE
Fix locales job by adding missing GH_TOKEN and skipping if there are no template changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,7 @@ jobs:
           github.event_name == 'pull_request'
         shell: bash
         env:
+          GH_TOKEN: ${{ secrets.L10N_GITHUB_TOKEN || github.token }}
           is_fork: ${{ needs.context.outputs.is_fork }}
           is_default_branch: ${{ needs.context.outputs.is_default_branch }}
           is_push: ${{ github.event_name == 'push' }}

--- a/scripts/run_l10n_extraction.sh
+++ b/scripts/run_l10n_extraction.sh
@@ -38,6 +38,17 @@ DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE} pybabel extract -F babeljs.cfg 
 
 pushd locale > /dev/null
 
+# Bail early if no changes to the template files.
+DIFF_WITH_ONE_LINE_CHANGE="2 files changed, 2 insertions(+), 2 deletions(-)"
+git_diff_stat=$(git diff --shortstat templates/LC_MESSAGES)
+info "git_diff_stat: $git_diff_stat"
+
+if [[ -z "$git_diff_stat" ]] || [[ "$git_diff_stat" == *"$DIFF_WITH_ONE_LINE_CHANGE"* ]]; then
+  info """
+    No substantial changes to l10n strings found. Exiting the process.
+  """
+  exit 0
+fi
 
 info "Merging any new keys from templates/LC_MESSAGES/django.pot"
 for i in `find . -name "django.po" | grep -v "en_US"`; do


### PR DESCRIPTION
That same logic was already used in addons-frontend to skip extracting if there are no changes to the template. This avoid creating useless changes to .po files that only contain line-wrapping changes (we also have that in the pushing script, and it's also useful there, but only if we also do it here to avoid merging `.po` files and creating those extra changes).

We also need GH_TOKEN to create the PR when there are changes.

Should fix the build on `master`.