### PR TITLE
Remove --no-location from l10n extraction since Pontoon adds it back

### DIFF
--- a/scripts/run_l10n_extraction.sh
+++ b/scripts/run_l10n_extraction.sh
@@ -15,7 +15,7 @@ set -u
 DJANGO_SETTINGS_MODULE=settings
 
 # gettext flags
-CLEAN_FLAGS="--no-obsolete --width=200 --no-location"
+CLEAN_FLAGS="--no-obsolete --width=200"
 MERGE_FLAGS="--update --width=200 --backup=none --no-fuzzy-matching"
 UNIQ_FLAGS="--width=200"
 LOCALE_TEMPLATE_DIR="locale/templates/LC_MESSAGES"


### PR DESCRIPTION
Follow-up for https://github.com/mozilla/addons/issues/16413

Locale extraction is working (see https://github.com/mozilla-l10n/addons-server-l10n/pull/2/) but when committing .po files, Pontoon adds the location back, so removing it in our extraction is pointless - it's having the exact opposite effect as intended, creating larger, noisier diffs.