### PR TITLE
Skip webhooks for langpacks

### DIFF
--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -708,6 +708,10 @@ class AutoApprovalSummary(ModelBase):
         if waffle.switch_is_active('disable-check-is-waiting-on-scanners'):
             return False
 
+        # Prevent langpacks from getting stuck on waiting
+        if version.addon.type == amo.ADDON_LPAPP:
+            return False
+
         webhook_event_ids = ScannerWebhookEvent.objects.filter(
             # We want to find the active events to wait for...
             event__in=WEBHOOK_EVENTS_BLOCKING_AUTO_APPROVAL,

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1095,6 +1095,18 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
 
         assert not run_actions_mock.called
 
+    @mock.patch.object(ScannerResult, 'run_actions')
+    def test_langpack_does_not_wait_on_scanners(self, run_actions_mock):
+        self.addon.update(type=amo.ADDON_LPAPP)
+        # Keep the version out of auto-approval so that it remains a candidate.
+        AddonReviewerFlags.objects.create(addon=self.addon, auto_approval_disabled=True)
+        self.create_pending_webhook_scanner_result()
+
+        call_command('auto_approve')
+
+        assert run_actions_mock.called
+        assert self.version.autoapprovalsummary.scanner_actions_executed
+
     def test_run_disapprove(self):
         def check_assertions():
             # Hasn't been approved, a NHR was created.

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -443,6 +443,10 @@ def call_webhooks_on_version_created(version_pk):
 
         version = Version.unfiltered.get(pk=version_pk)
 
+        if version.addon.type == amo.ADDON_LPAPP:
+            log.info('Skipping webhooks on langpack %s', version_pk)
+            return
+
         payload = {
             'addon': WebhookAddonSerializer(version.addon).data,
             'version': WebhookVersionSerializer(version).data,

--- a/src/olympia/versions/tests/test_tasks.py
+++ b/src/olympia/versions/tests/test_tasks.py
@@ -1051,6 +1051,15 @@ class TestCallWebhooksOnVersionCreated(TestCase):
         )
 
     @mock.patch('olympia.versions.tasks.call_webhooks')
+    def test_skip_webhooks_on_langpack_created(self, call_webhooks_mock):
+        addon = addon_factory(type=amo.ADDON_LPAPP)
+        version = version_factory(addon=addon)
+        addon.reload()
+
+        call_webhooks_on_version_created(version.pk)
+        call_webhooks_mock.assert_not_called()
+
+    @mock.patch('olympia.versions.tasks.call_webhooks')
     def test_call_with_mock_and_deleted_version(self, call_webhooks_mock):
         addon = addon_factory()
         version = version_factory(addon=addon)


### PR DESCRIPTION
Fixes mozilla/addons#16414

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Skips webhooks call on langpacks and allows them to bypass waiting on scanners. 

### Testing

1. Upload langpack [xpi](https://support.mozilla.org/en-US/kb/deploying-firefox-language-packs)
2. `docker compose logs` contains `Skipping webhooks call on langpack {version}`.
3. Is not blocked by `check_is_waiting_on_scanners` when an expected `ScannerResult` is missing

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
