### PR TITLE
Allow unreject action in reviewer tools on versions rejected by automation

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -777,7 +777,6 @@ class TestReviewHelper(TestReviewHelperBase):
         ]
 
         self.file.update(status=amo.STATUS_DISABLED)
-        self.file.version.update(human_review_date=datetime.now())
         self.addon.update(status=amo.STATUS_NULL)
         actions = list(self.get_helper().actions.keys())
         assert expected == actions

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -498,9 +498,7 @@ class ReviewHelper:
         )
         version_is_unreviewed = self.version and self.version.is_unreviewed
         version_was_rejected = bool(
-            self.version
-            and self.version.file.status == amo.STATUS_DISABLED
-            and self.version.human_review_date
+            self.version and self.version.file.status == amo.STATUS_DISABLED
         )
         addon_is_valid = self.addon.is_public() or self.addon.is_unreviewed()
         addon_is_valid_and_version_is_listed = addon_is_valid and version_is_listed


### PR DESCRIPTION
Fixes https://mozilla-hub.atlassian.net/browse/AMOENG-2775

### Description

The "Unreject" action was only available if the version had been rejected by a human, but we have automated rejections through scanners nowadays so this condition is preventing appeals on those automated decisions from being granted.

### Testing

- As an admin, set up a policy that would lead to a rejection action
- As an admin, set up a scanner rule that would use that policy and be triggered on the submission you're about to make in the next step (easiest is probably to make sure the switch for NARC, `enable-narc` is on, and just make a rule that matches the name of the add-on)
- As a developer, submit a listed add-on
- Run `auto_approve`, the version should be rejected
- As the developer, appeal the decision as the author using the link provided in the email
- As a reviewer, try to unreject the version - you should be able to (you will need to resolve the appeal separately)

### Notes
- This only applies to the **listed** channel (on unlisted channel, you can unreject multiple versions and that condition is not present)
- Waffle switch `enable-policy-review-selection` should be **off** for this
- Unreject is silent and doesn't resolve jobs, so the appeal must be resolved separately. That's something `enable-policy-review-selection` should solve in the future, everything should be more consistent.