### PR TITLE
Move the auto-approval blocking webhook events to the scanners package

### DIFF
--- a/src/olympia/constants/scanners.py
+++ b/src/olympia/constants/scanners.py
@@ -88,6 +88,12 @@ WEBHOOK_EVENTS = {
     WEBHOOK_PUSH: 'push',
 }
 
+# Events we wait on before auto-approving a version.
+WEBHOOK_EVENTS_BLOCKING_AUTO_APPROVAL = [
+    WEBHOOK_DURING_VALIDATION,
+    WEBHOOK_ON_VERSION_CREATED,
+]
+
 # Special rule name used as fallback when a scanner has no better rule to
 # associate with an annotation.
 ANNOTATIONS_RULE_NAME = 'ANNOTATIONS'

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -23,10 +23,6 @@ from olympia.amo.enum import EnumChoices
 from olympia.amo.models import ModelBase
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import send_mail
-from olympia.constants.scanners import (
-    WEBHOOK_DURING_VALIDATION,
-    WEBHOOK_ON_VERSION_CREATED,
-)
 from olympia.files.models import File, FileValidation
 from olympia.ratings.models import Rating
 from olympia.scanners.models import ScannerResult, ScannerWebhookEvent
@@ -76,11 +72,6 @@ VIEW_QUEUE_FLAGS = (
         'Unlisted Auto-approval delayed indefinitely',
     ),
 )
-
-WEBHOOK_EVENTS_BLOCKING_AUTO_APPROVAL = [
-    WEBHOOK_DURING_VALIDATION,
-    WEBHOOK_ON_VERSION_CREATED,
-]
 
 
 def get_reviewing_cache_key(addon_id):
@@ -712,16 +703,8 @@ class AutoApprovalSummary(ModelBase):
         if version.addon.type == amo.ADDON_LPAPP:
             return False
 
-        webhook_event_ids = ScannerWebhookEvent.objects.filter(
-            # We want to find the active events to wait for...
-            event__in=WEBHOOK_EVENTS_BLOCKING_AUTO_APPROVAL,
-            is_active=True,
-            # ...but only for scanners that are active...
-            webhook__is_active=True,
-            # ...and only if the scanner hasn't been modified after the version
-            # was created, in order to avoid waiting indefinitely on scanners
-            # that were enabled *after*.
-            webhook__modified__lte=version.created,
+        webhook_event_ids = ScannerWebhookEvent.blocking_auto_approval_for(
+            version
         ).values_list('pk', flat=True)
 
         # If there is no event, that means no active scanner is listening to

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -48,6 +48,7 @@ from olympia.constants.scanners import (
     SCHEDULED,
     WEBHOOK,
     WEBHOOK_EVENTS,
+    WEBHOOK_EVENTS_BLOCKING_AUTO_APPROVAL,
     YARA,
 )
 from olympia.files.models import FileUpload
@@ -396,6 +397,21 @@ class ScannerWebhookEvent(ModelBase):
     class Meta:
         db_table = 'scanners_webhook_events'
         unique_together = ('webhook', 'event')
+
+    @classmethod
+    def blocking_auto_approval_for(cls, version):
+        """Return the events we wait on before auto-approving the version."""
+        return cls.objects.filter(
+            # We want to find the active events to wait for...
+            event__in=WEBHOOK_EVENTS_BLOCKING_AUTO_APPROVAL,
+            is_active=True,
+            # ...but only for scanners that are active...
+            webhook__is_active=True,
+            # ...and only if the scanner hasn't been modified after the version
+            # was created, in order to avoid waiting indefinitely on scanners
+            # that were enabled *after*.
+            webhook__modified__lte=version.created,
+        )
 
     def __str__(self):
         return f'{self.webhook} ({WEBHOOK_EVENTS.get(self.event)})'


### PR DESCRIPTION
Refs https://github.com/mozilla/addons/issues/16428

---

The list of events lived in `olympia.reviewers.models` while it is
really scanner configuration, and the query to find the matching events
is about to be needed outside of `AutoApprovalSummary`.