### PR TITLE
Extract a build_webhook_payload() helper for scanner webhooks

### DIFF
--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -42,6 +42,7 @@ from olympia.constants.scanners import (
     WEBHOOK,
     WEBHOOK_DURING_VALIDATION,
     WEBHOOK_EVENTS,
+    WEBHOOK_ON_VERSION_CREATED,
     YARA,
 )
 from olympia.devhub.tasks import validation_task
@@ -84,7 +85,7 @@ def call_webhooks_during_validation(results, upload_pk):
 
         call_webhooks(
             event_id=WEBHOOK_DURING_VALIDATION,
-            payload={'download_url': upload.get_authenticated_download_url()},
+            payload=build_webhook_payload(WEBHOOK_DURING_VALIDATION, upload=upload),
             upload=upload,
         )
 
@@ -141,6 +142,27 @@ def call_webhooks(event_id, payload, upload=None, version=None, activity_log=Non
             statsd.incr(f'{statsd_name}.failure')
             log.exception('Error while calling webhook "%s".', event.webhook.name)
             raise exc
+
+
+def build_webhook_payload(event_id, *, upload=None, version=None):
+    """Return the payload for the given event.
+
+    Only supports the events we might have to deliver more than once."""
+    from olympia.scanners.serializers import (
+        WebhookAddonSerializer,
+        WebhookVersionSerializer,
+    )
+
+    if event_id == WEBHOOK_DURING_VALIDATION:
+        return {'download_url': upload.get_authenticated_download_url()}
+
+    if event_id == WEBHOOK_ON_VERSION_CREATED:
+        return {
+            'addon': WebhookAddonSerializer(version.addon).data,
+            'version': WebhookVersionSerializer(version).data,
+        }
+
+    raise ValueError(f'No payload for webhook event {event_id}')
 
 
 def _call_webhook(webhook, payload):

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -28,7 +28,7 @@ from olympia.files.utils import get_background_images
 from olympia.lib.crypto.tasks import duplicate_addon_version
 from olympia.reviewers.models import NeedsHumanReview
 from olympia.scanners.models import ScannerResult
-from olympia.scanners.tasks import call_webhooks
+from olympia.scanners.tasks import build_webhook_payload, call_webhooks
 from olympia.users.models import UserProfile
 from olympia.users.utils import get_task_user
 from olympia.versions.compare import VersionString
@@ -436,24 +436,15 @@ def call_webhooks_on_version_created(version_pk):
     log.info('Calling webhooks for new Version %s', version_pk)
 
     try:
-        from olympia.scanners.serializers import (
-            WebhookAddonSerializer,
-            WebhookVersionSerializer,
-        )
-
         version = Version.unfiltered.get(pk=version_pk)
 
         if version.addon.type == amo.ADDON_LPAPP:
             log.info('Skipping webhooks on langpack %s', version_pk)
             return
 
-        payload = {
-            'addon': WebhookAddonSerializer(version.addon).data,
-            'version': WebhookVersionSerializer(version).data,
-        }
         call_webhooks(
             event_id=WEBHOOK_ON_VERSION_CREATED,
-            payload=payload,
+            payload=build_webhook_payload(WEBHOOK_ON_VERSION_CREATED, version=version),
             version=version,
         )
     except Exception:


### PR DESCRIPTION
Refs https://github.com/mozilla/addons/issues/16428

---

The payload for `during_validation` and `on_version_created` was built
inline at each call site, which means it can only be built once, when
the event fires. Move both to a single `build_webhook_payload()` so that
the payload can be rebuilt later from an upload or a version, which
we'll need soon.