### PR TITLE
order CinderPolicy instances shown in the reviewer tools form

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -934,9 +934,11 @@ class ReviewForm(forms.Form):
             if self.helper.addon.type == amo.ADDON_STATICTHEME
             else POLICY_EXPOSURE.FOR_EXTENSIONS
         )
-        self.fields['cinder_policies'].queryset = CinderPolicy.objects.filter(
-            expose_in_reviewer_tools__in=policy_choices
-        ).select_related('parent')
+        self.fields['cinder_policies'].queryset = (
+            CinderPolicy.objects.filter(expose_in_reviewer_tools__in=policy_choices)
+            .select_related('parent')
+            .order_by('parent__name', 'name')
+        )
 
         # Pass on the reviewer tools actions so we can set the show/hide on policies
         self.fields['cinder_policies'].widget.helper_actions = self.helper.actions

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -1637,16 +1637,16 @@ class TestReviewForm(TestCase):
 
     def test_cinder_policies_choices(self):
         both_policy_exposed = CinderPolicy.objects.create(
-            uuid='1', name='foo', expose_in_reviewer_tools=POLICY_EXPOSURE.BOTH
+            uuid='1', name='both', expose_in_reviewer_tools=POLICY_EXPOSURE.BOTH
         )
         ext_policy_exposed = CinderPolicy.objects.create(
-            uuid='2', name='foo', expose_in_reviewer_tools=POLICY_EXPOSURE.EXTENSION
+            uuid='2', name='extn', expose_in_reviewer_tools=POLICY_EXPOSURE.EXTENSION
         )
         CinderPolicy.objects.create(
-            uuid='3', name='baa', expose_in_reviewer_tools=POLICY_EXPOSURE.NONE
+            uuid='3', name='none', expose_in_reviewer_tools=POLICY_EXPOSURE.NONE
         )
         thm_policy_exposed = CinderPolicy.objects.create(
-            uuid='4', name='baa', expose_in_reviewer_tools=POLICY_EXPOSURE.THEME
+            uuid='4', name='theme', expose_in_reviewer_tools=POLICY_EXPOSURE.THEME
         )
 
         form = self.get_form()
@@ -1726,39 +1726,39 @@ class TestReviewForm(TestCase):
 
         content = str(form['cinder_policies'])
         doc = pq(content)
-        label_0 = doc('#id_cinder_policies_0')
-        label_1 = doc('#id_cinder_policies_1')
-        label_2 = doc('#id_cinder_policies_2')
+        label_approve = doc('#id_cinder_policies_0')
+        label_reject = doc('#id_cinder_policies_1')
+        label_empty = doc('#id_cinder_policies_2')
 
-        assert label_0.attr['class'] == 'data-toggle'
-        assert label_0.attr['data-value'] == ''
-        assert label_0.attr['data-enforcement-primary-actions'] == '[]'
-        assert label_0.attr['data-enforcement-followup-actions'] == '[]'
-        assert label_0.attr['data-enforcement-actions-order'] == ''
-        assert label_0('input')[0].type == 'checkbox'
+        assert label_empty.attr['class'] == 'data-toggle'
+        assert label_empty.attr['data-value'] == ''
+        assert label_empty.attr['data-enforcement-primary-actions'] == '[]'
+        assert label_empty.attr['data-enforcement-followup-actions'] == '[]'
+        assert label_empty.attr['data-enforcement-actions-order'] == ''
+        assert label_empty('input')[0].type == 'checkbox'
 
-        assert label_1.attr['class'] == 'data-toggle'
-        assert label_1.attr['data-value'] == 'reject reject_multiple_versions'
+        assert label_reject.attr['class'] == 'data-toggle'
+        assert label_reject.attr['data-value'] == 'reject reject_multiple_versions'
         assert (
-            label_1.attr['data-enforcement-primary-actions']
+            label_reject.attr['data-enforcement-primary-actions']
             == f'[{DECISION_ACTIONS.AMO_DISABLE_ADDON.value}]'
         )
-        assert label_1.attr['data-enforcement-followup-actions'] == (
+        assert label_reject.attr['data-enforcement-followup-actions'] == (
             f'[{DECISION_ACTIONS.AMO_FU_DELAY_LONG_SOFT_BLOCK_ADDON.value}, '
             f'{DECISION_ACTIONS.AMO_FU_DELAY_SHORT_HARD_BLOCK_ADDON.value}]'
         )
-        assert label_1.attr['data-enforcement-actions-order'] == '090500'
-        assert label_1('input')[0].type == 'checkbox'
+        assert label_reject.attr['data-enforcement-actions-order'] == '090500'
+        assert label_reject('input')[0].type == 'checkbox'
 
-        assert label_2.attr['class'] == 'data-toggle'
-        assert label_2.attr['data-value'] == 'public'
+        assert label_approve.attr['class'] == 'data-toggle'
+        assert label_approve.attr['data-value'] == 'public'
         assert (
-            label_2.attr['data-enforcement-primary-actions']
+            label_approve.attr['data-enforcement-primary-actions']
             == f'[{DECISION_ACTIONS.AMO_APPROVE.value}]'
         )
-        assert label_2.attr['data-enforcement-followup-actions'] == '[]'
-        assert label_2.attr['data-enforcement-actions-order'] == ''
-        assert label_2('input')[0].type == 'radio'
+        assert label_approve.attr['data-enforcement-followup-actions'] == '[]'
+        assert label_approve.attr['data-enforcement-actions-order'] == ''
+        assert label_approve('input')[0].type == 'radio'
 
     def test_policy_values_fields(self):
         policy_0 = CinderPolicy.objects.create(


### PR DESCRIPTION
Fixes mozilla/addons#16422

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds the same ordering as used in the admin for cinder policies, which is parent policy name, then policy name.

<img width="1010" height="490" alt="image" src="https://github.com/user-attachments/assets/edf605fe-338d-4cfb-a167-358512045ea4" />


### Context

<!--
Often a pull request contains changes that are not fully self explanatory. Maybe this PR is a part of a series,
or maybe it is a partial change now with a more ambitious plan for the future. Add this additional context here.
If it is not relevant for your PR, remove this section.
-->

### Testing

- should be pretty obvious from the reviewer tools - regardless of how new or old the policy is, the list is in alphabetical order.
- To validate you can use django shell to update one of the policy (or parent policy) names.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
