### PR TITLE
Run actions/policies when a pushed rule matches

### DIFF
--- a/docs/topics/development/scanner_pipeline.md
+++ b/docs/topics/development/scanner_pipeline.md
@@ -420,6 +420,7 @@ The payload sent looks like this:
 }
 ```
 
+(scanner-push)=
 ### `push`
 
 In addition to responding to AMO-initiated webhook events, a scanner can
@@ -463,6 +464,16 @@ A push is rejected with `409 Conflict` when any rule in `matchedRules` has
 already been pushed for the same version via the same webhook. Only rules that
 exist as [scanner rules](#scanner-rules) are considered for this check.
 
+#### Actions
+
+When a pushed result matches at least one [scanner rule](#scanner-rules), the
+[actions](#scanner-actions) of those rules are executed asynchronously.
+
+Only the rules of the result that was just pushed are considered, unlike the
+auto-approval flow which considers every rule matched on the version. A rule
+matched earlier by another scanner is therefore not re-run, and the policy it
+may be attached to is not enforced a second time.
+
 ### Adding a new event
 
 1. Add a constant for the new event in `src/olympia/constants/scanners.py`. The
@@ -497,6 +508,15 @@ A scanner action is some logic that can be applied to an add-on version. For
 example, flagging a version for manual review is a scanner action.
 
 These actions are defined in `src/olympia/scanners/actions.py`.
+
+Actions are executed by `ScannerResult.run_actions()`, which is called:
+
+- by the auto-approval cron job, once per version, over every rule matched on
+  that version;
+- when a scanner [pushes](#scanner-push) a result, over the rules of that result
+  only;
+- when narc re-scans a version and finds new matches, over every rule matched
+  on that version.
 
 [addons-scanner-utils]: https://github.com/mozilla/addons-scanner-utils
 [hmac]: https://en.wikipedia.org/wiki/HMAC

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -830,6 +830,7 @@ CELERY_TASK_ROUTES = {
     'olympia.devhub.tasks.validate_upload': {'queue': 'devhub'},
     'olympia.files.tasks.repack_fileupload': {'queue': 'devhub'},
     'olympia.scanners.tasks.call_webhooks_during_validation': {'queue': 'devhub'},
+    'olympia.scanners.tasks.run_actions_for_scanner_result': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_narc_on_version': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_yara': {'queue': 'devhub'},
     'olympia.versions.tasks.call_webhooks_on_source_code_uploaded': {'queue': 'devhub'},

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -475,19 +475,35 @@ class ScannerResult(AbstractScannerResult):
             self.matched_rules.add(scanner_rule)
 
     @classmethod
-    def run_actions(cls, version):
+    def get_matched_rules_for_version(cls, version, *, rules=None):
+        """Active rules matched by the results of `version`, optionally narrowed
+        down to `rules`, a list of pks or a queryset of rules (e.g. the rules of
+        a single pushed result)."""
+        result_query_name = cls._meta.get_field('matched_rules').related_query_name()
+
+        qs = cls.rule_model.objects.filter(
+            **{f'{result_query_name}__version': version, 'is_active': True}
+        )
+        if rules is not None:
+            qs = qs.filter(pk__in=rules)
+        if version.addon.is_promoted:
+            qs = qs.exclude(exclude_promoted_addons=True)
+        return qs
+
+    @classmethod
+    def run_actions(cls, version, *, rules=None):
         if version.channel == amo.CHANNEL_ENTERPRISE:
             log.info(
                 'Not running actions on version %s as it is an enterprise version',
                 version.pk,
             )
             return False
-        cls.execute_workflow_action(version)
-        cls.execute_policy_enforcement_action(version)
+        cls.execute_workflow_action(version, rules=rules)
+        cls.execute_policy_enforcement_action(version, rules=rules)
         return True
 
     @classmethod
-    def execute_policy_enforcement_action(cls, version):
+    def execute_policy_enforcement_action(cls, version, *, rules=None):
         from olympia.abuse.models import (
             CinderPolicy,
             ContentDecision,
@@ -506,17 +522,9 @@ class ScannerResult(AbstractScannerResult):
             )
             return
 
-        result_query_name = cls._meta.get_field('matched_rules').related_query_name()
-
-        matching_rules = cls.rule_model.objects.filter(
-            **{
-                f'{result_query_name}__version': version,
-                'is_active': True,
-                'policy__isnull': False,
-            }
+        matching_rules = cls.get_matched_rules_for_version(version, rules=rules).filter(
+            policy__isnull=False
         )
-        if addon.is_promoted:
-            matching_rules = matching_rules.exclude(exclude_promoted_addons=True)
 
         policies = CinderPolicy.objects.filter(
             pk__in=matching_rules.values_list('policy', flat=True).distinct(),
@@ -568,7 +576,7 @@ class ScannerResult(AbstractScannerResult):
         )
 
     @classmethod
-    def execute_workflow_action(cls, version):
+    def execute_workflow_action(cls, version, *, rules=None):
         """Try to find and execute a "workflow action" for a given version,
         based on the scanner results and associated rules.
 
@@ -585,17 +593,14 @@ class ScannerResult(AbstractScannerResult):
             )
             return
 
-        result_query_name = cls._meta.get_field('matched_rules').related_query_name()
-
-        rule_qs = cls.rule_model.objects.filter(
-            **{f'{result_query_name}__version': version, 'is_active': True}
+        rule = (
+            cls.get_matched_rules_for_version(version, rules=rules)
+            .order_by(
+                # The `-` sign means descending order.
+                '-action'
+            )
+            .first()
         )
-        if version.addon.is_promoted:
-            rule_qs = rule_qs.exclude(exclude_promoted_addons=True)
-        rule = rule_qs.order_by(
-            # The `-` sign means descending order.
-            '-action'
-        ).first()
 
         if not rule:
             log.info('No workflow action to execute for version %s.', version.pk)

--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -269,6 +269,26 @@ def _run_scanner_for_url(scanner_result, url, scanner, api_url, api_key):
 
 @task
 @use_primary_db
+def run_actions_for_scanner_result(scanner_result_pk):
+    """Execute the scanner actions for the rules matched by a single scanner
+    result."""
+    log.info('Starting run actions task for ScannerResult %s.', scanner_result_pk)
+    scanner_result = ScannerResult.objects.get(pk=scanner_result_pk)
+    rule_pks = list(scanner_result.matched_rules.values_list('pk', flat=True))
+
+    if not rule_pks:
+        log.info(
+            'No matched rule for ScannerResult %s, not running any action.',
+            scanner_result_pk,
+        )
+        return
+
+    ScannerResult.run_actions(scanner_result.version, rules=rule_pks)
+    log.info('Ending run actions task for ScannerResult %s.', scanner_result_pk)
+
+
+@task
+@use_primary_db
 def run_narc_on_version(version_pk, *, run_actions_on_match=True):
     log.info('Starting narc task for Version %s.', version_pk)
     try:

--- a/src/olympia/scanners/tests/test_actions.py
+++ b/src/olympia/scanners/tests/test_actions.py
@@ -1824,3 +1824,66 @@ class TestRunAction(TestCase):
 
         # Nothing for human reviewers to do.
         assert not self.version.needshumanreview_set.exists()
+
+    def _create_additional_matched_rule(self, **kwargs):
+        other_rule = ScannerRule.objects.create(
+            name='rule-2', scanner=self.scanner, **kwargs
+        )
+        other_result = ScannerResult.objects.create(
+            version=self.version, scanner=self.scanner
+        )
+        other_result.matched_rules.add(other_rule)
+        return other_rule
+
+    @mock.patch('olympia.scanners.models._flag_for_human_review')
+    @mock.patch('olympia.scanners.models._delay_auto_approval_indefinitely')
+    def test_execute_workflow_action_limited_to_rules(
+        self, _delay_auto_approval_indefinitely_mock, _flag_for_human_review_mock
+    ):
+        self.scanner_rule.update(action=FLAG_FOR_HUMAN_REVIEW)
+        # More severe, but it's not part of the rules we pass.
+        self._create_additional_matched_rule(action=DELAY_AUTO_APPROVAL_INDEFINITELY)
+
+        ScannerResult.run_actions(
+            self.version, rules=self.scanner_result.matched_rules.all()
+        )
+
+        assert not _delay_auto_approval_indefinitely_mock.called
+        _flag_for_human_review_mock.assert_called_with(
+            version=self.version, rule=self.scanner_rule
+        )
+
+    @mock.patch('olympia.scanners.models._delay_auto_approval_indefinitely')
+    def test_execute_workflow_action_without_rules_considers_all(
+        self, _delay_auto_approval_indefinitely_mock
+    ):
+        self.scanner_rule.update(action=FLAG_FOR_HUMAN_REVIEW)
+        other_rule = self._create_additional_matched_rule(
+            action=DELAY_AUTO_APPROVAL_INDEFINITELY
+        )
+
+        ScannerResult.run_actions(self.version)
+
+        _delay_auto_approval_indefinitely_mock.assert_called_with(
+            version=self.version, rule=other_rule
+        )
+
+    def test_execute_policy_enforcement_action_limited_to_rules(self):
+        policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='some policy name',
+            text='some policy text',
+            enforcement_actions=[DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value],
+        )
+        # This policy was already enforced through another result: passing
+        # `rules` is what prevents us from enforcing it a second time.
+        self._create_additional_matched_rule(policy=policy)
+
+        ScannerResult.run_actions(
+            self.version, rules=self.scanner_result.matched_rules.all()
+        )
+
+        self.addon.reload()
+        assert self.addon.status == amo.STATUS_APPROVED
+        assert not ContentDecision.objects.exists()
+        assert len(responses.calls) == 0

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -29,6 +29,7 @@ from olympia.constants.scanners import (
     SCHEDULED,
     WEBHOOK,
     WEBHOOK_DURING_VALIDATION,
+    WEBHOOK_PUSH,
     YARA,
 )
 from olympia.files.models import File
@@ -48,6 +49,7 @@ from olympia.scanners.tasks import (
     call_webhooks,
     call_webhooks_during_validation,
     mark_scanner_query_rule_as_completed_or_aborted,
+    run_actions_for_scanner_result,
     run_narc_on_version,
     run_scanner,
     run_scanner_query_rule,
@@ -55,6 +57,56 @@ from olympia.scanners.tasks import (
     run_yara,
 )
 from olympia.versions.models import Version
+
+
+class TestRunActionsForScannerResult(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.version = version_factory(addon=addon_factory())
+        self.webhook = ScannerWebhook.objects.create(
+            name='test-webhook',
+            url='https://example.com/webhook',
+            api_key='secret',
+        )
+        self.event = ScannerWebhookEvent.objects.create(
+            webhook=self.webhook, event=WEBHOOK_PUSH
+        )
+        self.rule = ScannerRule.objects.create(name='rule-a', scanner=WEBHOOK)
+
+    def create_result(self, matched_rules):
+        return ScannerResult.objects.create(
+            scanner=WEBHOOK,
+            version=self.version,
+            webhook_event=self.event,
+            results={'version': '1.0.0', 'matchedRules': matched_rules},
+        )
+
+    @mock.patch.object(ScannerResult, 'run_actions')
+    def test_run_actions(self, run_actions_mock):
+        scanner_result = self.create_result(['rule-a'])
+
+        run_actions_for_scanner_result(scanner_result.pk)
+
+        assert run_actions_mock.call_count == 1
+        assert run_actions_mock.call_args[0] == (self.version,)
+        assert run_actions_mock.call_args[1]['rules'] == [self.rule.pk]
+
+    @mock.patch.object(ScannerResult, 'run_actions')
+    def test_no_run_actions_without_matched_rules(self, run_actions_mock):
+        scanner_result = self.create_result([])
+
+        run_actions_for_scanner_result(scanner_result.pk)
+
+        assert run_actions_mock.call_count == 0
+
+    @mock.patch.object(ScannerResult, 'run_actions')
+    def test_no_run_actions_for_unknown_rule(self, run_actions_mock):
+        scanner_result = self.create_result(['unknown-rule'])
+
+        run_actions_for_scanner_result(scanner_result.pk)
+
+        assert run_actions_mock.call_count == 0
 
 
 class TestRunScanner(UploadMixin, TestCase):

--- a/src/olympia/scanners/tests/test_views.py
+++ b/src/olympia/scanners/tests/test_views.py
@@ -424,6 +424,68 @@ class TestPushScannerResult(APIKeyAuthTestMixin, TestCase):
         assert response.status_code == 400
         assert response.json() == {'results': ['This field is required.']}
 
+    @mock.patch('olympia.scanners.views.run_actions_for_scanner_result')
+    def test_runs_actions_for_matched_rules(self, run_actions_mock):
+        response = self._push_scanner_result(
+            data={
+                'version_id': self.version.pk,
+                'results': {'version': '1.0.0', 'matchedRules': ['rule-a']},
+            }
+        )
+
+        assert response.status_code == 201
+        scanner_result = ScannerResult.objects.get()
+        assert scanner_result.has_matches
+        run_actions_mock.delay.assert_called_once_with(scanner_result.pk)
+
+    @mock.patch('olympia.scanners.views.run_actions_for_scanner_result')
+    def test_does_not_run_actions_without_matched_rules(self, run_actions_mock):
+        response = self._push_scanner_result()
+
+        assert response.status_code == 201
+        assert not ScannerResult.objects.get().has_matches
+        run_actions_mock.delay.assert_not_called()
+
+    @mock.patch('olympia.scanners.views.run_actions_for_scanner_result')
+    def test_does_not_run_actions_for_unknown_rule(self, run_actions_mock):
+        response = self._push_scanner_result(
+            data={
+                'version_id': self.version.pk,
+                'results': {'version': '1.0.0', 'matchedRules': ['unknown-rule']},
+            }
+        )
+
+        assert response.status_code == 201
+        assert not ScannerResult.objects.get().has_matches
+        run_actions_mock.delay.assert_not_called()
+
+    @mock.patch('olympia.scanners.views.run_actions_for_scanner_result')
+    def test_does_not_run_actions_for_inactive_rule(self, run_actions_mock):
+        ScannerRule.objects.filter(name='rule-a').update(is_active=False)
+
+        response = self._push_scanner_result(
+            data={
+                'version_id': self.version.pk,
+                'results': {'version': '1.0.0', 'matchedRules': ['rule-a']},
+            }
+        )
+
+        assert response.status_code == 201
+        assert not ScannerResult.objects.get().has_matches
+        run_actions_mock.delay.assert_not_called()
+
+    @mock.patch('olympia.scanners.views.run_actions_for_scanner_result')
+    def test_does_not_run_actions_on_duplicate_rule(self, run_actions_mock):
+        data = {
+            'version_id': self.version.pk,
+            'results': {'version': '1.0.0', 'matchedRules': ['rule-a']},
+        }
+        assert self._push_scanner_result(data=data).status_code == 201
+        run_actions_mock.delay.reset_mock()
+
+        assert self._push_scanner_result(data=data).status_code == 409
+        run_actions_mock.delay.assert_not_called()
+
 
 VALID_YARA_DEFINITION = 'rule some_rule { condition: true }'
 

--- a/src/olympia/scanners/views.py
+++ b/src/olympia/scanners/views.py
@@ -31,7 +31,7 @@ from .serializers import (
     ScannerQueryResultSerializer,
     ScannerQueryRuleSerializer,
 )
-from .tasks import run_scanner_query_rule
+from .tasks import run_actions_for_scanner_result, run_scanner_query_rule
 
 
 log = olympia.core.logger.getLogger('z.scanners.views')
@@ -81,6 +81,9 @@ def push_scanner_result(request):
     log.info(
         'Pushed new scanner result %s for version %s', scanner_result.pk, version_id
     )
+
+    if scanner_result.has_matches:
+        run_actions_for_scanner_result.delay(scanner_result.pk)
 
     return Response({'id': scanner_result.pk}, status=status.HTTP_201_CREATED)
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/16429

---

Besides doing what is stated in the title, I think it's worth calling
out that policies might be applied twice if the push event happens
before auto-approval (I think). In practice, that cannot really happen,
since scanners that use "push" events work on existing (and most likely
public) versions, which means auto-approval has necessarily run.