### PR TITLE
Improve ratings API performance & scalability

### DIFF
--- a/src/olympia/ratings/models.py
+++ b/src/olympia/ratings/models.py
@@ -173,8 +173,8 @@ class Rating(ModelBase):
             models.Index(fields=('user',), name='reviews_ibfk_2'),
             models.Index(fields=('addon',), name='reviews_addon_idx'),
             models.Index(
-                fields=('reply_to', 'is_latest', 'addon', 'created'),
-                name='latest_reviews',
+                fields=('addon', 'reply_to', 'deleted', 'is_latest'),
+                name='latest_reviews_per_addon',
             ),
             models.Index(fields=('ip_address',), name='reviews_ip_address_057fddfa'),
         ]

--- a/src/olympia/ratings/pagination.py
+++ b/src/olympia/ratings/pagination.py
@@ -1,0 +1,39 @@
+from django.core.paginator import InvalidPage
+
+from rest_framework.exceptions import NotFound
+
+from olympia.api.pagination import CustomPageNumberPagination
+
+
+class AddonRatingsPagination(CustomPageNumberPagination):
+    def paginate_queryset(self, queryset, request, view=None):
+        """
+        Like DRF's paginate_queryset(), but with the paginator.count set to
+        the add-on's total_ratings denormalized field.
+        """
+        page_size = self.get_page_size(request)
+        if not page_size:
+            return None
+
+        paginator = self.django_paginator_class(queryset, page_size)
+        # Override paginator.count with the total ratings from the add-on,
+        # avoiding the expensive count() query.
+        paginator.count = view.get_addon_object().total_ratings
+        page_number = request.query_params.get(self.page_query_param, 1)
+        if page_number in self.last_page_strings:
+            page_number = paginator.num_pages
+
+        try:
+            self.page = paginator.page(page_number)
+        except InvalidPage as exc:
+            msg = self.invalid_page_message.format(
+                page_number=page_number, message=str(exc)
+            )
+            raise NotFound(msg)
+
+        if paginator.num_pages > 1 and self.template is not None:
+            # The browsable API should display pagination controls.
+            self.display_page_controls = True
+
+        self.request = request
+        return list(self.page)

--- a/src/olympia/ratings/pagination.py
+++ b/src/olympia/ratings/pagination.py
@@ -29,7 +29,7 @@ class AddonRatingsPagination(CustomPageNumberPagination):
             msg = self.invalid_page_message.format(
                 page_number=page_number, message=str(exc)
             )
-            raise NotFound(msg)
+            raise NotFound(msg) from exc
 
         if paginator.num_pages > 1 and self.template is not None:
             # The browsable API should display pagination controls.

--- a/src/olympia/ratings/tests/test_views.py
+++ b/src/olympia/ratings/tests/test_views.py
@@ -227,12 +227,11 @@ class TestRatingViewSetGet(TestCase):
 
         assert Rating.unfiltered.count() == 3
 
-        with self.assertNumQueries(7):
-            # 7 queries:
+        with self.assertNumQueries(6):
+            # 6 queries:
             # - Two for opening and releasing a savepoint. Those only happen in
             #   tests, because TransactionTestCase wraps things in atomic().
-            # - One for the ratings count (pagination)
-            # - One for the ratings themselves
+            # - One for the ratings
             # - One for the replies (there aren't any, but we don't know
             #   that without making a query)
             # - One for the addon
@@ -293,11 +292,10 @@ class TestRatingViewSetGet(TestCase):
 
         assert Rating.unfiltered.count() == 5
 
-        with self.assertNumQueries(7):
-            # 7 queries:
+        with self.assertNumQueries(6):
+            # 6 queries:
             # - Two for opening and releasing a savepoint. Those only happen in
             #   tests, because TransactionTestCase wraps things in atomic().
-            # - One for the ratings count
             # - One for the ratings
             # - One for the replies (using prefetch_related())
             # - One for the addon
@@ -1021,16 +1019,22 @@ class TestRatingViewSetGet(TestCase):
         self.grant_permission(self.user, amo.permissions.ADDONS_EDIT)
         self.client.login_api(self.user)
         review1 = Rating.objects.create(
-            addon=self.addon, body='review 1', user=user_factory()
+            addon=self.addon,
+            body='review 1',
+            user=user_factory(),
+            rating=1,
         )
         review2 = Rating.objects.create(
-            addon=self.addon, body='review 2', user=user_factory()
+            addon=self.addon,
+            body='review 2',
+            user=user_factory(),
+            rating=2,
         )
         review1.update(created=self.days_ago(1))
         # Add a review belonging to a different add-on, a reply and a deleted
         # review. They should not be present in the list.
         review_deleted = Rating.objects.create(
-            addon=self.addon, body='review deleted', user=review1.user
+            addon=self.addon, body='review deleted', user=review1.user, rating=3
         )
         review_deleted.delete()
         Rating.objects.create(
@@ -1040,7 +1044,10 @@ class TestRatingViewSetGet(TestCase):
             user=user_factory(),
         )
         Rating.objects.create(
-            addon=addon_factory(), body='review other addon', user=review1.user
+            addon=addon_factory(),
+            body='review other addon',
+            user=review1.user,
+            rating=4,
         )
         # Also add a deleted reply to the first review, it should not be shown.
         deleted_reply = Rating.objects.create(

--- a/src/olympia/ratings/tests/test_views.py
+++ b/src/olympia/ratings/tests/test_views.py
@@ -399,8 +399,6 @@ class TestRatingViewSetGet(TestCase):
         review2 = Rating.objects.create(
             addon=self.addon, body='review 2', user=self.user
         )
-        review1.update(created=self.days_ago(1))
-        review2.update(created=self.days_ago(2))
         # Add a review belonging to a different user, a reply and a deleted
         # review. The reply should show up since it's made by the right user,
         # but the rest should be ignored.
@@ -439,8 +437,8 @@ class TestRatingViewSetGet(TestCase):
         assert data['results']
         assert len(data['results']) == 3
         assert data['results'][0]['id'] == reply.pk
-        assert data['results'][1]['id'] == review1.pk
-        assert data['results'][2]['id'] == review2.pk
+        assert data['results'][1]['id'] == review2.pk
+        assert data['results'][2]['id'] == review1.pk
         assert 'can_reply' not in data  # Not enough information to show this.
         return data
 
@@ -1081,13 +1079,11 @@ class TestRatingViewSetGet(TestCase):
         review2 = Rating.objects.create(
             addon=self.addon, body='review 2', user=user_factory()
         )
-        review1.update(created=self.days_ago(1))
         # Add a review belonging to a different add-on, a reply and a deleted
         # review. The deleted review should be present, not the rest.
         review_deleted = Rating.objects.create(
             addon=self.addon, body='review deleted', user=review1.user
         )
-        review_deleted.update(created=self.days_ago(2))
         review_deleted.delete()
         Rating.objects.create(
             addon=self.addon,
@@ -1118,12 +1114,12 @@ class TestRatingViewSetGet(TestCase):
         assert data['count'] == 3
         assert data['results']
         assert len(data['results']) == 3
-        assert data['results'][0]['id'] == review2.pk
-        assert data['results'][0]['reply'] is not None
-        assert data['results'][1]['id'] == review1.pk
+        assert data['results'][0]['id'] == review_deleted.pk
+        assert data['results'][1]['id'] == review2.pk
         assert data['results'][1]['reply'] is not None
-        assert data['results'][1]['reply']['id'] == deleted_reply.pk
-        assert data['results'][2]['id'] == review_deleted.pk
+        assert data['results'][2]['id'] == review1.pk
+        assert data['results'][2]['reply'] is not None
+        assert data['results'][2]['reply']['id'] == deleted_reply.pk
 
     def test_list_weird_parameters(self):
         self.addon.update(slug='my-slûg')

--- a/src/olympia/ratings/views.py
+++ b/src/olympia/ratings/views.py
@@ -27,6 +27,7 @@ from olympia.api.throttling import GranularIPRateThrottle, GranularUserRateThrot
 from olympia.api.utils import is_gate_active
 
 from .models import Rating, RatingFlag
+from .pagination import AddonRatingsPagination
 from .permissions import CanCreateRatingPermission, CanDeleteRatingPermission
 from .serializers import RatingFlagSerializer, RatingSerializer, RatingSerializerReply
 from .utils import get_grouped_ratings
@@ -236,6 +237,7 @@ class RatingViewSet(AddonChildMixin, ModelViewSet):
                 if is_gate_active(self.request, 'ratings-score-filter')
                 else None
             )
+            top_level_filter = self.request.GET.get('filter')
             exclude_ratings = self.request.GET.get('exclude_ratings')
             if addon_identifier:
                 qs = qs.filter(addon=self.get_addon_object())
@@ -262,11 +264,23 @@ class RatingViewSet(AddonChildMixin, ModelViewSet):
             if user_identifier and addon_identifier and version_identifier:
                 # When user, addon and version identifiers are set, we are
                 # effectively only looking for one or zero objects. Fake
-                # pagination in that case, avoiding all count() calls and
-                # therefore related cache-machine invalidation issues. Needed
+                # pagination in that case, avoiding all count() calls. Needed
                 # because the frontend wants to call this before and after
                 # having posted a new rating, and needs accurate results.
                 self.pagination_class = OneOrZeroPageNumberPagination
+            elif (
+                addon_identifier
+                and not user_identifier
+                and not version_identifier
+                and not top_level_filter
+                and not score_filter
+                and not exclude_ratings
+            ):
+                # Fast path: we're loading ratings for a specific add-on with
+                # no other filtering. We can avoid the count() by using the
+                # denormalized total_ratings field instead in a custom
+                # pagination class.
+                self.pagination_class = AddonRatingsPagination
             if score_filter:
                 try:
                     scores = [int(score) for score in score_filter.split(',')]
@@ -405,7 +419,9 @@ class RatingViewSet(AddonChildMixin, ModelViewSet):
         # separate query to fetch them all.
         queryset = queryset.select_related('version', 'user')
         replies_qs = Rating.unfiltered.select_related('user')
-        return queryset.prefetch_related(Prefetch('replies', queryset=replies_qs))
+        return queryset.prefetch_related(
+            Prefetch('replies', queryset=replies_qs)
+        ).order_by('-pk')
 
     @action(
         detail=True,


### PR DESCRIPTION
- Order by -pk rather than -created
- Tweak index on ratings to match actual query often performed
- Avoid count() in ratings API when only addon parameter is passed

Fixes https://github.com/mozilla/addons/issues/16416
