### PR TITLE
Disallow control characters in filenames inside zip/tar/xpi files

### DIFF
--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -1746,6 +1746,22 @@ class TestArchiveMemberValidatorZip(TestCase):
                 self._fake_archive_member('path\\to\\file.txt', 123)
             )
 
+    def test_raises_when_filename_contains_control_character(self):
+        with pytest.raises(utils.InvalidArchiveFile):
+            utils.archive_member_validator(
+                self._fake_archive_member('path\rfile.txt', 123)
+            )
+
+        with pytest.raises(utils.InvalidArchiveFile):
+            utils.archive_member_validator(
+                self._fake_archive_member('path\nfile.txt', 123)
+            )
+
+        with pytest.raises(utils.InvalidArchiveFile):
+            utils.archive_member_validator(
+                self._fake_archive_member('path\tfile.txt', 123)
+            )
+
     def test_raises_when_filename_is_dot_dot(self):
         with pytest.raises(utils.InvalidArchiveFile):
             utils.archive_member_validator(self._fake_archive_member('..', 123))

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -13,6 +13,7 @@ import stat
 import struct
 import tarfile
 import tempfile
+import unicodedata
 import zipfile
 from collections.abc import Mapping
 from types import MappingProxyType
@@ -581,6 +582,7 @@ def archive_member_validator(member, ignore_filename_errors=False):
             or '../' in filename
             or '..' == filename
             or filename.startswith('/')
+            or any(unicodedata.category(c)[0] == 'C' for c in filename)
         ):
             log.warning('Extraction error, invalid file name: %s', filename)
             # L10n: {0} is the name of the invalid file.


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/1831
