### PR TITLE
Don't check auto-approval restrictions for enterprise versions

### DIFF
--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -575,38 +575,42 @@ class Version(OnChangeMixin, ModelBase):
         if is_mozilla_signed and addon.type != amo.ADDON_LPAPP:
             reviewer_flags_defaults['auto_approval_disabled'] = True
 
-        # Check if the approval should be restricted
-        checker = RestrictionChecker(upload=upload)
-        if not checker.is_auto_approval_allowed():
-            flag = (
-                'auto_approval_disabled'
-                if channel == amo.CHANNEL_LISTED
-                else 'auto_approval_disabled_unlisted'
-            )
-            reviewer_flags_defaults[flag] = True
-            failed_names = [cls.__name__ for cls in checker.failed_restrictions]
-            history_ids = [entry.pk for entry in checker.history_entries]
-            # The checker ran before the version existed, so it could not
-            # record it on the history rows itself; backfill it now.
-            if history_ids:
-                UserRestrictionHistory.objects.filter(pk__in=history_ids).update(
-                    version=version
+        # Check if the approval should be restricted. Enterprise versions are
+        # exempt: their auto-approval can never be disabled (see
+        # AutoApprovalSummary.check_has_auto_approval_disabled()), so the flag
+        # is not set and nothing is recorded for them.
+        if channel != amo.CHANNEL_ENTERPRISE:
+            checker = RestrictionChecker(upload=upload)
+            if not checker.is_auto_approval_allowed():
+                flag = (
+                    'auto_approval_disabled'
+                    if channel == amo.CHANNEL_LISTED
+                    else 'auto_approval_disabled_unlisted'
                 )
-            activity.log_create(
-                amo.LOG.DISABLE_AUTO_APPROVAL,
-                addon,
-                details={
-                    'channel': version.channel,
-                    'comments': (
-                        f'{version.get_channel_display()} auto-approval automatically '
-                        'disabled because of a restriction'
-                        f' ({", ".join(failed_names)})'
-                    ),
-                    'restrictions': failed_names,
-                    'restriction_history_ids': history_ids,
-                },
-                user=get_task_user(),
-            )
+                reviewer_flags_defaults[flag] = True
+                failed_names = [cls.__name__ for cls in checker.failed_restrictions]
+                history_ids = [entry.pk for entry in checker.history_entries]
+                # The checker ran before the version existed, so it could not
+                # record it on the history rows itself; backfill it now.
+                if history_ids:
+                    UserRestrictionHistory.objects.filter(pk__in=history_ids).update(
+                        version=version
+                    )
+                activity.log_create(
+                    amo.LOG.DISABLE_AUTO_APPROVAL,
+                    addon,
+                    details={
+                        'channel': version.channel,
+                        'comments': (
+                            f'{version.get_channel_display()} auto-approval '
+                            'automatically disabled because of a restriction'
+                            f' ({", ".join(failed_names)})'
+                        ),
+                        'restrictions': failed_names,
+                        'restriction_history_ids': history_ids,
+                    },
+                    user=get_task_user(),
+                )
 
         if reviewer_flags_defaults:
             AddonReviewerFlags.objects.update_or_create(

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -579,38 +579,37 @@ class Version(OnChangeMixin, ModelBase):
         # exempt: their auto-approval can never be disabled (see
         # AutoApprovalSummary.check_has_auto_approval_disabled()), so the flag
         # is not set and nothing is recorded for them.
-        if channel != amo.CHANNEL_ENTERPRISE:
-            checker = RestrictionChecker(upload=upload)
-            if not checker.is_auto_approval_allowed():
-                flag = (
-                    'auto_approval_disabled'
-                    if channel == amo.CHANNEL_LISTED
-                    else 'auto_approval_disabled_unlisted'
+        checker = RestrictionChecker(upload=upload)
+        if channel != amo.CHANNEL_ENTERPRISE and not checker.is_auto_approval_allowed():
+            flag = (
+                'auto_approval_disabled'
+                if channel == amo.CHANNEL_LISTED
+                else 'auto_approval_disabled_unlisted'
+            )
+            reviewer_flags_defaults[flag] = True
+            failed_names = [cls.__name__ for cls in checker.failed_restrictions]
+            history_ids = [entry.pk for entry in checker.history_entries]
+            # The checker ran before the version existed, so it could not
+            # record it on the history rows itself; backfill it now.
+            if history_ids:
+                UserRestrictionHistory.objects.filter(pk__in=history_ids).update(
+                    version=version
                 )
-                reviewer_flags_defaults[flag] = True
-                failed_names = [cls.__name__ for cls in checker.failed_restrictions]
-                history_ids = [entry.pk for entry in checker.history_entries]
-                # The checker ran before the version existed, so it could not
-                # record it on the history rows itself; backfill it now.
-                if history_ids:
-                    UserRestrictionHistory.objects.filter(pk__in=history_ids).update(
-                        version=version
-                    )
-                activity.log_create(
-                    amo.LOG.DISABLE_AUTO_APPROVAL,
-                    addon,
-                    details={
-                        'channel': version.channel,
-                        'comments': (
-                            f'{version.get_channel_display()} auto-approval '
-                            'automatically disabled because of a restriction'
-                            f' ({", ".join(failed_names)})'
-                        ),
-                        'restrictions': failed_names,
-                        'restriction_history_ids': history_ids,
-                    },
-                    user=get_task_user(),
-                )
+            activity.log_create(
+                amo.LOG.DISABLE_AUTO_APPROVAL,
+                addon,
+                details={
+                    'channel': version.channel,
+                    'comments': (
+                        f'{version.get_channel_display()} auto-approval automatically '
+                        'disabled because of a restriction'
+                        f' ({", ".join(failed_names)})'
+                    ),
+                    'restrictions': failed_names,
+                    'restriction_history_ids': history_ids,
+                },
+                user=get_task_user(),
+            )
 
         if reviewer_flags_defaults:
             AddonReviewerFlags.objects.update_or_create(

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1978,6 +1978,35 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         assert version
         assert version.channel == amo.CHANNEL_ENTERPRISE
 
+    @override_switch('enterprise-channel', active=True)
+    def test_auto_approval_not_restricted_for_enterprise(self):
+        # Enterprise versions are exempt from auto-approval restrictions:
+        # the disabled flag is ignored for them (see
+        # AutoApprovalSummary.check_has_auto_approval_disabled()), so the
+        # check is skipped entirely - no flag, no history, no activity log.
+        upload_enterprise = self.get_upload(
+            self.filename, channel=amo.CHANNEL_ENTERPRISE
+        )
+        EmailUserRestriction.objects.create(
+            email_pattern=upload_enterprise.user.email,
+            restriction_type=RESTRICTION_TYPES.ADDON_APPROVAL,
+        )
+        version = Version.from_upload(
+            upload_enterprise,
+            self.addon,
+            amo.CHANNEL_ENTERPRISE,
+            selected_apps=[self.selected_app],
+            parsed_data=self.dummy_parsed_data,
+        )
+        assert version
+        assert not AddonReviewerFlags.objects.filter(addon=self.addon).exists()
+        assert not UserRestrictionHistory.objects.exists()
+        assert (
+            not ActivityLog.objects.for_addons(self.addon)
+            .filter(action=amo.LOG.DISABLE_AUTO_APPROVAL.id)
+            .exists()
+        )
+
     def test_addon_is_attached_to_upload_if_it_wasnt(self):
         assert self.upload_listed.addon is None
         version = Version.from_upload(


### PR DESCRIPTION
Part of mozilla/addons#16408

### Context

While reviewing #25344, QA pulled up enterprise addons still passing the transparency check. It turns out this existed before the aforementioned PR. 

### Description

After this PR, `Version.from_upload()` now skips the auto-approval restriction check entirely for enterprise-channel versions. Enterprise versions are exempt from the auto-approval-disabled flags anyway (`AutoApprovalSummary.check_has_auto_approval_disabled()`), so the check was recording a "disabled" that never applied — and, as a side effect, setting the *unlisted* flag on the add-on, since the flag selection predates the enterprise channel. Submission-type restrictions are unaffected.


### Testing

New test in `TestExtensionVersionFromUpload`: a matching "Add-on Approval" restriction plus an enterprise submission.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.