### PR TITLE
Add Activity Feed API

### DIFF
--- a/docs/topics/api/activity.rst
+++ b/docs/topics/api/activity.rst
@@ -136,3 +136,20 @@ Any other content or invalid emails will be discarded.
     :<json string Message.TextBody: The plain text body of the email.
     :<json array To: Array of To email addresses.  All will be parsed, and the first matching the correct format used.
     :<json string To[].EmailAddress: An email address in the format `reviewreply+randomuuidstring@addons.mozilla.org`.
+
+
+-----------------------
+Activity Feed End-point
+-----------------------
+
+.. _activity:
+
+This endpoint returns a list of activities relevant to the user.
+
+.. http:get:: /api/v5/activity/
+
+    .. note::
+        This endpoint exclusively uses session IDs.
+
+    :<json string addon: The add-on id or slug to filter on (optional).
+    :<json string version: The version ID to filter on (optional).

--- a/docs/topics/api/activity.rst
+++ b/docs/topics/api/activity.rst
@@ -149,7 +149,43 @@ This endpoint returns a list of activities relevant to the user.
 .. http:get:: /api/v5/activity/
 
     .. note::
-        This endpoint exclusively uses session IDs.
+        This endpoint exclusively uses :ref:`internal authentication <api-auth-internal>`.
 
-    :<json string addon: The add-on id or slug to filter on (optional).
-    :<json string version: The version ID to filter on (optional).
+    **Request:**
+
+    :query string addon: The add-on id or slug to filter on (optional).
+    :query string version: The version ID to filter on (optional).
+
+    **Response:**
+
+    .. sourcecode:: json
+
+        {
+            "id": 2,
+            "title": "Add-on version 3.0 has been approved.",
+            "comments": "lorum ipsum",
+            "date": "2026-09-11T00:00:00Z",
+            "user": {
+                "name": "username"
+            },
+            "addon": {
+                "id": 85,
+                "slug": "my-addon",
+                "name": "My Addon",
+                "disabled_by_user": false
+            },
+            "versions": [
+                {
+                    "version_id": 10,
+                    "version": "3.0",
+                    "channel": "unlisted",
+                    "status": "Approved",
+                    "addon_id": 85
+                }
+            ]
+        }
+
+    :statuscode 200: Success.
+    :statuscode 400: Invalid request parameters.
+    :statuscode 401: Authentication failed.
+

--- a/src/olympia/activity/api_urls.py
+++ b/src/olympia/activity/api_urls.py
@@ -6,3 +6,7 @@ from . import views
 urlpatterns = [
     re_path(r'^mail/', views.inbound_email, name='inbound-email-api'),
 ]
+
+activity_v5 = urlpatterns + [
+    re_path(r'^$', views.ActivityView.as_view(), name='developer-activity'),
+]

--- a/src/olympia/activity/serializers.py
+++ b/src/olympia/activity/serializers.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext
 
 from rest_framework import serializers
 
+from olympia import amo
 from olympia.activity.models import ActivityLog, CommentLog
 from olympia.amo.reverse import reverse
 from olympia.api.serializers import AMOModelSerializer
@@ -91,3 +92,44 @@ class ActivityLogSerializerForComments(serializers.Serializer):
     comments = serializers.CharField(
         required=True, max_length=CommentLog._meta.get_field('comments').max_length
     )
+
+
+class FeedActivityLogSerializer(AMOModelSerializer):
+    title = serializers.SerializerMethodField()
+    date = serializers.DateTimeField(source='created')
+    version = serializers.SerializerMethodField()
+    comments = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ActivityLog
+        fields = (
+            'id',
+            'version',
+            'title',
+            'comments',
+            'date',
+        )
+
+    def get_title(self, obj):
+        return obj.to_string()
+
+    def get_comments(self, obj):
+        comments = obj.details['comments'] if obj.details else ''
+        return getattr(obj.log(), 'sanitize', comments)
+
+    def get_version(self, obj):
+        return [
+            {
+                'version_id': version_log.version.id,
+                'version': version_log.version.version,
+                'channel': amo.CHANNEL_CHOICES_API[version_log.version.channel],
+                'status': version_log.version.get_review_status_display(),
+                'addon': {
+                    'id': version_log.version.addon.id,
+                    'slug': version_log.version.addon.slug,
+                    'name': str(version_log.version.addon.name),
+                    'disabled_by_user': version_log.version.addon.disabled_by_user,
+                },
+            }
+            for version_log in obj.versionlog_set.all()
+        ]

--- a/src/olympia/activity/serializers.py
+++ b/src/olympia/activity/serializers.py
@@ -5,9 +5,11 @@ from rest_framework import serializers
 
 from olympia import amo
 from olympia.activity.models import ActivityLog, CommentLog
+from olympia.addons.models import Addon
 from olympia.amo.reverse import reverse
 from olympia.api.serializers import AMOModelSerializer
 from olympia.api.utils import is_gate_active
+from olympia.versions.models import Version
 
 
 class ActivityLogSerializer(AMOModelSerializer):
@@ -97,18 +99,14 @@ class ActivityLogSerializerForComments(serializers.Serializer):
 class FeedActivityLogSerializer(AMOModelSerializer):
     title = serializers.SerializerMethodField()
     date = serializers.DateTimeField(source='created')
-    version = serializers.SerializerMethodField()
+    addon = serializers.SerializerMethodField()
+    versions = serializers.SerializerMethodField()
     comments = serializers.SerializerMethodField()
+    user = serializers.SerializerMethodField()
 
     class Meta:
         model = ActivityLog
-        fields = (
-            'id',
-            'version',
-            'title',
-            'comments',
-            'date',
-        )
+        fields = ('id', 'addon', 'versions', 'title', 'comments', 'date', 'user')
 
     def get_title(self, obj):
         return obj.to_string()
@@ -117,19 +115,35 @@ class FeedActivityLogSerializer(AMOModelSerializer):
         comments = obj.details['comments'] if obj.details else ''
         return getattr(obj.log(), 'sanitize', comments)
 
-    def get_version(self, obj):
+    def get_user(self, obj):
+        return {
+            'name': obj.user.name,
+        }
+
+    def get_addon(self, obj):
+        return next(
+            (
+                {
+                    'id': addon.id,
+                    'slug': addon.slug,
+                    'name': str(addon.name),
+                    'disabled_by_user': addon.disabled_by_user,
+                }
+                for addon in obj.arguments
+                if isinstance(addon, Addon)
+            ),
+            None,
+        )
+
+    def get_versions(self, obj):
         return [
             {
-                'version_id': version_log.version.id,
-                'version': version_log.version.version,
-                'channel': amo.CHANNEL_CHOICES_API[version_log.version.channel],
-                'status': version_log.version.get_review_status_display(),
-                'addon': {
-                    'id': version_log.version.addon.id,
-                    'slug': version_log.version.addon.slug,
-                    'name': str(version_log.version.addon.name),
-                    'disabled_by_user': version_log.version.addon.disabled_by_user,
-                },
+                'version_id': version.id,
+                'version': version.version,
+                'channel': amo.CHANNEL_CHOICES_API[version.channel],
+                'status': version.get_review_status_display(),
+                'addon_id': version.addon.id,
             }
-            for version_log in obj.versionlog_set.all()
+            for version in obj.arguments
+            if isinstance(version, Version)
         ]

--- a/src/olympia/activity/tests/test_serializers.py
+++ b/src/olympia/activity/tests/test_serializers.py
@@ -5,8 +5,16 @@ from rest_framework.test import APIRequestFactory
 
 from olympia import amo
 from olympia.activity.models import ActivityLog, AttachmentLog
-from olympia.activity.serializers import ActivityLogSerializer
-from olympia.amo.tests import TestCase, addon_factory, user_factory
+from olympia.activity.serializers import (
+    ActivityLogSerializer,
+    FeedActivityLogSerializer,
+)
+from olympia.amo.tests import (
+    TestCase,
+    addon_factory,
+    user_factory,
+    version_factory,
+)
 
 
 class LogMixin:
@@ -160,3 +168,60 @@ class TestReviewNotesSerializerOutput(TestCase, LogMixin):
         )
         result = self.serialize()
         assert result['attachment_size'] == filesizeformat(attachment.file.size)
+
+
+class TestFeedActivityLogSerializer(TestCase, LogMixin):
+    def setUp(self):
+        self.user = user_factory()
+        self.addon = addon_factory(users=[self.user])
+        self.version = self.addon.current_version
+        self.now = self.days_ago(0)
+
+    def serialize(self, log):
+        return FeedActivityLogSerializer().to_representation(log)
+
+    def test_basic(self):
+        log = self.log('foobar', amo.LOG.APPROVE_VERSION, self.now)
+        result = self.serialize(log)
+
+        assert result['id'] == log.pk
+        assert result['date'] == self.now.isoformat() + 'Z'
+        assert result['title'] == log.to_string()
+        assert result['comments'] == 'foobar'
+        assert result['version'] == [
+            {
+                'version_id': self.version.pk,
+                'version': self.version.version,
+                'channel': amo.CHANNEL_CHOICES_API[self.version.channel],
+                'status': self.version.get_review_status_display(),
+                'addon': {
+                    'id': self.version.addon.pk,
+                    'slug': self.version.addon.slug,
+                    'name': str(self.version.addon.name),
+                    'disabled_by_user': self.version.addon.disabled_by_user,
+                },
+            }
+        ]
+
+    def test_no_versionlog(self):
+        log = ActivityLog.objects.create(
+            amo.LOG.USER_DISABLE, self.addon, user=self.user
+        )
+        assert log.versionlog_set.count() == 0
+        assert self.serialize(log)['version'] == []
+
+    def test_multiple_versionlogs(self):
+        ul_version = version_factory(addon=self.addon, channel=amo.CHANNEL_UNLISTED)
+        log = ActivityLog.objects.create(
+            amo.LOG.APPROVE_VERSION,
+            self.addon,
+            self.version,
+            ul_version,
+            user=self.user,
+        )
+        result = self.serialize(log)
+        assert len(result['version']) == 2
+        assert {item['version_id'] for item in result['version']} == {
+            self.version.pk,
+            ul_version.pk,
+        }

--- a/src/olympia/activity/tests/test_serializers.py
+++ b/src/olympia/activity/tests/test_serializers.py
@@ -188,29 +188,30 @@ class TestFeedActivityLogSerializer(TestCase, LogMixin):
         assert result['date'] == self.now.isoformat() + 'Z'
         assert result['title'] == log.to_string()
         assert result['comments'] == 'foobar'
-        assert result['version'] == [
+        assert result['addon'] == {
+            'id': self.version.addon.pk,
+            'slug': self.version.addon.slug,
+            'name': str(self.version.addon.name),
+            'disabled_by_user': self.version.addon.disabled_by_user,
+        }
+        assert result['versions'] == [
             {
                 'version_id': self.version.pk,
                 'version': self.version.version,
                 'channel': amo.CHANNEL_CHOICES_API[self.version.channel],
                 'status': self.version.get_review_status_display(),
-                'addon': {
-                    'id': self.version.addon.pk,
-                    'slug': self.version.addon.slug,
-                    'name': str(self.version.addon.name),
-                    'disabled_by_user': self.version.addon.disabled_by_user,
-                },
+                'addon_id': self.version.addon.pk,
             }
         ]
 
-    def test_no_versionlog(self):
+    def test_no_versions(self):
         log = ActivityLog.objects.create(
             amo.LOG.USER_DISABLE, self.addon, user=self.user
         )
         assert log.versionlog_set.count() == 0
-        assert self.serialize(log)['version'] == []
+        assert self.serialize(log)['versions'] == []
 
-    def test_multiple_versionlogs(self):
+    def test_multiple_versions(self):
         ul_version = version_factory(addon=self.addon, channel=amo.CHANNEL_UNLISTED)
         log = ActivityLog.objects.create(
             amo.LOG.APPROVE_VERSION,
@@ -220,8 +221,8 @@ class TestFeedActivityLogSerializer(TestCase, LogMixin):
             user=self.user,
         )
         result = self.serialize(log)
-        assert len(result['version']) == 2
-        assert {item['version_id'] for item in result['version']} == {
+        assert len(result['versions']) == 2
+        assert {item['version_id'] for item in result['versions']} == {
             self.version.pk,
             ul_version.pk,
         }

--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -792,3 +792,101 @@ class TestDownloadAttachment(TestCase):
         self.addon.authors.add(self.user)
         response = self.client.get(self.url, follow=True)
         self.assertEqual(response.status_code, 404)
+
+
+class TestActivityView(LogMixin, TestCase):
+    client_class = APITestClientSessionID
+
+    def setUp(self):
+        self.user = user_factory()
+        self.addon = addon_factory(users=[self.user])
+        self.version = self.addon.current_version
+        self.url = reverse_ns('developer-activity')
+
+    def log(self, addon, action, version=None, user=None, comments=None):
+        version = version or addon.current_version
+        return ActivityLog.objects.create(
+            action or amo.LOG.APPROVE_VERSION,
+            addon,
+            version,
+            user=user or self.user,
+            details={
+                'comments': comments or 'Looks good',
+                'version': version.version,
+            },
+        )
+
+    def test_no_auth(self):
+        self.log(self.addon, amo.LOG.APPROVE_VERSION)
+        response = self.client.get(self.url)
+        assert response.status_code == 401
+
+    def test_basic(self):
+        log = self.log(self.addon, amo.LOG.APPROVE_VERSION)
+        self.client.login_api(self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert [item['id'] for item in response.data['results']] == [log.pk]
+        result = response.data['results'][0]
+        assert result['title'] == log.to_string()
+        assert result['comments'] == 'Looks good'
+        assert result['version'] == [
+            {
+                'version_id': self.version.pk,
+                'version': self.version.version,
+                'channel': amo.CHANNEL_CHOICES_API[self.version.channel],
+                'status': self.version.get_review_status_display(),
+                'addon': {
+                    'id': self.version.addon.pk,
+                    'slug': self.version.addon.slug,
+                    'name': str(self.version.addon.name),
+                    'disabled_by_user': self.version.addon.disabled_by_user,
+                },
+            }
+        ]
+
+    def test_authored_addons(self):
+        log = self.log(self.addon, amo.LOG.APPROVE_VERSION)
+        other_addon = addon_factory(users=[user_factory()])
+        self.log(other_addon, amo.LOG.APPROVE_VERSION, user=other_addon.authors.get())
+        self.client.login_api(self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert [item['id'] for item in response.data['results']] == [log.pk]
+
+    def test_excludes_actions_hidden_from_developers(self):
+        log = self.log(self.addon, amo.LOG.APPROVE_VERSION)
+        self.log(
+            self.addon, amo.LOG_BY_ID[amo.LOG_HIDE_DEVELOPER[0]], comments='hidden'
+        )
+        self.client.login_api(self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert [item['id'] for item in response.data['results']] == [log.pk]
+
+    def test_filter_by_addon(self):
+        log = self.log(self.addon, amo.LOG.APPROVE_VERSION)
+        other_addon = addon_factory(users=[self.user])
+        self.log(other_addon, amo.LOG.APPROVE_VERSION)
+        self.client.login_api(self.user)
+
+        response = self.client.get(self.url, {'addon': self.addon.pk})
+        assert response.status_code == 200
+        assert [item['id'] for item in response.data['results']] == [log.pk]
+
+        response = self.client.get(self.url, {'addon': self.addon.slug})
+        assert response.status_code == 200
+        assert [item['id'] for item in response.data['results']] == [log.pk]
+
+    def test_filter_by_version(self):
+        log = self.log(self.addon, amo.LOG.APPROVE_VERSION)
+        ul_version = version_factory(addon=self.addon, channel=amo.CHANNEL_UNLISTED)
+        self.log(self.addon, amo.LOG.APPROVE_VERSION, version=ul_version)
+        self.client.login_api(self.user)
+        response = self.client.get(self.url, {'version': self.version.pk})
+        assert response.status_code == 200
+        assert [item['id'] for item in response.data['results']] == [log.pk]
+
+        response = self.client.get(self.url, {'version': 'foo'})
+        assert response.status_code == 400
+        assert response.data['detail'] == 'version parameter should be an integer.'

--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -803,16 +803,15 @@ class TestActivityView(LogMixin, TestCase):
         self.version = self.addon.current_version
         self.url = reverse_ns('developer-activity')
 
-    def log(self, addon, action, version=None, user=None, comments=None):
-        version = version or addon.current_version
+    def log(self, addon, action, versions=None, user=None, comments=None):
+        versions = versions or (addon.current_version,)
         return ActivityLog.objects.create(
             action or amo.LOG.APPROVE_VERSION,
             addon,
-            version,
+            *versions,
             user=user or self.user,
             details={
                 'comments': comments or 'Looks good',
-                'version': version.version,
             },
         )
 
@@ -830,18 +829,20 @@ class TestActivityView(LogMixin, TestCase):
         result = response.data['results'][0]
         assert result['title'] == log.to_string()
         assert result['comments'] == 'Looks good'
-        assert result['version'] == [
+        assert result['user']['name'] == GENERIC_USER_NAME
+        assert result['addon'] == {
+            'id': self.version.addon.pk,
+            'slug': self.version.addon.slug,
+            'name': str(self.version.addon.name),
+            'disabled_by_user': self.version.addon.disabled_by_user,
+        }
+        assert result['versions'] == [
             {
                 'version_id': self.version.pk,
                 'version': self.version.version,
                 'channel': amo.CHANNEL_CHOICES_API[self.version.channel],
                 'status': self.version.get_review_status_display(),
-                'addon': {
-                    'id': self.version.addon.pk,
-                    'slug': self.version.addon.slug,
-                    'name': str(self.version.addon.name),
-                    'disabled_by_user': self.version.addon.disabled_by_user,
-                },
+                'addon_id': self.version.addon.pk,
             }
         ]
 
@@ -854,15 +855,50 @@ class TestActivityView(LogMixin, TestCase):
         assert response.status_code == 200
         assert [item['id'] for item in response.data['results']] == [log.pk]
 
-    def test_excludes_actions_hidden_from_developers(self):
-        log = self.log(self.addon, amo.LOG.APPROVE_VERSION)
+    def test_multiple_versions(self):
+        version1 = version_factory(addon=self.addon)
+        version2 = version_factory(addon=self.addon)
+
+        log = self.log(
+            self.addon, amo.LOG.APPROVE_VERSION, versions=[version1, version2]
+        )
+        self.client.login_api(self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert [item['id'] for item in response.data['results']] == [log.pk]
+        assert response.data['results'][0]['versions'] == [
+            {
+                'version_id': version.pk,
+                'version': version.version,
+                'channel': amo.CHANNEL_CHOICES_API[version.channel],
+                'status': version.get_review_status_display(),
+                'addon_id': self.addon.pk,
+            }
+            for version in (version1, version2)
+        ]
+
+    def test_excludes_and_anonymizes_actions_from_developers(self):
+        public_log = self.log(
+            self.addon,
+            amo.LOG.DEVELOPER_REPLY_VERSION,
+            user=user_factory(display_name='foo'),
+            comments='shown',
+        )
+        anon_log = self.log(self.addon, amo.LOG.FORCE_DISABLE, comments='anonymized')
         self.log(
             self.addon, amo.LOG_BY_ID[amo.LOG_HIDE_DEVELOPER[0]], comments='hidden'
         )
         self.client.login_api(self.user)
         response = self.client.get(self.url)
         assert response.status_code == 200
-        assert [item['id'] for item in response.data['results']] == [log.pk]
+        assert [item['id'] for item in response.data['results']] == [
+            anon_log.pk,
+            public_log.pk,
+        ]
+        assert [item['user']['name'] for item in response.data['results']] == [
+            GENERIC_USER_NAME,
+            'foo',
+        ]
 
     def test_filter_by_addon(self):
         log = self.log(self.addon, amo.LOG.APPROVE_VERSION)
@@ -881,7 +917,7 @@ class TestActivityView(LogMixin, TestCase):
     def test_filter_by_version(self):
         log = self.log(self.addon, amo.LOG.APPROVE_VERSION)
         ul_version = version_factory(addon=self.addon, channel=amo.CHANNEL_UNLISTED)
-        self.log(self.addon, amo.LOG.APPROVE_VERSION, version=ul_version)
+        self.log(self.addon, amo.LOG.APPROVE_VERSION, versions=[ul_version])
         self.client.login_api(self.user)
         response = self.client.get(self.url, {'version': self.version.pk})
         assert response.status_code == 200

--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -12,7 +12,10 @@ from rest_framework.decorators import (
     authentication_classes,
     permission_classes,
 )
+from rest_framework.exceptions import ParseError
+from rest_framework.generics import ListAPIView
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
@@ -23,6 +26,7 @@ from olympia.activity.models import ActivityLog, AddonLog
 from olympia.activity.serializers import (
     ActivityLogSerializer,
     ActivityLogSerializerForComments,
+    FeedActivityLogSerializer,
 )
 from olympia.activity.tasks import process_email
 from olympia.activity.utils import (
@@ -31,6 +35,7 @@ from olympia.activity.utils import (
 )
 from olympia.addons.views import AddonChildMixin
 from olympia.amo.utils import HttpResponseXSendFile
+from olympia.api.authentication import SessionIDAuthentication
 from olympia.api.permissions import (
     AllowAddonAuthor,
     AllowListedViewerOrReviewer,
@@ -38,6 +43,7 @@ from olympia.api.permissions import (
     AnyOf,
     GroupPermission,
 )
+from olympia.devhub.utils import get_activity_feed
 
 
 class VersionReviewNotesViewSet(
@@ -111,6 +117,31 @@ class VersionReviewNotesViewSet(
         )
         serializer = self.get_serializer(activity_object)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class ActivityView(ListAPIView):
+    authentication_classes = [SessionIDAuthentication]
+    permission_classes = [IsAuthenticated]
+    serializer_class = FeedActivityLogSerializer
+
+    def get_queryset(self):
+        feed = get_activity_feed(None, self.request.user.addons.all())
+        return feed.prefetch_related('versionlog_set__version')
+
+    def filter_queryset(self, qs):
+        if addon_id := self.request.GET.get('addon'):
+            if addon_id.isdigit():
+                qs = qs.filter(addonlog__addon=addon_id)
+            else:
+                qs = qs.filter(addonlog__addon__slug=addon_id)
+        if version_id := self.request.GET.get('version'):
+            try:
+                version_id = int(version_id)
+            except ValueError as exc:
+                raise ParseError('version parameter should be an integer.') from exc
+            qs = qs.filter(versionlog__version=version_id)
+
+        return super().filter_queryset(qs)
 
 
 log = olympia.core.logger.getLogger('z.amo.activity')

--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -125,8 +125,7 @@ class ActivityView(ListAPIView):
     serializer_class = FeedActivityLogSerializer
 
     def get_queryset(self):
-        feed = get_activity_feed(None, self.request.user.addons.all())
-        return feed.prefetch_related('versionlog_set__version')
+        return get_activity_feed(None, self.request.user.addons.all())
 
     def filter_queryset(self, qs):
         if addon_id := self.request.GET.get('addon'):

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -9,6 +9,7 @@ from drf_spectacular.views import (
 )
 
 from olympia.accounts.urls import accounts_v3, accounts_v4, auth_urls
+from olympia.activity.api_urls import activity_v5
 from olympia.addons.api_urls import addons_v3, addons_v4, addons_v5
 from olympia.amo.urls import api_patterns as amo_api_patterns
 from olympia.ratings.api_urls import ratings_v3, ratings_v4
@@ -89,7 +90,7 @@ v4_api_urls = [
 v5_api_urls = [
     re_path(r'^abuse/', include('olympia.abuse.api_urls')),
     re_path(r'^accounts/', include(accounts_v4)),
-    re_path(r'^activity/', include('olympia.activity.api_urls')),
+    re_path(r'^activity/', include(activity_v5)),
     re_path(r'^addons/', include(addons_v5)),
     re_path(r'^applications/', include('olympia.applications.api_urls')),
     re_path(r'^blocklist/', include('olympia.blocklist.urls')),

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -12,6 +12,7 @@ from django_statsd.clients import statsd
 
 import olympia.core.logger
 from olympia import amo, core
+from olympia.activity.models import ActivityLog
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.urlresolvers import linkify_and_clean
 from olympia.files.models import File, FileUpload
@@ -358,3 +359,40 @@ def create_version_for_upload(*, addon, upload, channel, client_info=None):
         # invalid. Addon.update_status will set the status to NOMINATATED.
         addon.update_status()
         return version
+
+
+def get_activity_feed(action, addons):
+    if not isinstance(addons, (list, tuple)):
+        # MySQL 8.0.21 (and maybe higher) doesn't optimize the join with
+        # double # subquery the ActivityLog.objects.for_addons(addons) below
+        # would generate if addons is not transformed into a list first. Since
+        # some people have a lot of add-ons, we only take the last 100.
+        addons = list(
+            addons.all().order_by('-modified').values_list('pk', flat=True)[:100]
+        )
+
+    filters = {
+        'updates': (amo.LOG.ADD_VERSION, amo.LOG.ADD_FILE_TO_VERSION),
+        'status': (
+            amo.LOG.USER_DISABLE,
+            amo.LOG.USER_ENABLE,
+            amo.LOG.CHANGE_STATUS,
+            amo.LOG.APPROVE_VERSION,
+        ),
+        'collections': (
+            amo.LOG.ADD_TO_COLLECTION,
+            amo.LOG.REMOVE_FROM_COLLECTION,
+        ),
+        'reviews': (amo.LOG.ADD_RATING,),
+    }
+
+    filter_ = filters.get(action)
+    items = (
+        ActivityLog.objects.for_addons(addons)
+        .exclude(action__in=amo.LOG_HIDE_DEVELOPER)
+        .transform(ActivityLog.transformer_anonymize_user_for_developer)
+    )
+    if filter_:
+        items = items.filter(action__in=[i.id for i in filter_])
+
+    return items

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -80,6 +80,7 @@ from olympia.devhub.file_validation_annotations import insert_validation_message
 from olympia.devhub.models import BlogPost, RssKey, SurveyResponse
 from olympia.devhub.utils import (
     extract_theme_properties,
+    get_activity_feed,
     wizard_unsupported_properties,
 )
 from olympia.files.models import File, FileUpload
@@ -176,7 +177,7 @@ def index(request):
 
 @login_required
 def dashboard(request, theme=False):
-    addon_items = _get_items(None, request.user.addons.all())[:4]
+    addon_items = get_activity_feed(None, request.user.addons.all())[:4]
 
     data = {
         'rss': _get_rss_feed(request),
@@ -252,43 +253,6 @@ def _get_activities(request, action):
     return items
 
 
-def _get_items(action, addons):
-    if not isinstance(addons, (list, tuple)):
-        # MySQL 8.0.21 (and maybe higher) doesn't optimize the join with
-        # double # subquery the ActivityLog.objects.for_addons(addons) below
-        # would generate if addons is not transformed into a list first. Since
-        # some people have a lot of add-ons, we only take the last 100.
-        addons = list(
-            addons.all().order_by('-modified').values_list('pk', flat=True)[:100]
-        )
-
-    filters = {
-        'updates': (amo.LOG.ADD_VERSION, amo.LOG.ADD_FILE_TO_VERSION),
-        'status': (
-            amo.LOG.USER_DISABLE,
-            amo.LOG.USER_ENABLE,
-            amo.LOG.CHANGE_STATUS,
-            amo.LOG.APPROVE_VERSION,
-        ),
-        'collections': (
-            amo.LOG.ADD_TO_COLLECTION,
-            amo.LOG.REMOVE_FROM_COLLECTION,
-        ),
-        'reviews': (amo.LOG.ADD_RATING,),
-    }
-
-    filter_ = filters.get(action)
-    items = (
-        ActivityLog.objects.for_addons(addons)
-        .exclude(action__in=amo.LOG_HIDE_DEVELOPER)
-        .transform(ActivityLog.transformer_anonymize_user_for_developer)
-    )
-    if filter_:
-        items = items.filter(action__in=[i.id for i in filter_])
-
-    return items
-
-
 def _get_rss_feed(request):
     key, _ = RssKey.objects.get_or_create(user=request.user)
     return urlparams(reverse('devhub.feed_all'), privaterss=key.key.hex)
@@ -333,7 +297,7 @@ def feed(request, addon_id=None):
 
     action = request.GET.get('action')
 
-    items = _get_items(action, addons)
+    items = get_activity_feed(action, addons)
 
     activities = _get_activities(request, action)
     addon_items = _get_addons(request, addons_all, addon_selected, action)


### PR DESCRIPTION
Fixes mozilla/addons#16383

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds Activity Feed API for new DevHub [use case](https://www.figma.com/design/CaTNJTjcUgSE5bWXlyr2S5/Add-On-Dev-Hub-redesign?node-id=777-13373&t=qNLl2nHt8EGU6Uqv-0).

### Testing

- `api/v5/activity/` endpoint returns user-related activities as seen in the existing DevHub feed view, alongside additional information needed by the new design.
-  Can further filter by `version` and `addon`.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add or update relevant [docs](../docs/) reflecting the changes made.
