### PR TITLE
Remove --auto from locales pr merge, feature is not enabled on the l10n repos

### DIFF
--- a/scripts/push_l10n_extraction.sh
+++ b/scripts/push_l10n_extraction.sh
@@ -78,6 +78,6 @@ fi
 git push "$@" -f origin $BRANCH_NAME
 
 PR_REF=$(gh pr create --fill --head $BRANCH_NAME)
-gh pr merge --auto --squash $PR_REF
+gh pr merge --squash $PR_REF
 
 cd -


### PR DESCRIPTION
(We'll still merge immediately - it doesn't matter for now as there are no checks to wait for on the l10n repos)

Fixes failure seen in https://github.com/mozilla/addons-server/actions/runs/34462000578/job/102823149863
