### PR TITLE
Show matched restriction instances on review page

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/includes/history.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/history.html
@@ -34,6 +34,29 @@
             {# <pre> rather than <div> so that white space is preserved on copy #}
             <pre class="light history-comment">{{ record.details.comments }}</pre>
           {% endif %}
+          {% if restriction_history_by_id is defined and record.details.restriction_history_ids %}
+            <ul class="restriction-matches">
+              {% for history_id in record.details.restriction_history_ids %}
+                {% set entry = restriction_history_by_id.get(history_id) %}
+                {% if entry %}
+                  <li class="light history-comment">
+                    {{ entry.get_restriction_display() }}:
+                    {% if entry.restriction_instance %}
+                      {% if entry.admin_url and is_advanced_admin %}
+                        <a href="{{ entry.admin_url }}">{{ entry.restriction_instance }}</a>
+                      {% else %}
+                        {{ entry.restriction_instance }}
+                      {% endif %}
+                    {% elif entry.restriction_object_id %}
+                      (restriction since removed)
+                    {% else %}
+                      (no specific restriction matched)
+                    {% endif %}
+                  </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          {% endif %}
           {% if record.details.reason %}
             <pre class="light history-comment">Reason: {{ record.details.reason }}</pre>
           {% endif %}

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -77,6 +77,7 @@ from olympia.stats.utils import VERSION_ADU_LIMIT
 from olympia.users.models import (
     RESTRICTION_TYPES,
     EmailUserRestriction,
+    IPNetworkUserRestriction,
     UserProfile,
     UserRestrictionHistory,
 )
@@ -5443,6 +5444,146 @@ class TestReview(ReviewBase):
             'Listed auto-approval automatically disabled because of a '
             'restriction (EmailUserRestriction)',
         )
+
+    def _create_restriction_disable_activity(self, *histories):
+        core.set_user(get_task_user())
+        return ActivityLog.objects.create(
+            amo.LOG.DISABLE_AUTO_APPROVAL,
+            self.addon,
+            details={
+                'channel': amo.CHANNEL_LISTED,
+                'comments': (
+                    'Listed auto-approval automatically disabled because of a '
+                    'restriction'
+                ),
+                'restrictions': [
+                    history.get_restriction_display() for history in histories
+                ],
+                'restriction_history_ids': [history.pk for history in histories],
+            },
+        )
+
+    def test_important_changes_restriction_admin_link_for_advanced_admin(self):
+        restriction = EmailUserRestriction.objects.create(
+            email_pattern=self.addon_author.email,
+            restriction_type=RESTRICTION_TYPES.ADDON_APPROVAL,
+        )
+        history = UserRestrictionHistory.objects.create(
+            user=self.addon_author,
+            restriction=2,  # EmailUserRestriction
+            restriction_instance=restriction,
+            version=self.version,
+        )
+        self._create_restriction_disable_activity(history)
+        self.grant_permission(self.reviewer, amo.permissions.ADMIN_ADVANCED)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        link = reverse(
+            'admin:users_emailuserrestriction_change', args=(restriction.pk,)
+        )
+        self.assertContains(
+            response,
+            f'<a href="{link}">{restriction.email_pattern}</a>',
+            html=True,
+        )
+        self.assertContains(response, 'EmailUserRestriction:')
+
+    def test_important_changes_restriction_no_admin_link_without_permission(self):
+        restriction = EmailUserRestriction.objects.create(
+            email_pattern=self.addon_author.email,
+            restriction_type=RESTRICTION_TYPES.ADDON_APPROVAL,
+        )
+        history = UserRestrictionHistory.objects.create(
+            user=self.addon_author,
+            restriction=2,  # EmailUserRestriction
+            restriction_instance=restriction,
+            version=self.version,
+        )
+        self._create_restriction_disable_activity(history)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        # The value is shown, but not linked to the admin.
+        self.assertContains(response, restriction.email_pattern)
+        link = reverse(
+            'admin:users_emailuserrestriction_change', args=(restriction.pk,)
+        )
+        self.assertNotContains(response, link)
+
+    def test_important_changes_multiple_restrictions_linked(self):
+        email_restriction = EmailUserRestriction.objects.create(
+            email_pattern=self.addon_author.email,
+            restriction_type=RESTRICTION_TYPES.ADDON_APPROVAL,
+        )
+        ip_restriction = IPNetworkUserRestriction.objects.create(
+            network='10.0.0.0/24',
+            restriction_type=RESTRICTION_TYPES.ADDON_APPROVAL,
+        )
+        email_history = UserRestrictionHistory.objects.create(
+            user=self.addon_author,
+            restriction=2,  # EmailUserRestriction
+            restriction_instance=email_restriction,
+            version=self.version,
+        )
+        ip_history = UserRestrictionHistory.objects.create(
+            user=self.addon_author,
+            restriction=3,  # IPNetworkUserRestriction
+            restriction_instance=ip_restriction,
+            version=self.version,
+        )
+        self._create_restriction_disable_activity(email_history, ip_history)
+        self.grant_permission(self.reviewer, amo.permissions.ADMIN_ADVANCED)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        email_link = reverse(
+            'admin:users_emailuserrestriction_change', args=(email_restriction.pk,)
+        )
+        ip_link = reverse(
+            'admin:users_ipnetworkuserrestriction_change', args=(ip_restriction.pk,)
+        )
+        self.assertContains(
+            response,
+            f'<a href="{email_link}">{email_restriction.email_pattern}</a>',
+            html=True,
+        )
+        self.assertContains(
+            response,
+            f'<a href="{ip_link}">{ip_restriction.network}</a>',
+            html=True,
+        )
+
+    def test_important_changes_restriction_since_removed(self):
+        restriction = EmailUserRestriction.objects.create(
+            email_pattern=self.addon_author.email,
+            restriction_type=RESTRICTION_TYPES.ADDON_APPROVAL,
+        )
+        history = UserRestrictionHistory.objects.create(
+            user=self.addon_author,
+            restriction=2,  # EmailUserRestriction
+            restriction_instance=restriction,
+            version=self.version,
+        )
+        self._create_restriction_disable_activity(history)
+        link = reverse(
+            'admin:users_emailuserrestriction_change', args=(restriction.pk,)
+        )
+        restriction.delete()
+        self.grant_permission(self.reviewer, amo.permissions.ADMIN_ADVANCED)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertContains(response, 'restriction since removed')
+        self.assertNotContains(response, link)
+
+    def test_important_changes_restriction_no_instance(self):
+        # A structural denial records a history row with no instance.
+        history = UserRestrictionHistory.objects.create(
+            user=self.addon_author,
+            restriction=3,  # IPNetworkUserRestriction
+            version=self.version,
+        )
+        self._create_restriction_disable_activity(history)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertContains(response, 'no specific restriction matched')
 
     def test_important_changes_log_with_versions_attached(self):
         version1 = self.addon.versions.get()

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -71,7 +71,7 @@ from olympia.stats.utils import (
     VERSION_ADU_LIMIT,
     get_average_daily_users_per_version_from_bigquery,
 )
-from olympia.users.models import UserProfile
+from olympia.users.models import UserProfile, UserRestrictionHistory
 from olympia.versions.models import Version
 from olympia.zadmin.models import get_config, set_config
 from src.olympia.abuse.actions import CONTENT_ACTION_FROM_DECISION_ACTION
@@ -670,6 +670,33 @@ def review(request, addon, channel=None):
         addonlog__addon=addon,
     ).order_by('id')
 
+    # Resolve the restriction instances recorded on DISABLE_AUTO_APPROVAL
+    # entries, so the template can show which restriction(s) matched - as a
+    # link to the admin for users that can access it.
+    restriction_history_ids = [
+        pk
+        for record in important_changes_log
+        if record.details
+        for pk in record.details.get('restriction_history_ids', ())
+    ]
+    restriction_history_by_id = {}
+    if restriction_history_ids:
+        restriction_history_entries = (
+            UserRestrictionHistory.objects.filter(pk__in=restriction_history_ids)
+            .select_related('restriction_content_type')
+            .prefetch_related('restriction_instance')
+        )
+        for entry in restriction_history_entries:
+            entry.admin_url = (
+                reverse(
+                    f'admin:users_{entry.restriction_content_type.model}_change',
+                    args=(entry.restriction_object_id,),
+                )
+                if entry.restriction_content_type_id and entry.restriction_object_id
+                else None
+            )
+            restriction_history_by_id[entry.pk] = entry
+
     name_translations = (
         addon.name.__class__.objects.filter(
             id=addon.name.id, localized_string__isnull=False
@@ -728,6 +755,9 @@ def review(request, addon, channel=None):
         .exists(),
         important_changes_log=important_changes_log,
         is_admin=is_admin,
+        is_advanced_admin=acl.action_allowed_for(
+            request.user, amo.permissions.ADMIN_ADVANCED
+        ),
         is_user_admin=acl.action_allowed_for(request.user, amo.permissions.USERS_EDIT),
         language_dict=dict(settings.LANGUAGES),
         latest_not_disabled_version=latest_not_disabled_version,
@@ -744,6 +774,7 @@ def review(request, addon, channel=None):
         num_pages=num_pages,
         pager=pager,
         reports=reports,
+        restriction_history_by_id=restriction_history_by_id,
         session_id=request.session.session_key,
         subscribed_listed=ReviewerSubscription.objects.filter(
             user=request.user, addon=addon, channel=amo.CHANNEL_LISTED


### PR DESCRIPTION
Fixes mozilla/addons#16408

### Description

#### What this change does:

- The `DISABLE_AUTO_APPROVAL` entry in the review page's important-changes history now lists the specific restriction instance(s) that matched, resolved from the `UserRestrictionHistory` rows recorded at submission time (via the `restriction_history_ids` the entry already carries).
- Each match shows class and value ("EmailUserRestriction: foo@example.com"), linked to its admin change page for users with `Admin:Advanced`, plain text for everyone else.
- A match whose restriction has since been deleted shows "restriction since removed"; a structural denial with no instance shows "no specific restriction matched".

#### What it looks like:

The entry in "Add-on important changes history" gains a list under the existing comment, one line per matched restriction.

A reviewer *with* `Admin:Advanced` sees each value as a link to that
restriction's admin page:

> Listed auto-approval automatically disabled because of a restriction (EmailUserRestriction, IPNetworkUserRestriction)
> - EmailUserRestriction: [foo@example.com](#) <- links to `/admin/models/users/emailuserrestriction/1257/change/`
> - IPNetworkUserRestriction: [10.0.0.0/24](#) <- links to `/admin/models/users/ipnetworkuserrestriction/527/change/`

#### Why this shape:

1. Rendered from the recorded history rows, never `AddonReviewerFlags`. The flag is add-on-level and has non-restriction causes (Mozilla-signed packages), so it can't say *which* restriction fired.
2. The link is gated on `Admin:Advanced` because that's the
exact permission gating the restriction admin pages. Nobody gets a link they can't follow, and reviewers without it still see the value.
3. "Since removed" is a designed state, not an error: restrictions are bulk-deleted or are normal for an audit trail.
4. The restriction's `reason` field is deliberately not shown. It's documented as a private description.

### Context

Completes the third acceptance criterion of #16408 (the DB and Redash queryability landed in #25344; this is the reviewer-facing exposure agreed as a follow-up). 

### Testing

Six tests in `TestReview`: the admin link href and value for an `Admin:Advanced` user; value-without-link for a regular reviewer; two
matched restrictions rendering two links; a deleted restriction
rendering "since removed" with no link; a structural NULL-instance row rendering its message; and the existing comment-rendering test unchanged. Full `reviewers/tests/test_views.py` passes.

### Checklist
                          
- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).